### PR TITLE
moe能够多卡运行

### DIFF
--- a/scripts/qwen_hybrid.py
+++ b/scripts/qwen_hybrid.py
@@ -254,7 +254,7 @@ class QwenHybridForCausalLM:
                 total_time += end_time - start_time
 
         print("\n")
-        avg_time = total_time * 1000 / (steps - 1)
+        avg_time = total_time * 1000 / (steps - 1 + 1e-9)
         print(f"Time per step: {avg_time:.3f}ms")
 
         infer_task._kv_cache.drop(self)

--- a/src/models/qwen_hybrid/qwen_hybrid_weight.cpp
+++ b/src/models/qwen_hybrid/qwen_hybrid_weight.cpp
@@ -181,9 +181,9 @@ QwenHybridWeights::QwenHybridWeights(
                 REGISTER_LAYER_WEIGHT_2D("model.layers." + std::to_string(layer) + ".self_attn.k_proj.weight", w_attn_k, d, nkvh * dh, dt_logits, ROW);
                 REGISTER_LAYER_WEIGHT_2D("model.layers." + std::to_string(layer) + ".self_attn.v_proj.weight", w_attn_v, d, nkvh * dh, dt_logits, ROW);
                 REGISTER_LAYER_WEIGHT_2D("model.layers." + std::to_string(layer) + ".self_attn.o_proj.weight", w_attn_out, nh * dh, d, dt_logits, COLUMN);
-                REGISTER_LAYER_WEIGHT_1D("model.layers." + std::to_string(layer) + ".self_attn.q_proj.bias", b_attn_q, nh * dh, dt_logits, FULL);
-                REGISTER_LAYER_WEIGHT_1D("model.layers." + std::to_string(layer) + ".self_attn.k_proj.bias", b_attn_k, nkvh * dh, dt_logits, FULL);
-                REGISTER_LAYER_WEIGHT_1D("model.layers." + std::to_string(layer) + ".self_attn.v_proj.bias", b_attn_v, nkvh * dh, dt_logits, FULL);
+                REGISTER_LAYER_WEIGHT_1D("model.layers." + std::to_string(layer) + ".self_attn.q_proj.bias", b_attn_q, nh * dh, dt_logits, ROW);
+                REGISTER_LAYER_WEIGHT_1D("model.layers." + std::to_string(layer) + ".self_attn.k_proj.bias", b_attn_k, nkvh * dh, dt_logits, ROW);
+                REGISTER_LAYER_WEIGHT_1D("model.layers." + std::to_string(layer) + ".self_attn.v_proj.bias", b_attn_v, nkvh * dh, dt_logits, ROW);
                 weight->b_la_dt.push_back(nullptr);
                 weight->alpha_la_g.push_back(nullptr);
                 weight->w_la_conv.push_back(nullptr);
@@ -199,10 +199,10 @@ QwenHybridWeights::QwenHybridWeights(
             {
                 // gate
                 name = "model.layers." + std::to_string(layer) + ".mlp.shared_expert_gate.weight";
-                REGISTER_LAYER_WEIGHT_2D(name, w_shared_expert_gate, d, 1, dt_logits, ROW);
+                REGISTER_LAYER_WEIGHT_2D(name, w_shared_expert_gate, d, 1, dt_logits, FULL);
 
                 name = "model.layers." + std::to_string(layer) + ".mlp.gate.weight";
-                REGISTER_LAYER_WEIGHT_2D(name, w_router_expert_gate, d, meta->nexperts, dt_logits, ROW);
+                REGISTER_LAYER_WEIGHT_2D(name, w_router_expert_gate, d, meta->nexperts, dt_logits, FULL);
             }
 
             {
@@ -224,7 +224,7 @@ QwenHybridWeights::QwenHybridWeights(
                 size_t moe_di = meta->moe_di / ndev;
                 for (size_t iexpert = 0; iexpert < meta->nexperts; ++iexpert) {
 
-                    // REGISTER_LAYER_WEIGHT_2D(name, w_shared_expert_ffn_gate, d, moe_di, dt_logits, COLUMN);
+                    // REGISTER_LAYER_WEIGHT_2D(name, w_shared_expert_ffn_gate, d, moe_di, dt_logits, ROW);
                     {
                         name = "model.layers." + std::to_string(layer) + ".mlp.experts." + std::to_string(iexpert) + ".gate_proj.weight";
                         auto gate = Tensor::weight(nullptr, dt_logits, {moe_di, d})->permute({1, 0});
@@ -232,7 +232,7 @@ QwenHybridWeights::QwenHybridWeights(
                         weight->w_router_expert_ffn_gate[layer].push_back(gate);
                     }
 
-                    // REGISTER_LAYER_WEIGHT_2D(name, w_shared_expert_ffn_up, d, moe_di, dt_logits, COLUMN);
+                    // REGISTER_LAYER_WEIGHT_2D(name, w_shared_expert_ffn_up, d, moe_di, dt_logits, ROW);
                     {
                         name = "model.layers." + std::to_string(layer) + ".mlp.experts." + std::to_string(iexpert) + ".up_proj.weight";
                         auto up = Tensor::weight(nullptr, dt_logits, {moe_di, d})->permute({1, 0});
@@ -240,7 +240,7 @@ QwenHybridWeights::QwenHybridWeights(
                         weight->w_router_expert_ffn_up[layer].push_back(up);
                     }
 
-                    // REGISTER_LAYER_WEIGHT_2D(name, w_shared_expert_ffn_down, moe_di, d, dt_logits, ROW);
+                    // REGISTER_LAYER_WEIGHT_2D(name, w_shared_expert_ffn_down, moe_di, d, dt_logits, COLUMN);
                     {
                         name = "model.layers." + std::to_string(layer) + ".mlp.experts." + std::to_string(iexpert) + ".down_proj.weight";
                         auto down = Tensor::weight(nullptr, dt_logits, {d, moe_di})->permute({1, 0});


### PR DESCRIPTION
在最新的commit上，添加代码，注释掉manba的权重加载和推理计算的代码后，可以在A100上多卡运行Qwen2moe。
测试数据集为Qwen1.5-MoE。

git log显示为最近：
<img width="1105" height="440" alt="img_v3_02q1_61234f80-16ee-4332-b09e-236ac8c8c00g" src="https://github.com/user-attachments/assets/389159c2-24d7-4320-bfe6-4f6106e385ee" />

8卡运行结果：
<img width="1220" height="726" alt="img_v3_02q1_ac8a9835-d908-4d33-b180-088d672f837g" src="https://github.com/user-attachments/assets/eab29803-3fd8-407f-8652-63f14f7fccb6" />

4卡运行结果：
<img width="1253" height="728" alt="img_v3_02q1_19147300-6ed8-4016-a71b-c2a6840dfc5g" src="https://github.com/user-attachments/assets/c4241bdb-bca3-4b04-86da-4ef4d960121d" />

2卡运行结果：
<img width="1228" height="730" alt="img_v3_02q1_e7d8a5a9-762a-4afa-a501-2603f907bfeg" src="https://github.com/user-attachments/assets/100d885f-d221-4a6d-bde3-3fd3ce034cd9" />


1卡运行结果：
<img width="1231" height="711" alt="img_v3_02q1_dc39380d-6564-4e1c-a3ce-40e388df3ebg" src="https://github.com/user-attachments/assets/d066df78-91b7-4700-898f-cc1c5a14e579" />
