### PR TITLE
Use logsoftmax operator in InfiniCore

### DIFF
--- a/scripts/jiuge.py
+++ b/scripts/jiuge.py
@@ -616,7 +616,7 @@ class JiugeForCauslLM:
                 batch_id += 1
 
             batch_inputs = JiugeBatchedTask(tasks[:batch_id])
-            logits = torch.zeros(
+            log_probs = torch.zeros(
                 (batch_inputs.ntok, self.meta.dvoc), dtype=self.meta.torch_dtype_logits
             )
             self.jiuge_model.forward_batch(
@@ -627,12 +627,12 @@ class JiugeForCauslLM:
                 batch_inputs.nreq,
                 batch_inputs.req_pos,
                 batch_inputs.kv_caches,
-                logits.data_ptr(),
+                log_probs.data_ptr(),
             )
 
-            logits = logits.float()
+            # forward_batch now returns log_softmax results, no need for additional calculation
+            log_probs = log_probs.float()
             token_ids = torch.tensor(true_tokens, dtype=torch.int64)  # [ntok,]
-            log_probs = torch.nn.functional.log_softmax(logits, dim=-1)  # (ntok, vocab)
             token_logprobs = log_probs[
                 torch.arange(batch_inputs.ntok), token_ids
             ]  # (ntok,)

--- a/scripts/test_ppl.py
+++ b/scripts/test_ppl.py
@@ -33,8 +33,9 @@ if __name__ == "__main__":
 
         # endcode, chunk and decode
         tokens = tokenizer.encode(text, add_special_tokens=False)
-        for i in range(0, len(tokens), CHUNK_SIZE):
-            chunk_tokens = tokens[i : min(i + CHUNK_SIZE, len(tokens))]
+        # 使用与jiuge_ppl.py相同的分割逻辑，只处理完整的chunk
+        for i in range(0, len(tokens) - CHUNK_SIZE + 1, CHUNK_SIZE):
+            chunk_tokens = tokens[i : i + CHUNK_SIZE]
             chunk_text = tokenizer.decode(chunk_tokens)
 
             resp = requests.post(

--- a/src/cache_manager/opcache_manager.hpp
+++ b/src/cache_manager/opcache_manager.hpp
@@ -158,6 +158,7 @@ public:
     DECLARE_OP_CACHE(RoPE)
     DECLARE_OP_CACHE(Rearrange)
     DECLARE_OP_CACHE(CausalSoftmax)
+    DECLARE_OP_CACHE(LogSoftmax)
     DECLARE_OP_CACHE(Topkrouter)
     DECLARE_OP_CACHE(SwiGLU)
     DECLARE_OP_CACHE(RandomSample)
@@ -170,6 +171,7 @@ public:
           RoPE_cache(capacity, DESTROY_FUNC(RoPE)),
           Rearrange_cache(capacity, DESTROY_FUNC(Rearrange)),
           CausalSoftmax_cache(capacity, DESTROY_FUNC(CausalSoftmax)),
+          LogSoftmax_cache(capacity, DESTROY_FUNC(LogSoftmax)),
           Topkrouter_cache(capacity, DESTROY_FUNC(Topkrouter)),
           SwiGLU_cache(capacity, DESTROY_FUNC(SwiGLU)),
           RandomSample_cache(capacity, DESTROY_FUNC(RandomSample)),

--- a/src/models/inference_context.hpp
+++ b/src/models/inference_context.hpp
@@ -37,6 +37,8 @@ struct InferenceContext {
               infiniopRoPEAlgo_t algo);
     void causalSoftmax(std::shared_ptr<Tensor> y,
                        std::shared_ptr<Tensor> x);
+    void logSoftmax(std::shared_ptr<Tensor> y,
+                    std::shared_ptr<Tensor> x);
 
     void topkrouter(std::shared_ptr<Tensor> values,  // F32
                     std::shared_ptr<Tensor> indices, // I32
@@ -109,6 +111,10 @@ inline void rope_v2(std::shared_ptr<Tensor> q, std::shared_ptr<Tensor> k,
 
 inline void causalSoftmax(std::shared_ptr<Tensor> y, std::shared_ptr<Tensor> x) {
     getInferenceContext().causalSoftmax(y, x);
+}
+
+inline void logSoftmax(std::shared_ptr<Tensor> y, std::shared_ptr<Tensor> x) {
+    getInferenceContext().logSoftmax(y, x);
 }
 
 inline void topkrouter(std::shared_ptr<Tensor> values,  // F32

--- a/src/models/jiuge/jiuge.cpp
+++ b/src/models/jiuge/jiuge.cpp
@@ -262,8 +262,12 @@ void inferDeviceBatch(const JiugeMeta &meta, JiugeDeviceResource &rsrc,
             rmsnorm(logits_out, logits_in, rsrc.w_out_norm, meta.epsilon);
             auto last_logits_buf = Tensor::buffer(dt_logits, {ntok, dvoc}, rsrc.memory_pool);
             linear(last_logits_buf, logits_out, rsrc.w_out_embd, 1.0, 0.0, nullptr, nullptr);
+            
+            auto log_logits_buf = Tensor::buffer(dt_logits, {ntok, dvoc}, rsrc.memory_pool);
+            logSoftmax(log_logits_buf, last_logits_buf);
+            
             RUN_INFINI(infinirtStreamSynchronize(stream));
-            RUN_INFINI(infinirtMemcpy(last_logits, last_logits_buf->data(), dsize(dt_logits) * ntok * dvoc, INFINIRT_MEMCPY_D2H));
+            RUN_INFINI(infinirtMemcpy(last_logits, log_logits_buf->data(), dsize(dt_logits) * ntok * dvoc, INFINIRT_MEMCPY_D2H));
         }
         if (output != nullptr) {
             size_t token_offset = 0;


### PR DESCRIPTION
1. 接入使用InfiniCore分支中的logsoftmax算子
2. 增加completion端口，支持launch_server后通过http端口计算得到max_tokens=0的logprobs
3. 更改test_ppl和jiuge_ppl中用到的torch库的log_softmax算子
4. 对齐test_ppl的token分块方式，使得和jiuge_ppl对perlexity的计算结果保持一致