### PR TITLE
issue/53: update AWQ-dequantize op name to match infinicore op dequantizeAWQ

### DIFF
--- a/src/cache_manager/opcache_manager.hpp
+++ b/src/cache_manager/opcache_manager.hpp
@@ -161,7 +161,7 @@ public:
     DECLARE_OP_CACHE(Topkrouter)
     DECLARE_OP_CACHE(SwiGLU)
     DECLARE_OP_CACHE(RandomSample)
-    DECLARE_OP_CACHE(Dequantize)
+    DECLARE_OP_CACHE(DequantizeAWQ)
 
     CacheManager(size_t capacity = 100)
         : Add_cache(capacity, DESTROY_FUNC(Add)),
@@ -173,7 +173,7 @@ public:
           Topkrouter_cache(capacity, DESTROY_FUNC(Topkrouter)),
           SwiGLU_cache(capacity, DESTROY_FUNC(SwiGLU)),
           RandomSample_cache(capacity, DESTROY_FUNC(RandomSample)),
-          Dequantize_cache(capacity, DESTROY_FUNC(Dequantize)) {}
+          DequantizeAWQ_cache(capacity, DESTROY_FUNC(DequantizeAWQ)) {}
 
     template <typename... Tensors>
     static size_t createDescriptorKey(Tensors... tensors) {

--- a/src/models/inference_context.cpp
+++ b/src/models/inference_context.cpp
@@ -266,18 +266,18 @@ void InferenceContext::dequant(std::shared_ptr<Tensor> weight,
 
     size_t key = CacheManager::createDescriptorKey(weight, in_w, in_s, in_z);
 
-    infiniopDequantizeDescriptor_t desc;
-    if (!cache_manager->getDequantizeDescriptor(key, desc)) {
-        RUN_INFINI(infiniopCreateDequantizeDescriptor(op_handle, &desc, weight->desc(), in_w->desc(), in_s->desc(), in_z->desc()));
-        cache_manager->putDequantizeDescriptor(key, desc);
+    infiniopDequantizeAWQDescriptor_t desc;
+    if (!cache_manager->getDequantizeAWQDescriptor(key, desc)) {
+        RUN_INFINI(infiniopCreateDequantizeAWQDescriptor(op_handle, &desc, weight->desc(), in_w->desc(), in_s->desc(), in_z->desc()));
+        cache_manager->putDequantizeAWQDescriptor(key, desc);
     }
 
     size_t workspace_size = 0;
-    RUN_INFINI(infiniopGetDequantizeWorkspaceSize(desc, &workspace_size));
+    RUN_INFINI(infiniopGetDequantizeAWQWorkspaceSize(desc, &workspace_size));
     ensure_workspace(workspace_size);
     void *workspace = workspace_storage->memory();
 
-    RUN_INFINI(infiniopDequantize(
+    RUN_INFINI(infiniopDequantizeAWQ(
         desc, workspace, workspace_size,
         weight->data(), in_w->data(), in_s->data(), in_z->data(), stream));
 }


### PR DESCRIPTION
1.  InfiniCore 中的 AWQ 量化算子 Dequantize 相关信息重命名为 DequantizeAWQ ，为其他量化算子的添加预留空间，见 https://github.com/InfiniTensor/InfiniCore/pull/476
2.  InfiniLM AWQ 反量化算子调用适配 InfiniCore 更改
3. python 测试截图：
<img width="1624" height="516" alt="image" src="https://github.com/user-attachments/assets/e115e340-113f-4c25-8759-39fc75352d70" />
