### PR TITLE
issue/86 - 添加计算结束前的同步函数

### DIFF
--- a/python/infinilm/generation/utils.py
+++ b/python/infinilm/generation/utils.py
@@ -224,6 +224,9 @@ class GenerationMixin:
                     1.0,
                     out=out,
                 )
+
+            infinicore.sync_stream()  # 计算结束前需要同步
+
             end_time = time.time()
             time_list.append((end_time - start_time) * 1000)
 


### PR DESCRIPTION
**版本**
main

**问题描述**

python的llama当generate输出token速度比较快时, 在输出几个token后, 开始乱码

**测试结果**

<img width="1164" height="626" alt="Screenshot from 2025-11-26 15-38-44" src="https://github.com/user-attachments/assets/8999fff1-be57-45c5-9077-9573d43f8ca6" />


