### PR TITLE
issue/89 针对python的llama结构，使用matmul函数、减少Tensor对象创建次数

### DIFF
--- a/examples/llama.py
+++ b/examples/llama.py
@@ -86,6 +86,7 @@ def test(
     infini_device=infinicore.device("cpu", 0),
     backend="python",
 ):
+    model_path = os.path.expanduser(model_path)
     # ---------------------------------------------------------------------------- #
     #                        创建模型,
     # ---------------------------------------------------------------------------- #
@@ -104,14 +105,12 @@ def test(
 
     model.load_state_dict(model_param_infini)
 
-    config = model.config
-
     # ---------------------------------------------------------------------------- #
     #                        创建 tokenizer
     # ---------------------------------------------------------------------------- #
-    tokenizer = AutoTokenizer.from_pretrained(model_path)
+    tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
 
-    if "llama" == config.model_type:
+    if "llama" == model.config.model_type:
         backend = getattr(tokenizer, "backend_tokenizer", None)
         target = getattr(backend, "_tokenizer", backend)
         norm = getattr(target, "normalizer", None)
@@ -129,7 +128,7 @@ def test(
                 ]
             )
     else:
-        raise ValueError(f"Unsupported model type: {config.model_type}")
+        raise ValueError(f"Unsupported model type: {model.config.model_type}")
 
     # ---------------------------------------------------------------------------- #
     #                        token编码
@@ -162,7 +161,6 @@ def test(
         max_new_tokens=max_new_tokens,
         device=infini_device,
         tokenizer=tokenizer,
-        config=config,
     )
     t2 = time.time()
 

--- a/python/infinilm/cache_utils.py
+++ b/python/infinilm/cache_utils.py
@@ -65,12 +65,12 @@ class DynamicLayer(CacheLayerMixin):
             self.max_seq_len = max(self.max_position_embeddings, seq_len)
 
             self.keys = infinicore.empty(
-                [batch_size, self.max_seq_len, num_heads, head_dim],
+                (batch_size, self.max_seq_len, num_heads, head_dim),
                 dtype=dtype,
                 device=device,
             )
             self.values = infinicore.empty(
-                [batch_size, self.max_seq_len, num_heads, head_dim],
+                (batch_size, self.max_seq_len, num_heads, head_dim),
                 dtype=dtype,
                 device=device,
             )
@@ -80,12 +80,12 @@ class DynamicLayer(CacheLayerMixin):
             self.max_seq_len = max(self.max_seq_len * 2, self.cache_position + seq_len)
 
             keys_new = infinicore.empty(
-                [batch_size, self.max_seq_len, num_heads, head_dim],
+                (batch_size, self.max_seq_len, num_heads, head_dim),
                 dtype=dtype,
                 device=device,
             )
             values_new = infinicore.empty(
-                [batch_size, self.max_seq_len, num_heads, head_dim],
+                (batch_size, self.max_seq_len, num_heads, head_dim),
                 dtype=dtype,
                 device=device,
             )

--- a/python/infinilm/generation/utils.py
+++ b/python/infinilm/generation/utils.py
@@ -121,7 +121,6 @@ class GenerationMixin:
         max_new_tokens: int,
         device: infinicore.device,
         tokenizer,
-        config,
         **kwargs,
     ):
         model_kwargs = kwargs
@@ -144,7 +143,6 @@ class GenerationMixin:
             max_new_tokens=max_new_tokens,
             device=device,
             tokenizer=tokenizer,
-            config=config,
             **model_kwargs,
         )
         return result
@@ -155,7 +153,6 @@ class GenerationMixin:
         max_new_tokens: int,
         device: infinicore.device,
         tokenizer,
-        config,
         **model_kwargs,
     ):
         r"""
@@ -170,7 +167,7 @@ class GenerationMixin:
 
         batch_size, seq_len = input_ids.shape[:2]
 
-        eos_token_id = config.eos_token_id
+        eos_token_id = self.config.eos_token_id
         eos_token_id_list = (
             [eos_token_id] if isinstance(eos_token_id, int) else eos_token_id
         )
@@ -216,7 +213,7 @@ class GenerationMixin:
                 device=token_scores.device,
             )
             for i in range(0, batch_size):
-                score = token_scores.narrow(0, i, 1).view([vocab_size])
+                score = token_scores.narrow(0, i, 1).view((vocab_size,))
                 out = next_tokens.narrow(0, i, 1).view([])
                 infinicore.nn.functional.random_sample(
                     score,
@@ -247,16 +244,16 @@ class GenerationMixin:
                 break
 
         print("\n</s>")
-        print(f"\n\n\n Generation completed in {round(sum(time_list),2)} ms")
+        print(f"\n\n\n Generation completed in {round(sum(time_list), 2)} ms")
         print(
             f" Batchsize={batch_size}  Per_Batch_Input_Len={seq_len}  Per_Batch_New_Tokens={len(time_list)}\n"
         )
         print(
-            f" Prefill TTFT: {round(time_list[0], 2)}ms  Throughput: {round((1000 * batch_size * seq_len)/time_list[0], 2)}tok/s\n",
+            f" Prefill TTFT: {round(time_list[0], 2)}ms  Throughput: {round((1000 * batch_size * seq_len) / time_list[0], 2)}tok/s\n",
         )
         if len(time_list) > 1:
             print(
-                f" Decode  Avg ITL: {round(sum(time_list[1:]) / (len(time_list) - 1), 2)}ms   Throughput: {round((1000 * batch_size * (len(time_list) - 1))/ sum(time_list[1:]), 2)}tok/s\n",
+                f" Decode  Avg ITL: {round(sum(time_list[1:]) / (len(time_list) - 1), 2)}ms   Throughput: {round((1000 * batch_size * (len(time_list) - 1)) / sum(time_list[1:]), 2)}tok/s\n",
             )
 
         return output_tokens_list, output_content


### PR DESCRIPTION
**目标版本**
main

**功能描述**
针对python的llama结构:
(1)使用matmul函数
(2)减少Tensor对象创建次数，以减少耗时
(3) 使用os.path.expanduser处理相对路径找不到文件的问题
(4) 删除generate函数中，作用不大的config参数

**测试截图**

修改后，耗时有所降低。

修改前：
<img width="1453" height="432" alt="Screenshot from 2025-12-04 17-38-54" src="https://github.com/user-attachments/assets/fdcf6f46-e051-4ec2-95ad-180e137aa0dd" />

修改后：
<img width="1504" height="472" alt="Screenshot from 2025-12-04 17-33-08" src="https://github.com/user-attachments/assets/28a0b087-a384-4f85-899f-070c56ae89c9" />

