### PR TITLE
issue/137 : support paged attention in InfiniLM v0.1.0 in metax-gpu

### DIFF
--- a/python/example.py
+++ b/python/example.py
@@ -40,6 +40,12 @@ def main():
     else:
         raise ValueError("Error: --device_type is required.")
 
+    if not args.enable_paged_attn:
+        raise ValueError(
+            "This script currently only supports paged attention. "
+            "Please enable it with --enable-paged-attn."
+        )
+
     path = args.model_path
     tokenizer = AutoTokenizer.from_pretrained(path, trust_remote_code=True)
     llm = InfiniEngine(

--- a/python/icinfer/engine/model_runner.py
+++ b/python/icinfer/engine/model_runner.py
@@ -105,8 +105,7 @@ class ModelRunner:
         在程序退出时，安全地释放 C++ 侧的资源。
         """
         if hasattr(self, "kv_cache") and self.kv_cache:
-            print("drop_paged_kv_cache")
-            # ！！！待完善的部分，需要后续在处理！！！drop_paged_kv_cache 和 drop_kv_cache
+            print("[info] drop_paged_kv_cache")
             drop_paged_kv_cache(self.kv_cache.data())
             self.kv_cache = None
         if hasattr(self, "model") and self.model:
@@ -134,7 +133,7 @@ class ModelRunner:
             self.ndev,
         )
         self.kv_cache = PagedKVCache(kv_cache)
-        print("kvcache allocated ")
+        print("[info] Paged kvcache allocated ")
 
     def allocate_kv_cache(self):
         kv_cache = self.create_kv_cache(


### PR DESCRIPTION
InfiniLM v0.1.0 沐曦平台支持 paged attention，测试截图：
<img width="1629" height="895" alt="image" src="https://github.com/user-attachments/assets/ae661619-b07b-40a4-b96f-39563cd7b2ff" />

测试命令参考：
"""
运行 example.py 测试脚本
python path/to/example.py \
    --model-path <path_to_your_model> \
    --device-type <device_type> \
    --ndev <num_devices> \
    --max-kvcache-tokens <kv_cache_limit> \
    --enable-paged-attn
"""
