### PR TITLE
Issue/229： fix: fix inference_server.py for moore gpu

### DIFF
--- a/python/infinilm/llm/llm.py
+++ b/python/infinilm/llm/llm.py
@@ -138,7 +138,7 @@ class LLMEngine:
 
     def _init_device(self):
         """Initialize infinicore device and dtype."""
-        supported_devices = ["cpu", "cuda", "mlu", "moore"]
+        supported_devices = ["cpu", "cuda", "mlu", "musa"]
         device_str = self.config.device
         if device_str not in supported_devices:
             raise ValueError(

--- a/python/infinilm/server/inference_server.py
+++ b/python/infinilm/server/inference_server.py
@@ -624,7 +624,7 @@ def main():
     elif args.metax:
         device = "cuda"
     elif args.moore:
-        device = "moore"
+        device = "musa"
     elif args.iluvatar:
         device = "cuda"
     elif args.cambricon:


### PR DESCRIPTION
修复摩尔平台运行 python/infinilm/server/inference_server.py 出现无法识别 moore 的问题。