### PR TITLE
issue/321 - Decouple Qwen2 and Llama model logic from FM9G

### DIFF
--- a/csrc/models/fm9g/fm9g_for_causal_lm.cpp
+++ b/csrc/models/fm9g/fm9g_for_causal_lm.cpp
@@ -19,16 +19,6 @@ namespace {
 #ifndef USE_CLASSIC_LLAMA
 
 INFINILM_REGISTER_CAUSAL_LM_MODEL(
-    llama,
-    infinilm::models::fm9g::FM9GForCausalLM,
-    infinilm::models::fm9g::create_fm9g_model_config);
-
-INFINILM_REGISTER_CAUSAL_LM_MODEL(
-    qwen2,
-    infinilm::models::fm9g::FM9GForCausalLM,
-    infinilm::models::fm9g::create_fm9g_model_config);
-
-INFINILM_REGISTER_CAUSAL_LM_MODEL(
     fm9g,
     infinilm::models::fm9g::FM9GForCausalLM,
     infinilm::models::fm9g::create_fm9g_model_config);

--- a/csrc/models/llama/llama_for_causal_lm.cpp
+++ b/csrc/models/llama/llama_for_causal_lm.cpp
@@ -1,0 +1,40 @@
+#include "llama_for_causal_lm.hpp"
+#include "../models_registry.hpp"
+
+namespace infinilm::models::llama {
+
+std::shared_ptr<infinilm::config::ModelConfig> create_llama_model_config(std::shared_ptr<infinilm::config::ModelConfig> model_config) {
+    const std::string &model_type = model_config->get<std::string>("model_type");
+    if ("llama" != model_type) {
+        throw std::runtime_error(
+            "infinilm::models::llama::create_llama_model_config: model_type is not llama");
+    }
+
+    nlohmann::json &config_json = model_config->get_config_json();
+
+    if (!config_json.contains("head_dim")) {
+        config_json["head_dim"] = model_config->get<size_t>("hidden_size")
+            / model_config->get<size_t>("num_attention_heads");
+    }
+
+    if (!config_json.contains("attention_bias")) {
+        config_json["attention_bias"] = false;
+    }
+
+    return model_config;
+}
+
+} // namespace infinilm::models::llama
+
+namespace {
+
+#ifndef USE_CLASSIC_LLAMA
+
+INFINILM_REGISTER_CAUSAL_LM_MODEL(
+    llama,
+    infinilm::models::llama::LlamaForCausalLM,
+    infinilm::models::llama::create_llama_model_config);
+
+#endif
+
+} // namespace

--- a/csrc/models/llama/llama_for_causal_lm.hpp
+++ b/csrc/models/llama/llama_for_causal_lm.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "../../layers/common_modules.hpp"
+#include <memory>
+
+namespace infinilm::models::llama {
+
+using LlamaMLP = infinilm::layers::MLP;
+
+using LlamaAttention = infinilm::layers::attention::Attention;
+
+using LlamaDecoderLayer = infinilm::layers::causal_lm_templates::TextDecoderLayer<LlamaAttention, LlamaMLP>;
+
+using LlamaModel = infinilm::layers::causal_lm_templates::TextModel<LlamaDecoderLayer>;
+
+using LlamaForCausalLM = infinilm::layers::causal_lm_templates::TextCausalLM<LlamaModel>;
+
+} // namespace infinilm::models::llama
+
+namespace infinilm::models::llama {
+
+std::shared_ptr<infinilm::config::ModelConfig> create_llama_model_config(std::shared_ptr<infinilm::config::ModelConfig> model_config);
+
+} // namespace infinilm::models::llama

--- a/csrc/models/qwen2/qwen2_for_causal_lm.cpp
+++ b/csrc/models/qwen2/qwen2_for_causal_lm.cpp
@@ -1,0 +1,37 @@
+#include "qwen2_for_causal_lm.hpp"
+#include "../models_registry.hpp"
+
+namespace infinilm::models::qwen2 {
+
+std::shared_ptr<infinilm::config::ModelConfig> create_qwen2_model_config(std::shared_ptr<infinilm::config::ModelConfig> model_config) {
+    const std::string &model_type = model_config->get<std::string>("model_type");
+    if ("qwen2" != model_type) {
+        throw std::runtime_error(
+            "infinilm::models::qwen2::create_qwen2_model_config: model_type is not qwen2");
+    }
+
+    nlohmann::json &config_json = model_config->get_config_json();
+
+    if (!config_json.contains("head_dim")) {
+        size_t head_dim = model_config->get<size_t>("hidden_size")
+            / model_config->get<size_t>("num_attention_heads");
+        config_json["head_dim"] = head_dim;
+    }
+
+    return model_config;
+}
+
+} // namespace infinilm::models::qwen2
+
+namespace {
+
+#ifndef USE_CLASSIC_LLAMA
+
+INFINILM_REGISTER_CAUSAL_LM_MODEL(
+    qwen2,
+    infinilm::models::qwen2::Qwen2ForCausalLM,
+    infinilm::models::qwen2::create_qwen2_model_config);
+
+#endif
+
+} // namespace

--- a/csrc/models/qwen2/qwen2_for_causal_lm.hpp
+++ b/csrc/models/qwen2/qwen2_for_causal_lm.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "../../layers/common_modules.hpp"
+#include <memory>
+
+namespace infinilm::models::qwen2 {
+
+using Qwen2MLP = infinilm::layers::MLP;
+
+using Qwen2Attention = infinilm::layers::attention::Attention;
+
+using Qwen2DecoderLayer = infinilm::layers::causal_lm_templates::TextDecoderLayer<Qwen2Attention, Qwen2MLP>;
+
+using Qwen2Model = infinilm::layers::causal_lm_templates::TextModel<Qwen2DecoderLayer>;
+
+using Qwen2ForCausalLM = infinilm::layers::causal_lm_templates::TextCausalLM<Qwen2Model>;
+
+} // namespace infinilm::models::qwen2
+
+namespace infinilm::models::qwen2 {
+
+std::shared_ptr<infinilm::config::ModelConfig> create_qwen2_model_config(std::shared_ptr<infinilm::config::ModelConfig> model_config);
+
+} // namespace infinilm::models::qwen2


### PR DESCRIPTION
## Description
Decouple Qwen2 and Llama model logic from FM9G

## Test evidence
TinyLlama-1.1B-Chat-v1.0 model type： llama. attn_bias=false in config.json
<img width="3072" height="915" alt="image" src="https://github.com/user-attachments/assets/eac42c88-5498-4a56-8cd7-f84f5723f864" />

DeepSeek-R1-Distill-Qwen-1.5B model type： qwen2
<img width="3070" height="753" alt="image" src="https://github.com/user-attachments/assets/cfabdd0e-5a3d-42ba-b723-05706046d017" />

9g_8b_thinking_llama model type： llama. attn_bias in config.json
<img width="3074" height="780" alt="image" src="https://github.com/user-attachments/assets/fde477d1-d6ff-4f79-9b6e-44a930b6eb3d" />

01-ai_Yi-6B model type： llama. **no attn_bias in config.json, support inference after this code change**
<img width="3053" height="576" alt="image" src="https://github.com/user-attachments/assets/6a877224-5e2c-4043-892f-d0d25db2d86c" />

--use-classic-llama=y
TinyLlama-1.1B-Chat-v1.0 model type： llama. attn_bias=false in config.json
<img width="3054" height="938" alt="image" src="https://github.com/user-attachments/assets/34fe8b5f-1a16-425e-a8b1-15381546b091" />
