### PR TITLE
issue/325 - Add scaling config process to adapt native 9g8b

### DIFF
--- a/csrc/models/fm9g/fm9g_for_causal_lm.hpp
+++ b/csrc/models/fm9g/fm9g_for_causal_lm.hpp
@@ -1,19 +1,61 @@
 #pragma once
 
 #include "../../layers/common_modules.hpp"
+#include "infinicore/nn/linear.hpp"
+#include <cmath>
 #include <memory>
 
 namespace infinilm::models::fm9g {
 
-using FM9GMLP = infinilm::layers::MLP;
+// FM9GAttention: extends shared Attention, sets MuP alpha on o_proj
+class FM9GAttention : public infinilm::layers::attention::Attention {
+public:
+    FM9GAttention(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+                  size_t layer_idx,
+                  const infinicore::Device &device)
+        : Attention(model_config, layer_idx, device) {
+        float scale_depth = model_config->get_or<float>("scale_depth", 1.0f);
+        if (scale_depth != 1.0f) {
+            size_t num_hidden_layers = model_config->get<size_t>("num_hidden_layers");
+            float scale_output = scale_depth / std::sqrt(static_cast<float>(num_hidden_layers));
+            o_proj_->set_alpha(scale_output);
+        }
+    }
+};
 
-using FM9GAttention = infinilm::layers::attention::Attention;
+// FM9GMLP: extends shared MLP, sets MuP alpha on down_proj
+class FM9GMLP : public infinilm::layers::mlp::MLP {
+public:
+    FM9GMLP(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+            const infinicore::Device &device)
+        : MLP(model_config, device) {
+        float scale_depth = model_config->get_or<float>("scale_depth", 1.0f);
+        if (scale_depth != 1.0f) {
+            size_t num_hidden_layers = model_config->get<size_t>("num_hidden_layers");
+            float scale_down = scale_depth / std::sqrt(static_cast<float>(num_hidden_layers));
+            down_proj_->set_alpha(scale_down);
+        }
+    }
+};
 
 using FM9GDecoderLayer = infinilm::layers::causal_lm_templates::TextDecoderLayer<FM9GAttention, FM9GMLP>;
 
 using FM9GModel = infinilm::layers::causal_lm_templates::TextModel<FM9GDecoderLayer>;
 
-using FM9GForCausalLM = infinilm::layers::causal_lm_templates::TextCausalLM<FM9GModel>;
+// FM9GForCausalLM: extends TextCausalLM, sets MuP alpha on lm_head
+class FM9GForCausalLM : public infinilm::layers::causal_lm_templates::TextCausalLM<FM9GModel> {
+public:
+    FM9GForCausalLM(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+                    const infinicore::Device &device)
+        : TextCausalLM<FM9GModel>(model_config, device) {
+        if (model_config->get_config_json().contains("dim_model_base")) {
+            float dim_model_base = model_config->get<float>("dim_model_base");
+            size_t hidden_size = model_config->get<size_t>("hidden_size");
+            float scale_lm_head = dim_model_base / static_cast<float>(hidden_size);
+            this->lm_head_->set_alpha(scale_lm_head);
+        }
+    }
+};
 
 } // namespace infinilm::models::fm9g
 

--- a/python/infinilm/modeling_utils.py
+++ b/python/infinilm/modeling_utils.py
@@ -1,4 +1,5 @@
 import os
+import json
 from typing import Dict, Union
 import time
 import torch
@@ -6,6 +7,17 @@ from safetensors import safe_open
 import glob
 from tqdm import tqdm
 import infinicore
+
+
+def _get_scale_emb(model_path: str) -> float:
+    config_path = os.path.join(model_path, "config.json")
+    if not os.path.exists(config_path):
+        raise FileNotFoundError(f"config.json not found at {config_path}")
+    with open(config_path, "r") as f:
+        config = json.load(f)
+    if config.get("model_type") != "fm9g":
+        return 1.0
+    return config.get("scale_emb", 1.0)
 
 
 def parse_dtype(dtype_str: str):
@@ -122,8 +134,18 @@ def get_model_state_dict(
             load_state_dict(file_path, device=torch_device, dtype=torch_dtype)
         )
 
+    # Apply scale_emb for fm9g models (embed_tokens uses lookup, not GEMM)
+    scale_emb = _get_scale_emb(model_path)
+    embed_tokens_unscaled = None
+    if "model.embed_tokens.weight" in model_param:
+        embed_tokens_unscaled = model_param["model.embed_tokens.weight"]
+        if scale_emb != 1.0:
+            model_param["model.embed_tokens.weight"] = embed_tokens_unscaled * float(scale_emb)
+
     if model_param.get("lm_head.weight", None) is None:
-        model_param["lm_head.weight"] = model_param["model.embed_tokens.weight"]
+        # Use unscaled weight for lm_head (C++ alpha handles dim_model_base scaling)
+        if embed_tokens_unscaled is not None:
+            model_param["lm_head.weight"] = embed_tokens_unscaled
 
     # --------------------------------------------------------- #
     #         model_param_infini references torch.Tensor
@@ -151,8 +173,10 @@ def load_model_state_dict_by_file(
     torch_device = "cpu"
     torch_dtype = infinicore.utils.to_torch_dtype(dtype)
     model_keys = model.state_dict_keyname()
+    scale_emb = _get_scale_emb(model_path)
 
     already_loaded_keys = []
+    embed_tokens_torch_unscaled = None
 
     file_list = glob.glob(os.path.join(model_path, "*.safetensors"))
     if len(file_list) > 0:
@@ -168,6 +192,15 @@ def load_model_state_dict_by_file(
             already_loaded_keys.extend(model_param.keys())
 
             # --------------------------------------------------------- #
+            #         Scale embed_tokens on torch side before converting
+            # --------------------------------------------------------- #
+            if "model.embed_tokens.weight" in model_param:
+                embed_tokens_torch_unscaled = model_param["model.embed_tokens.weight"]
+                if scale_emb != 1.0:
+                    model_param["model.embed_tokens.weight"] = \
+                        embed_tokens_torch_unscaled * float(scale_emb)
+
+            # --------------------------------------------------------- #
             #         model_param_infini references torch.Tensor
             # --------------------------------------------------------- #
             model_param_infini = {}
@@ -180,6 +213,13 @@ def load_model_state_dict_by_file(
         file_path = os.path.join(model_path, "pytorch_model.bin")
         model_params = torch.load(file_path, weights_only=True, map_location="cpu")
 
+        # Scale embed_tokens on torch side before converting
+        if "model.embed_tokens.weight" in model_params:
+            embed_tokens_torch_unscaled = model_params["model.embed_tokens.weight"].to(dtype=torch_dtype)
+            if scale_emb != 1.0:
+                model_params["model.embed_tokens.weight"] = \
+                    embed_tokens_torch_unscaled * float(scale_emb)
+
         model_param_infini = {}
         for key in model_params.keys():
             model_param_infini[key] = infinicore.from_torch(
@@ -191,6 +231,14 @@ def load_model_state_dict_by_file(
         infinicore.sync_device()
     else:
         raise KeyError("Weight file not found.")
+
+    # Handle tied weights: if lm_head.weight is missing, share embed_tokens.weight
+    # Use unscaled weight for lm_head (C++ alpha handles dim_model_base scaling)
+    if "lm_head.weight" in model_keys and "lm_head.weight" not in already_loaded_keys:
+        if embed_tokens_torch_unscaled is not None:
+            lm_head_tensor = infinicore.from_torch(embed_tokens_torch_unscaled)
+            model.load_state_dict({"lm_head.weight": lm_head_tensor}, strict=False)
+            already_loaded_keys.append("lm_head.weight")
 
     check_parameters(model_keys, already_loaded_keys)
 
@@ -212,7 +260,9 @@ def load_model_state_dict_by_tensor(
 
     torch_dtype = infinicore.utils.to_torch_dtype(dtype)
     model_keys = model.state_dict_keyname()
+    scale_emb = _get_scale_emb(model_path)
     already_loaded_keys = []
+    embed_tokens_torch_unscaled = None
 
     file_list = glob.glob(os.path.join(model_path, "*.safetensors"))
     if len(file_list) > 0:
@@ -221,9 +271,14 @@ def load_model_state_dict_by_tensor(
 
             with safe_open(file_path, "pt", "cpu") as f:
                 for name in f.keys():
-                    weight_infini = infinicore.from_torch(
-                        f.get_tensor(name).to(dtype=torch_dtype)
-                    )
+                    tensor = f.get_tensor(name).to(dtype=torch_dtype)
+
+                    if name == "model.embed_tokens.weight":
+                        embed_tokens_torch_unscaled = tensor
+                        if scale_emb != 1.0:
+                            tensor = tensor * float(scale_emb)
+
+                    weight_infini = infinicore.from_torch(tensor)
                     model.load_param(name, weight_infini)
                     already_loaded_keys.append(name)
                     infinicore.sync_stream()
@@ -233,13 +288,24 @@ def load_model_state_dict_by_tensor(
         model_params = torch.load(file_path, weights_only=True, map_location="cpu")
 
         for key in model_params.keys():
-            weight_infini = infinicore.from_torch(
-                model_params[key].to(dtype=torch_dtype)
-            )
+            tensor = model_params[key].to(dtype=torch_dtype)
+            if key == "model.embed_tokens.weight":
+                embed_tokens_torch_unscaled = tensor
+                if scale_emb != 1.0:
+                    tensor = tensor * float(scale_emb)
+            weight_infini = infinicore.from_torch(tensor)
             model.load_param(key, weight_infini)
             already_loaded_keys.append(key)
     else:
         raise KeyError("Weight file not found.")
+
+    # Handle tied weights: if lm_head.weight is missing, share embed_tokens.weight
+    # Use unscaled weight for lm_head (C++ alpha handles dim_model_base scaling)
+    if "lm_head.weight" in model_keys and "lm_head.weight" not in already_loaded_keys:
+        if embed_tokens_torch_unscaled is not None:
+            lm_head_tensor = infinicore.from_torch(embed_tokens_torch_unscaled)
+            model.load_param("lm_head.weight", lm_head_tensor)
+            already_loaded_keys.append("lm_head.weight")
 
     check_parameters(model_keys, already_loaded_keys)
 


### PR DESCRIPTION
## Description
Add scaling config process to adapt native 9g8b && Add lm_head.weight process to adapt native 9g4b

## Test evidence
fm9g: native 9G4B
<img width="3153" height="658" alt="图片11" src="https://github.com/user-attachments/assets/e3fd0eb8-d9f5-4540-b606-de4d63196284" />


fm9g: native 9g_8B_thinking
<img width="3104" height="787" alt="图片10" src="https://github.com/user-attachments/assets/729d4ec5-5cad-411d-9b5d-929d45a138eb" />

llama: 9G4B llama


<img width="3152" height="654" alt="图片2" src="https://github.com/user-attachments/assets/d07a546f-7443-41a5-b438-c4a80513c26b" />

qwen2: 9G7B_QW

<img width="3153" height="573" alt="图片3" src="https://github.com/user-attachments/assets/91f56be6-d5bf-429d-93c9-e80d4a2df1a4" />


llama: 9G7B_MHA

<img width="3094" height="579" alt="图片4" src="https://github.com/user-attachments/assets/f56a3bb9-891a-4f61-9031-b7ee0602cd2d" />


llama: 9g_8b_thinking_llama
<img width="3153" height="786" alt="图片5" src="https://github.com/user-attachments/assets/4bd97b35-3433-443b-a72c-f343199eaacd" />


qwen2: 9G70B
<img width="2629" height="525" alt="图片6" src="https://github.com/user-attachments/assets/a14294e3-036d-4713-a3db-109648f0771f" />



llama: TinyLlama

<img width="3150" height="913" alt="图片7" src="https://github.com/user-attachments/assets/51a71081-ebbe-4b42-9906-9f8b7cce9130" />


qwen2: DP 1.5B 

<img width="3147" height="757" alt="图片8" src="https://github.com/user-attachments/assets/a9d536bd-ade9-49a7-8292-d3a1fda71306" />


fm9g: 9G7B_MHA
<img width="2312" height="526" alt="图片9" src="https://github.com/user-attachments/assets/ce315f44-9b72-498d-9fce-41c98c17f22c" />




