### PR TITLE
issue/341 - support internlm3 model

### DIFF
--- a/csrc/config/model_config.cpp
+++ b/csrc/config/model_config.cpp
@@ -66,7 +66,7 @@ ModelConfig::get_rope_scaling() const {
             std::move(long_factor),
             original_max_position_embeddings,
             factor);
-    } else if (type_str == "default" || type_str == "none") {
+    } else if (type_str == "default" || type_str == "none" || type_str == "dynamic") {
         // Default scaling, no scaling applied
         return nullptr;
     } else {

--- a/csrc/models/internlm3/internlm3_for_causal_lm.cpp
+++ b/csrc/models/internlm3/internlm3_for_causal_lm.cpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "internlm3_for_causal_lm.hpp"
+#include "../models_registry.hpp"
+
+namespace infinilm::models::internlm3 {
+
+std::shared_ptr<infinilm::config::ModelConfig> create_internlm3_model_config(
+    std::shared_ptr<infinilm::config::ModelConfig> model_config) {
+    const std::string &model_type = model_config->get<std::string>("model_type");
+    if ("internlm3" != model_type) {
+        throw std::runtime_error(
+            "infinilm::models::internlm3::create_internlm3_model_config: model_type is not internlm3");
+    }
+
+    nlohmann::json &config_json = model_config->get_config_json();
+
+    if (!config_json.contains("attention_bias")) {
+        config_json["attention_bias"] = false; 
+    }
+
+    return model_config;
+}
+
+} // namespace infinilm::models::internlm3
+
+namespace {
+
+INFINILM_REGISTER_CAUSAL_LM_MODEL(
+    internlm3,
+    infinilm::models::internlm3::InternLM3ForCausalLM,
+    infinilm::models::internlm3::create_internlm3_model_config);
+} // namespace
+

--- a/csrc/models/internlm3/internlm3_for_causal_lm.hpp
+++ b/csrc/models/internlm3/internlm3_for_causal_lm.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "../llama/llama_for_causal_lm.hpp"
+#include "../../layers/common_modules.hpp"
+#include <memory>
+
+namespace infinilm::models::internlm3 {
+    using InternLM3ForCausalLM= infinilm::models::llama::LlamaForCausalLM;
+
+    std::shared_ptr<infinilm::config::ModelConfig> create_internlm3_model_config(
+		    std::shared_ptr<infinilm::config::ModelConfig> model_config);
+
+}


### PR DESCRIPTION
增加internlm3 model适配

test_infer.py执行截图
<img width="1507" height="829" alt="image" src="https://github.com/user-attachments/assets/61443c98-dc0a-4997-9bba-871df2673bee" />
服务启动参数如下：
python python/infinilm/server/inference_server.py --device nvidia --model=/data/rubik/models/internlm3-8b-instruct/ --max-new-tokens=100 --max-batch-size=32 --tp=1 --temperature=1.0 --top-p=0.8 --top-k=1 --enable-paged-attn --cache-type=paged --enable-graph --attn=flash-attn
启动截图：
<img width="1498" height="897" alt="image" src="https://github.com/user-attachments/assets/44d53c01-3147-4d37-801f-26c13eeee960" />
<img width="1509" height="901" alt="image" src="https://github.com/user-attachments/assets/d79cf00d-969e-4a5c-b34e-1554ea6f42fa" />
benchmark客户端输出截图如下：
<img width="1174" height="320" alt="image" src="https://github.com/user-attachments/assets/515b19ca-cd64-4f81-9604-2cd4921e034a" />
<img width="1509" height="856" alt="image" src="https://github.com/user-attachments/assets/7ad54810-32c3-4e79-a52c-5aa3439bce9a" />
<img width="1499" height="863" alt="image" src="https://github.com/user-attachments/assets/46086eb8-a0a9-478e-ab40-0bf3e664d503" />





