### PR TITLE
issue/350 - add ChatGLM causal LM model support

### DIFF
--- a/csrc/config/config_factory.cpp
+++ b/csrc/config/config_factory.cpp
@@ -17,7 +17,7 @@ std::shared_ptr<infinilm::config::ModelConfig> ConfigFactory::createConfig(const
     if (it != config_map.end()) {
         it->second(model_config);
     } else {
-        std::vector<std::string> classic_models = {"llama", "qwen2", "minicpm", "fm9g", "fm9g7b", "glm4"};
+        std::vector<std::string> classic_models = {"llama", "qwen2", "minicpm", "fm9g", "fm9g7b", "glm4", "chatglm"};
         const std::string &model_type = model_config->get<std::string>("model_type");
         if (std::find(classic_models.begin(), classic_models.end(), model_type) == classic_models.end()) {
             throw std::invalid_argument("infinilm::config::ConfigFactory::createConfig: Unsupported model config type: " + model_type);

--- a/csrc/config/config_factory.cpp
+++ b/csrc/config/config_factory.cpp
@@ -17,7 +17,7 @@ std::shared_ptr<infinilm::config::ModelConfig> ConfigFactory::createConfig(const
     if (it != config_map.end()) {
         it->second(model_config);
     } else {
-        std::vector<std::string> classic_models = {"llama", "qwen2", "minicpm", "fm9g", "fm9g7b"};
+        std::vector<std::string> classic_models = {"llama", "qwen2", "minicpm", "fm9g", "fm9g7b", "glm4"};
         const std::string &model_type = model_config->get<std::string>("model_type");
         if (std::find(classic_models.begin(), classic_models.end(), model_type) == classic_models.end()) {
             throw std::invalid_argument("infinilm::config::ConfigFactory::createConfig: Unsupported model config type: " + model_type);

--- a/csrc/engine/rank_worker.cpp
+++ b/csrc/engine/rank_worker.cpp
@@ -281,7 +281,13 @@ void RankWorker::thread_loop() {
             const std::string &model_type = model_config_->get<std::string>("model_type");
             const auto &model_map = models::get_causal_lm_model_map();
             auto it = model_map.find(model_type);
-            if (it != model_map.end()) {
+            if (model_type == "glm4") {
+                model_ = InfinilmModelFactory::createModel(
+                    model_config_,
+                    rank_info_,
+                    pending_cache_config_ != nullptr ? pending_cache_config_.get() : nullptr,
+                    attention_backend_);
+            } else if (it != model_map.end()) {
                 model_ = InfinilmModelFactory::createModel(
                     model_config_,
                     rank_info_.device,

--- a/csrc/engine/rank_worker.cpp
+++ b/csrc/engine/rank_worker.cpp
@@ -281,7 +281,7 @@ void RankWorker::thread_loop() {
             const std::string &model_type = model_config_->get<std::string>("model_type");
             const auto &model_map = models::get_causal_lm_model_map();
             auto it = model_map.find(model_type);
-            if (model_type == "glm4") {
+            if (model_type == "glm4" || model_type == "chatglm") {
                 model_ = InfinilmModelFactory::createModel(
                     model_config_,
                     rank_info_,

--- a/csrc/models/chatglm/chatglm_for_causal_lm.cpp
+++ b/csrc/models/chatglm/chatglm_for_causal_lm.cpp
@@ -1,0 +1,56 @@
+#include "chatglm_for_causal_lm.hpp"
+#include "../llama/llama_for_causal_lm.hpp"
+#include "../models_registry.hpp"
+
+namespace infinilm::models::chatglm {
+
+std::shared_ptr<infinilm::config::ModelConfig> create_chatglm_model_config(
+    std::shared_ptr<infinilm::config::ModelConfig> model_config) {
+    const std::string &model_type = model_config->get<std::string>("model_type");
+    if ("chatglm" != model_type) {
+        throw std::runtime_error(
+            "infinilm::models::chatglm::create_chatglm_model_config: model_type is not chatglm");
+    }
+
+    nlohmann::json &config_json = model_config->get_config_json();
+
+    auto rename_key = [&config_json](const std::string &old_key, const std::string &new_key) {
+        if (config_json.contains(old_key) && !config_json.contains(new_key)) {
+            config_json[new_key] = config_json[old_key];
+        }
+    };
+
+    rename_key("num_layers", "num_hidden_layers");
+    rename_key("multi_query_group_num", "num_key_value_heads");
+    rename_key("kv_channels", "head_dim");
+    rename_key("layernorm_epsilon", "rms_norm_eps");
+    rename_key("seq_length", "max_position_embeddings");
+    rename_key("ffn_hidden_size", "intermediate_size");
+
+    if (!config_json.contains("vocab_size") && config_json.contains("padded_vocab_size")) {
+        config_json["vocab_size"] = config_json["padded_vocab_size"];
+    }
+
+    if (!config_json.contains("attention_bias")) { config_json["attention_bias"] = true; }
+
+    if (!config_json.contains("rope_theta")) {
+        config_json["rope_theta"] = 10000.0;
+    }
+
+    return model_config;
+}
+
+} // namespace infinilm::models::chatglm
+
+namespace {
+
+#ifndef USE_CLASSIC_LLAMA
+
+INFINILM_REGISTER_CAUSAL_LM_MODEL(
+    chatglm,
+    infinilm::models::llama::LlamaForCausalLM,
+    infinilm::models::chatglm::create_chatglm_model_config);
+
+#endif
+
+} // namespace

--- a/csrc/models/chatglm/chatglm_for_causal_lm.hpp
+++ b/csrc/models/chatglm/chatglm_for_causal_lm.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "../../layers/common_modules.hpp"
+#include <memory>
+
+namespace infinilm::models::chatglm {
+
+std::shared_ptr<infinilm::config::ModelConfig> create_chatglm_model_config(
+    std::shared_ptr<infinilm::config::ModelConfig> model_config);
+
+} // namespace infinilm::models::chatglm

--- a/csrc/models/glm4/glm4_for_causal_lm.cpp
+++ b/csrc/models/glm4/glm4_for_causal_lm.cpp
@@ -1,0 +1,42 @@
+#include "glm4_for_causal_lm.hpp"
+#include "../llama/llama_for_causal_lm.hpp"
+#include "../models_registry.hpp"
+
+namespace infinilm::models::glm4 {
+
+std::shared_ptr<infinilm::config::ModelConfig> create_glm4_model_config(
+    std::shared_ptr<infinilm::config::ModelConfig> model_config) {
+    const std::string &model_type = model_config->get<std::string>("model_type");
+    if ("glm4" != model_type) {
+        throw std::runtime_error(
+            "infinilm::models::glm4::create_glm4_model_config: model_type is not glm4");
+    }
+
+    nlohmann::json &config_json = model_config->get_config_json();
+
+    if (!config_json.contains("head_dim")) {
+        config_json["head_dim"] = model_config->get<size_t>("hidden_size")
+            / model_config->get<size_t>("num_attention_heads");
+    }
+
+    if (!config_json.contains("attention_bias")) {
+        config_json["attention_bias"] = true;
+    }
+
+    return model_config;
+}
+
+} // namespace infinilm::models::glm4
+
+namespace {
+
+#ifndef USE_CLASSIC_LLAMA
+
+INFINILM_REGISTER_CAUSAL_LM_MODEL(
+    glm4,
+    infinilm::models::llama::LlamaForCausalLM,
+    infinilm::models::glm4::create_glm4_model_config);
+
+#endif
+
+} // namespace

--- a/csrc/models/glm4/glm4_for_causal_lm.hpp
+++ b/csrc/models/glm4/glm4_for_causal_lm.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "../../layers/common_modules.hpp"
+#include <memory>
+
+namespace infinilm::models::glm4 {
+
+std::shared_ptr<infinilm::config::ModelConfig> create_glm4_model_config(
+    std::shared_ptr<infinilm::config::ModelConfig> model_config);
+
+} // namespace infinilm::models::glm4

--- a/csrc/models/llama_legacy/llama_attention.cpp
+++ b/csrc/models/llama_legacy/llama_attention.cpp
@@ -1,6 +1,7 @@
 #include "llama_attention.hpp"
 
 #include "../../utils.hpp"
+#include "llama_utils.hpp"
 #include "infinicore/nn/linear.hpp"
 #include "infinicore/nn/rope.hpp"
 #include "infinicore/ops.hpp"
@@ -42,6 +43,7 @@ LlamaAttention::LlamaAttention(const LlamaConfig &config,
       num_attention_heads_(config.num_attention_heads),
       num_key_value_heads_(config.num_key_value_heads),
       head_dim_(config.head_dim),
+      rotary_dim_(config.head_dim),
       kv_dim_(config.kv_dim()),
       use_bias_(config.attention_bias),
       use_output_bias_(config.attention_output_bias),
@@ -90,6 +92,7 @@ LlamaAttention::LlamaAttention(std::shared_ptr<infinilm::config::ModelConfig> mo
       num_attention_heads_(model_config->get<size_t>("num_attention_heads")),
       num_key_value_heads_(model_config->get<size_t>("num_key_value_heads")),
       head_dim_(model_config->get_head_dim()),
+      rotary_dim_(get_rotary_dim(model_config->get_head_dim(), model_config->get_or<double>("partial_rotary_factor", 1.0))),
       kv_dim_(model_config->get_kv_dim()),
       use_bias_(model_config->get_or<bool>("attention_bias", true)),
       use_output_bias_(model_config->get_or<bool>("attention_output_bias", false)),
@@ -204,8 +207,21 @@ infinicore::Tensor LlamaAttention::forward_(const infinicore::Tensor &hidden_sta
 
     // 4. Apply RoPE to Q and K
     auto q_rope = infinicore::Tensor::empty({batch_size, num_attention_heads_, seq_len, head_dim_}, q_reshaped->dtype(), q_reshaped->device())->permute({0, 2, 1, 3});
-    rotary_emb_->forward(q_rope, q_reshaped, pos_ids_for_rope); // [bs, seq_len, n_q_head, head_dim]
-    rotary_emb_->forward(k_reshaped, pos_ids_for_rope, true);   // [bs, seq_len, n_kv_head, head_dim]
+    q_rope->copy_from(q_reshaped);
+
+    auto k_rope = infinicore::Tensor::empty({batch_size, seq_len, num_key_value_heads_, head_dim_}, k_reshaped->dtype(), k_reshaped->device());
+    k_rope->copy_from(k_reshaped);
+
+    if (rotary_dim_ == head_dim_) {
+        rotary_emb_->forward(q_rope, q_reshaped, pos_ids_for_rope); // [bs, seq_len, n_q_head, head_dim]
+        rotary_emb_->forward(k_rope, pos_ids_for_rope, true);       // [bs, seq_len, n_kv_head, head_dim]
+    } else {
+        rotary_emb_->forward(
+            q_rope->narrow({{3, 0, rotary_dim_}}),
+            q_reshaped->narrow({{3, 0, rotary_dim_}}),
+            pos_ids_for_rope);
+        rotary_emb_->forward(k_rope->narrow({{3, 0, rotary_dim_}}), pos_ids_for_rope, true);
+    }
 
     infinilm::KVQuantUtils::quantize(
         k_reshaped, v_reshaped,
@@ -217,7 +233,7 @@ infinicore::Tensor LlamaAttention::forward_(const infinicore::Tensor &hidden_sta
     // Convert to [batch, n_head, seq_len, head_dim] for cache
     // Ensure contiguous after permute for F16 compatibility with cache operations
     q_reshaped = q_rope->permute({0, 2, 1, 3});          // [bs, n_q_head, seq_len, head_dim]
-    auto k_permuted = k_reshaped->permute({0, 2, 1, 3}); // [bs, n_kv_head, seq_len, head_dim]
+    auto k_permuted = k_rope->permute({0, 2, 1, 3});     // [bs, n_kv_head, seq_len, head_dim]
     auto v_permuted = v_reshaped->permute({0, 2, 1, 3}); // [bs, n_kv_head, seq_len, head_dim]
     infinicore::Tensor k_total;                          // [bs, n_kv_head, max_seq_len, head_dim]
     infinicore::Tensor v_total;                          // [bs, n_kv_head, max_seq_len, head_dim]
@@ -330,8 +346,19 @@ infinicore::Tensor LlamaAttention::forward_paged_(const infinicore::Tensor &hidd
     }
 
     // 4. Apply RoPE to Q and K
-    rotary_emb_->forward(q_reshaped, pos_ids_for_rope, true); // [bs, seq_len, n_q_head, head_dim]
-    rotary_emb_->forward(k_reshaped, pos_ids_for_rope, true); // [bs, seq_len, n_kv_head, head_dim]
+    if (rotary_dim_ == head_dim_) {
+        rotary_emb_->forward(q_reshaped, pos_ids_for_rope, true); // [seq_len, n_q_head, head_dim]
+        rotary_emb_->forward(k_reshaped, pos_ids_for_rope, true); // [seq_len, n_kv_head, head_dim]
+    } else {
+        auto q_rope = infinicore::Tensor::empty({seq_len, num_attention_heads_, head_dim_}, q_reshaped->dtype(), q_reshaped->device());
+        q_rope->copy_from(q_reshaped);
+        auto k_rope = infinicore::Tensor::empty({seq_len, num_key_value_heads_, head_dim_}, k_reshaped->dtype(), k_reshaped->device());
+        k_rope->copy_from(k_reshaped);
+        rotary_emb_->forward(q_rope->narrow({{2, 0, rotary_dim_}}), pos_ids_for_rope, true);
+        rotary_emb_->forward(k_rope->narrow({{2, 0, rotary_dim_}}), pos_ids_for_rope, true);
+        q_reshaped = q_rope;
+        k_reshaped = k_rope;
+    }
 
     //  5. Prepare KV caches
     //  Ensure contiguous after permute for F16 compatibility with cache operations

--- a/csrc/models/llama_legacy/llama_attention.hpp
+++ b/csrc/models/llama_legacy/llama_attention.hpp
@@ -135,6 +135,7 @@ private:
     size_t num_attention_heads_;
     size_t num_key_value_heads_;
     size_t head_dim_;
+    size_t rotary_dim_;
     size_t kv_dim_;
     bool use_bias_;                  // Bias for Q/K/V projections
     bool use_output_bias_;           // Bias for output projection (o_proj)

--- a/csrc/models/llama_legacy/llama_decoder_layer.cpp
+++ b/csrc/models/llama_legacy/llama_decoder_layer.cpp
@@ -40,11 +40,18 @@ LlamaDecoderLayer::LlamaDecoderLayer(std::shared_ptr<infinilm::config::ModelConf
                                      engine::distributed::RankInfo rank_info,
                                      backends::AttentionBackend attention_backend) : model_config_(model_config), layer_idx_(layer_idx), rank_info_(rank_info) {
     const auto &dtype{model_config_->get_dtype()};
+    use_glm4_post_norms_ = model_config_->get<std::string>("model_type") == "glm4";
     // Initialize layer normalization layers
     INFINICORE_NN_MODULE_INIT(input_layernorm, model_config_->get<size_t>("hidden_size"), model_config_->get<double>("rms_norm_eps"),
                               dtype, device);
     INFINICORE_NN_MODULE_INIT(post_attention_layernorm, model_config_->get<size_t>("hidden_size"), model_config_->get<double>("rms_norm_eps"),
                               dtype, device);
+    if (use_glm4_post_norms_) {
+        INFINICORE_NN_MODULE_INIT(post_self_attn_layernorm, model_config_->get<size_t>("hidden_size"), model_config_->get<double>("rms_norm_eps"),
+                                  dtype, device);
+        INFINICORE_NN_MODULE_INIT(post_mlp_layernorm, model_config_->get<size_t>("hidden_size"), model_config_->get<double>("rms_norm_eps"),
+                                  dtype, device);
+    }
 
     // Initialize attention and MLP modules
     INFINICORE_NN_MODULE_INIT(self_attn, model_config_, device, layer_idx, rank_info_, attention_backend);
@@ -62,6 +69,20 @@ LlamaDecoderLayer::forward(infinicore::Tensor &hidden_states,
                            std::optional<infinicore::Tensor> cu_seqlens,
                            std::optional<infinicore::Tensor> block_tables,
                            std::optional<infinicore::Tensor> slot_mapping) const {
+    if (use_glm4_post_norms_) {
+        hidden_states = forward_naive(
+            hidden_states,
+            position_ids,
+            kv_cache,
+            past_sequence_lengths,
+            total_sequence_lengths,
+            input_offsets,
+            cu_seqlens,
+            block_tables,
+            slot_mapping);
+        return std::make_tuple(hidden_states, residual);
+    }
+
     // 1. Attention layer normalization
     input_layernorm_->forward_inplace(hidden_states, residual);
 
@@ -76,6 +97,36 @@ LlamaDecoderLayer::forward(infinicore::Tensor &hidden_states,
     hidden_states = mlp_->forward(hidden_states);
 
     return std::make_tuple(hidden_states, residual);
+}
+
+infinicore::Tensor LlamaDecoderLayer::forward_naive(
+    infinicore::Tensor &hidden_states,
+    const infinicore::Tensor &position_ids,
+    std::shared_ptr<infinilm::cache::Cache> kv_cache,
+    std::optional<infinicore::Tensor> past_sequence_lengths,
+    std::optional<infinicore::Tensor> total_sequence_lengths,
+    std::optional<infinicore::Tensor> input_offsets,
+    std::optional<infinicore::Tensor> cu_seqlens,
+    std::optional<infinicore::Tensor> block_tables,
+    std::optional<infinicore::Tensor> slot_mapping) const {
+    auto residual = hidden_states;
+    hidden_states = input_layernorm_->forward(hidden_states);
+    hidden_states = self_attn_->forward(
+        hidden_states, position_ids, kv_cache, past_sequence_lengths, total_sequence_lengths, input_offsets, cu_seqlens, block_tables, slot_mapping);
+
+    if (use_glm4_post_norms_) {
+        hidden_states = post_self_attn_layernorm_->forward(hidden_states);
+    }
+    hidden_states = infinicore::op::add(residual, hidden_states);
+
+    residual = hidden_states;
+    hidden_states = post_attention_layernorm_->forward(hidden_states);
+    hidden_states = mlp_->forward(hidden_states);
+    if (use_glm4_post_norms_) {
+        hidden_states = post_mlp_layernorm_->forward(hidden_states);
+    }
+    hidden_states = infinicore::op::add(residual, hidden_states);
+    return hidden_states;
 }
 
 } // namespace infinilm::models::llama_legacy

--- a/csrc/models/llama_legacy/llama_decoder_layer.hpp
+++ b/csrc/models/llama_legacy/llama_decoder_layer.hpp
@@ -79,6 +79,17 @@ public:
             std::optional<infinicore::Tensor> block_tables,
             std::optional<infinicore::Tensor> slot_mappin) const;
 
+    infinicore::Tensor forward_naive(
+        infinicore::Tensor &hidden_states,
+        const infinicore::Tensor &position_ids,
+        std::shared_ptr<infinilm::cache::Cache> kv_cache,
+        std::optional<infinicore::Tensor> past_sequence_lengths,
+        std::optional<infinicore::Tensor> total_sequence_lengths,
+        std::optional<infinicore::Tensor> input_offsets,
+        std::optional<infinicore::Tensor> cu_seqlens,
+        std::optional<infinicore::Tensor> block_tables,
+        std::optional<infinicore::Tensor> slot_mapping) const;
+
     /**
      * @brief Get the layer index
      */
@@ -94,6 +105,8 @@ protected:
     // Layer normalization
     INFINICORE_NN_MODULE(infinicore::nn::RMSNorm, input_layernorm);
     INFINICORE_NN_MODULE(infinicore::nn::RMSNorm, post_attention_layernorm);
+    INFINICORE_NN_MODULE(infinicore::nn::RMSNorm, post_self_attn_layernorm);
+    INFINICORE_NN_MODULE(infinicore::nn::RMSNorm, post_mlp_layernorm);
 
     // Attention and MLP
     INFINICORE_NN_MODULE(LlamaAttention, self_attn);
@@ -103,6 +116,7 @@ protected:
 
 private:
     size_t layer_idx_; // Layer index for cache management and debugging
+    bool use_glm4_post_norms_ = false;
 };
 
 } // namespace infinilm::models::llama_legacy

--- a/csrc/models/llama_legacy/llama_model.cpp
+++ b/csrc/models/llama_legacy/llama_model.cpp
@@ -1,4 +1,5 @@
 #include "llama_model.hpp"
+#include "llama_utils.hpp"
 #include "infinicore/nn/embedding.hpp"
 #include "infinicore/nn/rmsnorm.hpp"
 #include "infinicore/nn/rope.hpp"
@@ -6,6 +7,22 @@
 #include <iostream>
 
 namespace infinilm::models::llama_legacy {
+
+namespace {
+
+infinicore::nn::RoPE::Algo get_rope_algo(const std::string &model_type) {
+    if (model_type == "glm4") {
+        return infinicore::nn::RoPE::Algo::GPT_J;
+    }
+    return infinicore::nn::RoPE::Algo::GPT_NEOX;
+}
+
+bool uses_naive_residual_path(const std::shared_ptr<infinilm::config::ModelConfig> &model_config) {
+    return model_config != nullptr && model_config->get<std::string>("model_type") == "glm4";
+}
+
+} // namespace
+
 /**
  * @deprecated This function is deprecated and will be REMOVED in the next major release (v0.2.0).
  *
@@ -45,7 +62,7 @@ LlamaModel::LlamaModel(const LlamaConfig &config,
     // Initialize Rotary Position Embeddings (shared across all layers)
     // Use GPT-J-style inverse frequencies (default) and GPT_NEOX rotation pairing
     INFINICORE_NN_MODULE_INIT(rotary_emb, config.head_dim, config.max_position_embeddings,
-                              config.rope_theta, infinicore::nn::RoPE::Algo::GPT_NEOX,
+                              config.rope_theta, get_rope_algo(config.model_type),
                               dtype, device, config.rope_scaling);
 
     for (auto &layer : layers_) {
@@ -78,8 +95,8 @@ LlamaModel::LlamaModel(std::shared_ptr<infinilm::config::ModelConfig> model_conf
                               dtype, device);
     // Initialize Rotary Position Embeddings (shared across all layers)
     // Use GPT-J-style inverse frequencies (default) and GPT_NEOX rotation pairing
-    INFINICORE_NN_MODULE_INIT(rotary_emb, model_config_->get_head_dim(), model_config_->get<size_t>("max_position_embeddings"),
-                              model_config_->get<double>("rope_theta"), infinicore::nn::RoPE::Algo::GPT_NEOX,
+    INFINICORE_NN_MODULE_INIT(rotary_emb, get_rotary_dim(model_config_->get_head_dim(), model_config_->get_or<double>("partial_rotary_factor", 1.0)), model_config_->get<size_t>("max_position_embeddings"),
+                              model_config_->get<double>("rope_theta"), get_rope_algo(model_config_->get<std::string>("model_type")),
                               dtype, device, model_config_->get_rope_scaling());
 
     for (auto &layer : layers_) {
@@ -117,6 +134,10 @@ infinicore::Tensor LlamaModel::forward(const infinicore::Tensor &input_ids,
             slot_mapping);
     }
 
+    if (uses_naive_residual_path(model_config_)) {
+        return norm_->forward(hidden_states);
+    }
+
     norm_->forward_inplace(hidden_states, residual);
 
     return hidden_states;
@@ -136,6 +157,11 @@ infinicore::Tensor LlamaModel::forward_embeds(const infinicore::Tensor &inputs_e
     for (size_t i = 0; i < num_layers; ++i) {
         layers_.at(i)->forward(hidden_states, residual, position_ids, kv_cache_, past_sequence_lengths, total_sequence_lengths, input_offsets, cu_seqlens, block_tables, slot_mapping);
     }
+
+    if (uses_naive_residual_path(model_config_)) {
+        return norm_->forward(hidden_states);
+    }
+
     norm_->forward_inplace(hidden_states, residual);
 
     return hidden_states;

--- a/csrc/models/llama_legacy/llama_utils.hpp
+++ b/csrc/models/llama_legacy/llama_utils.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+
+namespace infinilm::models::llama_legacy {
+
+inline size_t get_rotary_dim(size_t head_dim, double partial_rotary_factor) {
+    if (partial_rotary_factor <= 0.0 || partial_rotary_factor >= 1.0) {
+        return head_dim;
+    }
+
+    size_t rotary_dim = static_cast<size_t>(std::llround(
+        static_cast<double>(head_dim) * partial_rotary_factor));
+    rotary_dim = std::clamp(rotary_dim, static_cast<size_t>(2), head_dim);
+    if (rotary_dim % 2 != 0) {
+        rotary_dim -= 1;
+    }
+    return std::max(rotary_dim, static_cast<size_t>(2));
+}
+
+} // namespace infinilm::models::llama_legacy

--- a/examples/test_infer.py
+++ b/examples/test_infer.py
@@ -104,7 +104,10 @@ def test(
             updated_prompts.append(prompt)
         prompts = updated_prompts
 
-    if hasattr(tokenizer, "chat_template") and tokenizer.chat_template is not None:
+    used_chat_template = (
+        hasattr(tokenizer, "chat_template") and tokenizer.chat_template is not None
+    )
+    if used_chat_template:
         input_contents = [
             tokenizer.apply_chat_template(
                 conversation=[{"role": "user", "content": prompt}],
@@ -139,6 +142,10 @@ def test(
         else:
             raise ValueError(f"Unsupported multimodal model_type: {model.model_type}")
     else:
+        add_special_tokens = not used_chat_template or (
+            model.model_type == "chatglm"
+            and tokenizer.__class__.__name__ == "ChatGLM4Tokenizer"
+        )
         if hasattr(tokenizer, "batch_encode_plus"):
             input_ids_list = tokenizer.batch_encode_plus(input_contents)["input_ids"]
         elif hasattr(tokenizer, "_encode_plus"):
@@ -155,14 +162,20 @@ def test(
             # Ideally this is solved by upgrading transformers. However, doing so causes version mismatch between transformers and mlu pytorch on devices with Phytium CPU. So a branch is temporarily used.
             input_ids_list = [
                 tokenizer.encode_plus(
-                    text, truncation=True, max_length=2048, add_special_tokens=True
+                    text,
+                    truncation=True,
+                    max_length=2048,
+                    add_special_tokens=add_special_tokens,
                 )["input_ids"]
                 for text in input_contents
             ]
         else:
             input_ids_list = [
                 tokenizer._encode_plus(
-                    text, truncation=True, max_length=2048, add_special_tokens=True
+                    text,
+                    truncation=True,
+                    max_length=2048,
+                    add_special_tokens=add_special_tokens,
                 )["input_ids"]
                 for text in input_contents
             ]

--- a/python/infinilm/auto_config.py
+++ b/python/infinilm/auto_config.py
@@ -48,5 +48,7 @@ class AutoConfig:
             return cfg
         elif config_dict["model_type"] == "glm4":
             return LlamaConfig(**config_dict)
+        elif config_dict["model_type"] == "chatglm":
+            return LlamaConfig(**config_dict)
 
         raise ValueError(f"Unsupported model type `{config_dict['model_type']}`.")

--- a/python/infinilm/auto_config.py
+++ b/python/infinilm/auto_config.py
@@ -46,5 +46,7 @@ class AutoConfig:
             cfg = LlamaConfig(**config_dict)
             cfg.model_type = "minicpmv"
             return cfg
+        elif config_dict["model_type"] == "glm4":
+            return LlamaConfig(**config_dict)
 
         raise ValueError(f"Unsupported model type `{config_dict['model_type']}`.")

--- a/python/infinilm/modeling_utils.py
+++ b/python/infinilm/modeling_utils.py
@@ -68,6 +68,58 @@ def _remap_glm4_weights(state_dict):
     return new_sd
 
 
+def _rename_chatglm_key(key):
+    new_key = key.replace("transformer.encoder.layers.", "model.layers.")
+    new_key = new_key.replace("transformer.embedding.word_embeddings", "model.embed_tokens")
+    new_key = new_key.replace("transformer.encoder.final_layernorm", "model.norm")
+    new_key = new_key.replace("transformer.output_layer", "lm_head")
+    new_key = new_key.replace("self_attention.", "self_attn.")
+    new_key = new_key.replace("self_attn.dense", "self_attn.o_proj")
+    return new_key.replace("mlp.dense_4h_to_h", "mlp.down_proj")
+
+
+def _remap_chatglm_weights(state_dict, hf_config):
+    num_heads = hf_config.get("num_attention_heads", 32)
+    num_kv = hf_config.get("multi_query_group_num", 2)
+    head_dim = hf_config.get("kv_channels", 128)
+    ffn_hidden = hf_config.get("ffn_hidden_size", 13696)
+    q_dim = num_heads * head_dim
+    k_dim = num_kv * head_dim
+    new_sd = {}
+
+    for key, tensor in state_dict.items():
+        if "rotary_pos_emb" in key:
+            continue
+
+        new_key = _rename_chatglm_key(key)
+        if "query_key_value" in new_key:
+            suffix = "weight" if tensor.dim() == 2 else "bias"
+            q, k, v = _split_first_dim(
+                tensor,
+                [q_dim, k_dim, tensor.shape[0] - q_dim - k_dim],
+                "query_key_value",
+            )
+            base_key = new_key.rsplit(".query_key_value", 1)[0]
+            new_sd[f"{base_key}.q_proj.{suffix}"] = q
+            new_sd[f"{base_key}.k_proj.{suffix}"] = k
+            new_sd[f"{base_key}.v_proj.{suffix}"] = v
+            continue
+
+        if "dense_h_to_4h" in new_key:
+            base_key = new_key.replace(".dense_h_to_4h.weight", "")
+            gate, up = _split_first_dim(
+                tensor,
+                [ffn_hidden, tensor.shape[0] - ffn_hidden],
+                "dense_h_to_4h",
+            )
+            new_sd[f"{base_key}.gate_proj.weight"] = gate
+            new_sd[f"{base_key}.up_proj.weight"] = up
+            continue
+
+        new_sd[new_key] = tensor
+    return new_sd
+
+
 def maybe_remap_weights(state_dict, model):
     if not hasattr(model, "hf_config"):
         return state_dict
@@ -76,6 +128,8 @@ def maybe_remap_weights(state_dict, model):
     model_type = hf_config.get("model_type", "")
     if model_type == "glm4":
         return _remap_glm4_weights(state_dict)
+    if model_type == "chatglm":
+        return _remap_chatglm_weights(state_dict, hf_config)
     return state_dict
 
 

--- a/python/infinilm/modeling_utils.py
+++ b/python/infinilm/modeling_utils.py
@@ -1,4 +1,5 @@
 import os
+import re
 from typing import Dict, Union
 import time
 import torch
@@ -39,6 +40,43 @@ str_to_torch_dtype = {
     "F8_E4M3": torch.float8_e4m3fn,
     "F8_E5M2": torch.float8_e5m2,
 }
+
+
+def _split_first_dim(tensor, sizes, name):
+    if tensor.dim() not in (1, 2):
+        raise ValueError(f"Cannot split {name} with shape {tensor.shape}")
+    return torch.split(tensor, sizes, dim=0)
+
+
+def _remap_glm4_weights(state_dict):
+    new_sd = {}
+
+    for key, tensor in state_dict.items():
+        if "gate_up_proj" not in key:
+            new_sd[key] = tensor
+            continue
+
+        base_key = key.replace(".gate_up_proj.weight", "")
+        intermediate = tensor.shape[0] // 2
+        gate, up = _split_first_dim(
+            tensor,
+            [intermediate, tensor.shape[0] - intermediate],
+            "gate_up_proj",
+        )
+        new_sd[f"{base_key}.gate_proj.weight"] = gate
+        new_sd[f"{base_key}.up_proj.weight"] = up
+    return new_sd
+
+
+def maybe_remap_weights(state_dict, model):
+    if not hasattr(model, "hf_config"):
+        return state_dict
+
+    hf_config = model.hf_config
+    model_type = hf_config.get("model_type", "")
+    if model_type == "glm4":
+        return _remap_glm4_weights(state_dict)
+    return state_dict
 
 
 def check_parameters(model_keys: list, already_loaded_keys: list):
@@ -165,6 +203,7 @@ def load_model_state_dict_by_file(
             model_param = load_state_dict(
                 file_path, device=torch_device, dtype=torch_dtype
             )
+            model_param = maybe_remap_weights(model_param, model)
             already_loaded_keys.extend(model_param.keys())
 
             # --------------------------------------------------------- #
@@ -180,6 +219,8 @@ def load_model_state_dict_by_file(
     elif os.path.exists(os.path.join(model_path, "pytorch_model.bin")):
         file_path = os.path.join(model_path, "pytorch_model.bin")
         model_params = torch.load(file_path, weights_only=True, map_location="cpu")
+
+        model_params = maybe_remap_weights(model_params, model)
 
         model_param_infini = {}
         for key in model_params.keys():


### PR DESCRIPTION
## Summary

- Add ChatGLM model config adapter (`csrc/models/chatglm/`)
- Extend `rank_worker.cpp` condition to include `"chatglm"`
- Register `"chatglm"` in `config_factory.cpp` classic_models list and `auto_config.py`
- Add ChatGLM weight remapping (key rename + QKV/FFN split) in `modeling_utils.py`
- Update `test_infer.py` for ChatGLM tokenizer special token handling

**Note:** This branch is based on `issue/349` (GLM4 support) since ChatGLM depends on GLM4's infrastructure changes (partial rotary, RoPE algo, rank_worker special path). Please merge #352 first.

Closes #350
Parent issue: #332