### PR TITLE
chore: add standard contribution requirements

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,153 @@
+<!--
+Thanks for contributing to InfiniLM! Please read `CONTRIBUTING.md` before
+opening a pull request and fill out every section below. Delete any section
+that is genuinely not applicable (and note why), but do not delete the
+"Checklist" section — it must be filled in for every PR.
+
+The PR title MUST follow Conventional Commits, e.g.
+  feat: support Llama 3 models
+  fix: correct linear attention calculations
+See: https://www.conventionalcommits.org/
+-->
+
+## Summary
+
+<!--
+A concise description of **what** this PR changes. Prefer bullet points over
+prose. Reference files with backtick-fenced paths (e.g. `csrc/models/llama/*`).
+-->
+
+-
+-
+
+## Motivation
+
+<!--
+Explain **why** this change is needed. Link to any related issue, bug, or
+discussion. If this is a performance change, include before/after numbers
+(hardware, shape, dtype, and the measurement methodology).
+-->
+
+Closes #
+
+## Type of Change
+
+<!-- Tick one or more. -->
+
+- [ ] `feat` — new feature / new model
+- [ ] `fix` — bug fix
+- [ ] `perf` — performance improvement (no behavioral change)
+- [ ] `refactor` — code restructuring without behavior change
+- [ ] `test` — adding or fixing tests only
+- [ ] `docs` — documentation only
+- [ ] `build` / `ci` — build system or CI configuration
+- [ ] `chore` — tooling, formatting, or other non-code changes
+- [ ] Breaking change
+
+## Test Results of Involved Models on Supported Platforms (Please attach screenshots)
+
+<!--
+For now, provide the screenshots for involved tests performed on platforms supposed to support the changes.
+
+Tests that might be involved:
+Single request test: examples/test_infer.py
+Offline performance: examples/bench.py
+Sanity test: test/bench/test_benchmark.py
+Service: python/infinilm/server/inference_server.py + scripts/test_perf.py
+
+Model adaptations may involve all four tests, unless specifying partial support for vastly new structures and confirmed with admin.
+
+Python-level changes may involve less tests depending on which files/features are modified. 
+
+Framework-level and Python-level changes may affect different models. Test a few models that might be affected.
+-->
+
+## Benchmark / Performance Impact
+
+<!--
+Required for `perf` PRs; optional otherwise. Describe the benchmark harness,
+shapes, dtypes, hardware, and include baseline vs. new numbers. If the PR is
+not performance-sensitive, write "N/A".
+-->
+
+## Notes for Reviewers
+
+<!--
+Anything reviewers should focus on: subtle invariants, known trade-offs,
+follow-up work intentionally left out of scope, etc.
+-->
+
+---
+
+## Checklist
+
+> Every contributor **must** verify every item below before requesting
+> review. Tick each box only after the check has actually been performed —
+> do not tick speculatively. If an item truly does not apply, replace the
+> checkbox with `N/A` and briefly explain why in an inline comment.
+
+### Title, Branch, and Commits
+
+- [ ] PR **title** follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(nvidia): …`, `fix(cuda/gemm): …`).
+- [ ] Branch name follows `<type>/xxx-yyyy-zzzz` where `<type>` matches the PR title's Conventional Commits type and words are joined with hyphens (see `CONTRIBUTING.md` §Branches).
+- [ ] Each **commit** message follows Conventional Commits.
+- [ ] Small PR is a **single squashable commit**; or, for a large PR, every commit is meaningful, well-formed, and independently reviewable (see `CONTRIBUTING.md` §Pull Requests).
+- [ ] No stray merge commits from `main` — the branch is rebased cleanly on top of the current `main`.
+- [ ] No `fixup!` / `squash!` / `wip` commits remain.
+- [ ] Existing PR/branch/commit that followed the legacy issue format.
+
+### Scope and Design
+
+- [ ] Changes are **minimal** — nothing unrelated to the stated motivation was added (`CONTRIBUTING.md` §Code/General).
+- [ ] No dead code, commented-out blocks, debug prints, `printf`/`std::cout`/`print(...)` left behind, or `TODO` without an owner and issue link.
+- [ ] No unrelated formatting churn that would obscure the diff.
+- [ ] Public API changes (if any) are intentional, documented, and reflected in affected callers/tests.
+
+### General Code Hygiene (applies to all languages)
+
+- [ ] The code is self-explanatory; comments were added **only** where the *why* is non-obvious (`CONTRIBUTING.md` §Code/General).
+- [ ] Every modified or added file **ends with a single trailing newline** (`CONTRIBUTING.md` §Code/General).
+- [ ] No trailing whitespace, tab/space mixing, or stray BOMs.
+- [ ] Identifiers in comments and error messages are wrapped in backticks (e.g. ``the `seqlens_k` tensor``) (`CONTRIBUTING.md` §Code/General).
+- [ ] All comments and error messages are in **English** (`CONTRIBUTING.md` §Code/General).
+- [ ] Comments and error messages are complete sentences — capitalized first letter, terminal punctuation — **unless** the language/framework convention says otherwise (`CONTRIBUTING.md` §Code/General; §Python).
+
+### C++ Specific (if C++ files changed)
+
+- [ ] Code follows the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) strictly.
+- [ ] Error and warning message wording follows the [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html#error-and-warning-messages) (`CONTRIBUTING.md` §C++).
+- [ ] Constructor **initializer list order matches member declaration order** (`CONTRIBUTING.md` §C++).
+- [ ] No raw `new`/`delete`; RAII / smart pointers / existing allocators are used.
+- [ ] Changed files are formatted by `scripts/format.py`.
+- [ ] No changes/reference to `csrc/models/llama_legacy/`.
+
+### Python Specific (if Python files changed)
+
+- [ ] Code is [PEP 8](https://peps.python.org/pep-0008/) compliant.
+- [ ] Comments are complete English sentences, starting with a capital letter and ending with punctuation; Markdown backticks are used for code references (`CONTRIBUTING.md` §Python).
+- [ ] Docstrings (if any) follow [PEP 257](https://peps.python.org/pep-0257/) (`CONTRIBUTING.md` §Python).
+- [ ] Changed files are formatted by `scripts/format.py`.
+- [ ] No changes/reference to `python/infinilm/auto_config.py`.
+
+### Testing
+
+- [ ] For any platform that could not be tested, an explicit reason is given in the table and a reviewer with access has been tagged.
+- [ ] Passed single request test (`examples/test_infer.py`), or specify the reason for skipping.
+- [ ] Passed offline performance test (`examples/bench.py`), or specify the reason for skipping.
+- [ ] Passed sanity test (`test/bench/test_benchmark.py`), or specify the reason for skipping.
+- [ ] Passed service test (`python/infinilm/server/inference_server.py` + `scripts/test_perf.py`), or specify the reason for skipping.
+
+### Build, CI, and Tooling
+
+- [ ] The project builds cleanly from a fresh directory on at least one affected platform.
+
+### Documentation
+
+- [ ] `README.md`, `CONTRIBUTING.md`, or inline docs updated when behavior, build flags, or developer workflow changed.
+- [ ] Any user-visible breaking change is called out explicitly under "Motivation" **and** in the commit/PR title with a `!` or `BREAKING CHANGE:` footer.
+
+### Security and Safety
+
+- [ ] No secrets, access tokens, internal URLs, customer data, or personal hardware identifiers have been committed.
+- [ ] Third-party code is license-compatible and attributed.
+- [ ] No unsafe pointer arithmetic, uninitialized reads, or missing bounds checks were introduced.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,65 @@
+# Contributing Guide
+
+For development setup, see [Development Guide](#development-guide) below.
+
+## Code
+
+Please review these details before committing, especially for AI-generated code.
+
+### General
+
+1. Keep changes minimal — do not add what is not necessary.
+2. Comments are not always better when abundant. Ideally, the code should be self-explanatory.
+3. Files must end with a newline.
+4. Use Markdown syntax (backtick-fenced) for identifiers in comments and error messages.
+5. Comments and error messages must be in English.
+6. Comments and error messages should follow the language's conventions first. If the language does not specify, use complete sentences — capitalize the first letter and end with punctuation.
+
+### C++
+
+1. Unless specified in [Adapt New Models](MODELS.md), follow the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) strictly. Use the default `.clang-format`.
+2. Error and warning messages follow the [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html#error-and-warning-messages).
+3. Initializer list order must match member declaration order.
+4. Formatted by `scripts/format.py`
+
+### Python
+
+Unless specified in [Adapt New Models](MODELS.md), follow [PEP 8](https://peps.python.org/pep-0008/) as the primary style guide. For anything PEP 8 does not cover in detail, refer to the [GDScript style guide](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html)—while it targets a different language, its non-syntax conventions are still applicable.
+
+Formatted by `scripts/format.py`
+
+#### Additional Rules
+
+1. **Comments** should be complete English sentences, starting with a capital letter and ending with punctuation. Use Markdown syntax when referencing code within comments.
+
+2. **Docstrings:** Follow [PEP 257](https://peps.python.org/pep-0257/) conventions.
+
+3. Formatted by `scripts/format.py`
+
+## Commits
+
+Commit messages must follow [Conventional Commits](https://www.conventionalcommits.org/).
+
+Existing commit messages may follow the "issue/### - " legacy format with an issue created to describe the case.
+
+## Pull Requests
+
+1. Small PRs should be squashed. Large PRs may keep multiple commits, but each commit must be meaningful and well-formed.
+2. PR titles should respect to issue number and case summary.
+3. Before merging (or after each stage of changes), build and test on major involved platforms. Include the results in PRs.
+
+## Branches
+
+Branch names use the format `<type>/xxx-yyyy-zzzz`, where `<type>` matches the PR title's Conventional Commits type, and words are joined with hyphens.
+
+Existing branch names may use the legacy format `issue/###`, followed by a suffix when necessary.
+
+---
+
+# Development Guide
+
+Refer to [ReadMe](README.md) and [Adapt New Models](MODELS.md)
+
+## Troubleshooting
+
+1. to be populated

--- a/MODELS.md
+++ b/MODELS.md
@@ -1,0 +1,245 @@
+# InfiniLM Model Adaptation Reference
+
+This document describes how to support a new model in the InfiniLM C++ inference framework.
+
+
+---
+
+## 1. Major Content
+
+### 1.1 `InfinilmModel` Abstract Class
+
+Inference models must inherit from `infinilm::InfinilmModel`(`csrc/models/infinilm_model.hpp`), and implement at least the following:
+
+- **`Output forward(const Input &input) const`(pure virtual)**  
+  Forward computation entry point: produces **`Output`** from `Input`.
+
+- **`void reset_cache(const cache::CacheConfig *cache_config)`(overridable; default implementation in base class)**  
+  **Allocates or rebuilds per-layer KV tensors** based on `cache_config` .
+
+
+---
+
+### 1.2 Model Structure
+
+- **Model Directory**: Each model has its own directory, e.g., `csrc/models/qwen3/`, `csrc/models/qwen3_next/`. The directory name corresponds to the `model_type` name in `config.json`.
+- **Module Separation**: Files are split by module. Common files include `<name>_for_causal_lm.hpp/.cpp`, `<name>_attention.*`, `<name>_decoderLayer.*`, `<name>_allocate_kv_cache_tensors.cpp` (only required when a custom KV allocation is needed).
+- **Reuse**: Consider using components such as `TextDecoderLayer`, `TextModel`, `TextCausalLM`, and `MLP` provided by `csrc/layers/`.
+
+---
+
+### 1.3 KV cache
+
+- **Implementation and Invocation**:  The KV cache is implemented in the `default_allocate_kv_cache_tensors`function or a **custom `<name>_allocate_kv_cache_tensors`** function; it is called within the `reset_cache(cache_config)` function.
+- **Custom Implementation**: When the default KV cache implementation is unsuitable, implement your own function by referring to examples such as `qwen3_next_allocate_kv_cache_tensors` and `minicpm_sala_allocate_kv_cache_tensors`.
+
+---
+
+### 1.4 `ModelConfig` Object
+
+- The **`ModelConfig`** object is constructed from **`config.json`**.
+- The **`create_<架构>_model_config`** function is used to **validate** `model_type`,  and to **complete** missing information (e.g., `head_dim`, `layer_types`).
+
+---
+
+### 1.5 Model Registration
+
+- Register **model information** using the macro **`INFINILM_REGISTER_CAUSAL_LM_MODEL(...)`**.
+- **Location**: The registration call is placed in an anonymous namespace **at the end of `<name>_for_causal_lm.cpp`** .
+- **Constraint**: The string used for registration must match the **`model_type` in `config.json`**.
+
+
+---
+
+## 2. Notes
+
+### 2.1 Naming Conventions
+The following conventions are recommended for new models:
+
+- **Directory Name**: `csrc/models/<model_type>/`, matching `model_type` in `config.json` (e.g., `qwen3`).
+- **Namespace**: `namespace infinilm::models::<model_type> { ... }`, to reduce naming conflicts between different models.
+- **Core Files**: 
+  - `<model_type>_for_causal_lm.hpp/.cpp`: Top-level model and registration entry point.
+  - `<model_type>_attention.hpp/.cpp`: Custom attention (added when the general implementation is insufficient).
+  - `<model_type>_decoderLayer.hpp/.cpp`: Custom decoder layer (added when templates are insufficient).
+  - `<model_type>_allocate_kv_cache_tensors.cpp`: Custom KV cache allocation (added when the default implementation does not fit).
+- **Configuration Post-processing Functions**: `create_<model_type>_model_config(...)`, keeping the name consistent with the function specified in the registration macro.
+- **Registration Macro Usage**: `INFINILM_REGISTER_CAUSAL_LM_MODEL(qwen3, Qwen3ForCausalLM, create_qwen3_model_config)`(example).
+
+### 2.2 Code Reuse
+- **Level 1: `csrc/layers/`**
+  - Prefer using templates such as `TextDecoderLayer`, `TextModel`, `TextCausalLM`.
+  - Prefer using modules such as `infinilm::layers::MLP`, `ReplicatedLinear`, and the general `AttentionLayer`.
+  - Example: `using Qwen3MLP = infinilm::layers::MLP;`
+
+- **Level 2: Same-series `csrc/models/` modules**
+  - When the architecture is consistent with an existing model, reusing stable modules is recommended.
+  - Example: `qwen3_moe` reuses the existing `Qwen3Attention` module via `using Qwen3MoeAttention = qwen3::Qwen3Attention`.
+
+- **Level 3: New Implementation**
+  - When required modules are incompatible with existing implementations, custom attention, decoder, cache, or other related code may be written.
+
+### 2.3 Avoid Modifying the Framework
+Implementation of a new model should be concentrated within the model's own directory (involving tasks such as: `model structure assembly`, `forward`, `reset_cache`, `create_<name>_model_config`, and model registration), **Avoid modifying** common framework code unless necessary.
+
+- **Scope**: Avoid modifying `csrc/layers/`, `csrc/models/infinilm_model.*`, `models_registry.*`, `model_factory.*`, etc., unless strictly necessary.
+
+- **Change Note**: If modifications to files outside a model directory are required, it indicates that the framework's capabilities or interfaces are insufficient to meet the requirements. Such changes will be reviewed carefully and may involve framework-level changes to be added and rebased on.
+
+### 2.4 Do Not Reference/Modify/Use the llama_legacy Directory
+
+The integration approach within `csrc/models/llama_legacy/` is **not the currently recommended path** and might be removed in the future. For new model implementations, please use the models listed in §3 as primary references.
+
+
+`python/infinilm/auto_config.py` typically requires no changes.
+
+---
+
+## 3. Reference Model Selection Guide
+
+### 3.1 `fm9g`: Composition of Existing Modules
+
+- **Attention**: General `infinilm::layers::attention::Attention` (see `common_modules.hpp` and the `attention` module for dependencies).
+- **MLP**: `infinilm::layers::MLP`.
+- **Type Aliases**: `TextDecoderLayer<FM9GAttention, FM9GMLP>` → `TextModel` → `TextCausalLM`.
+- **Configuration**: `create_fm9g_model_config` can supplement JSON fields (e.g., deriving `head_dim` from dimensions).
+
+
+**Files**: `csrc/models/fm9g/fm9g_for_causal_lm.hpp`, `.cpp`.
+
+### 3.2 `qwen3`: Custom Attention + Standard MLP
+
+- **Attention**: `Qwen3Attention`(`qwen3_attention.hpp`, `.cpp`).
+- **MLP**: `infinilm::layers::MLP`.
+- **Top Level**: `TextCausalLM<Qwen3Model>`.
+
+**Files**: `csrc/models/qwen3/qwen3_for_causal_lm.hpp`, `.cpp`, and `qwen3_attention.*`.
+
+
+
+### 3.3 `minicpm_sala`: Custom KV Allocation
+
+- `MiniCPMSALAForCausalLM` inherits from `InfinilmModel`; its `reset_cache` calls **`minicpm_sala_allocate_kv_cache_tensors`**.
+
+**Files**: `csrc/models/minicpm_sala/minicpm_sala_for_causal_lm.hpp`, `.cpp`, `minicpm_sala_allocate_kv_cache_tensors.cpp` etc.
+
+
+
+---
+
+## 4. Implementation Steps (C++)
+
+### 4.1 Create a New Directory
+
+Organize header and implementation files under `csrc/models/<your_model>/`. The following is an example directory layout using `qwen3`; add or remove files as needed:
+
+```text
+csrc/models/qwen3/
+├── qwen3_for_causal_lm.hpp  
+├── qwen3_for_causal_lm.cpp   
+├── qwen3_attention.hpp
+└── qwen3_attention.cpp
+```
+
+- `<name>_for_causal_lm.hpp` / `.cpp`: Assembles the top-level `ForCausalLM` or `TextCausalLM` and contains the **registration macro** translation unit.
+- If custom sub-modules exist, add files such as `<name>_attention.*`, `<name>_decoderLayer.*`, `<name>_allocate_kv_cache_tensors.cpp`.
+
+### 4.2 Implement Decoder Modules
+
+**(1)Type Alias Composition for `TextModel` / `TextCausalLM`(Dense model example: `qwen3`)**
+
+```7:15:csrc/models/qwen3/qwen3_for_causal_lm.hpp
+using Qwen3MLP = infinilm::layers::MLP;
+
+using Qwen3Attention = infinilm::models::qwen3::Qwen3Attention;
+
+using Qwen3DecoderLayer = infinilm::layers::causal_lm_templates::TextDecoderLayer<Qwen3Attention, Qwen3MLP>;
+
+using Qwen3Model = infinilm::layers::causal_lm_templates::TextModel<Qwen3DecoderLayer>;
+
+using Qwen3ForCausalLM = infinilm::layers::causal_lm_templates::TextCausalLM<Qwen3Model>;
+```
+
+**(2)Sub-module Constructor Convention: `TextDecoderLayer` requires `Attention` and `MLP`(or MoE block)to be registered with fixed parameters** (see full implementation at `csrc/layers/causal_lm_templates/text_decoder_layer.hpp`)
+
+```cpp
+// Interface summary (implementation found in source file)
+template <typename Attention, typename MLP>
+class TextDecoderLayer : public infinicore::nn::Module {
+public:
+    TextDecoderLayer(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+                     size_t layer_idx,
+                     const infinicore::Device &device);
+    // 内部: register_module<Attention>("self_attn", model_config, layer_idx, device);
+    //       register_module<MLP>("mlp", model_config, device);
+};
+```
+
+A custom `Attention` module must provide a constructor matching the signature `(model_config, layer_idx, device)`; the FFN slot must provide `(model_config, device)`.
+
+**(3)`TextCausalLM`: Registers `model` and `lm_head`, `forward` maps hidden states to logits** (see full implementation at `csrc/layers/causal_lm_templates/text_causal_lm.hpp`)
+
+```cpp
+// Interface summary (constructor and forward implementation found in source file)
+template <typename Model>
+class TextCausalLM : public InfinilmModel {
+public:
+    TextCausalLM(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+                 const infinicore::Device &device);
+    Output forward(const Input &input) const override;
+};
+```
+
+If `TextCausalLM` cannot be used directly as the top-level class, create a custom subclass and explicitly execute `INFINICORE_NN_MODULE_INIT(model, ...)` and `lm_head` initialization.
+
+### 4.3 Configuration Post-processing： `create_<name>_model_config`
+
+Signature： `std::shared_ptr<infinilm::config::ModelConfig> create_<name>_model_config(std::shared_ptr<infinilm::config::ModelConfig>)`(see `models_registry.hpp`).
+
+**Validating `model_type` only (example: `qwen3`)**(`csrc/models/qwen3/qwen3_for_causal_lm.cpp`); 
+**Supplementing JSON fields (example: `fm9g` deriving `head_dim`)**(`csrc/models/fm9g/fm9g_for_causal_lm.cpp`): 
+```cpp
+std::shared_ptr<infinilm::config::ModelConfig> create_qwen3_model_config(
+    std::shared_ptr<infinilm::config::ModelConfig> model_config);
+```
+
+
+
+### 4.4 Static Registration
+
+`#include` `models_registry.hpp` and place within an anonymous namespace at the end of **`qwen3_for_causal_lm.cpp`**. Structure overview (using `qwen3` as an example; see `csrc/models/qwen3/qwen3_for_causal_lm.cpp` for the complete code):
+
+```cpp
+#include "<name>_for_causal_lm.hpp"
+#include "../models_registry.hpp"  // relative path adjusted for directory depth
+
+namespace infinilm::models::qwen3 {
+std::shared_ptr<infinilm::config::ModelConfig> create_qwen3_model_config(
+    std::shared_ptr<infinilm::config::ModelConfig> model_config);
+// create_xxx: logic such as model_type validation
+} // namespace infinilm::models::qwen3
+
+namespace {
+INFINILM_REGISTER_CAUSAL_LM_MODEL(
+    qwen3,
+    infinilm::models::qwen3::Qwen3ForCausalLM,
+    infinilm::models::qwen3::create_qwen3_model_config);
+}
+```
+
+### 4.5 KV Cache
+
+- **Default Path**: When `reset_cache` is not overridden, the base class `InfinilmModel::reset_cache` calls `default_allocate_kv_cache_tensors` (`infinilm_model.cpp`).
+- **KV Element dtype** is retrieved from **`model_config_->get_kv_cache_dtype()`**.
+- **Custom Path**: The subclass overrides `reset_cache`, clears and populates `global_state::get_forward_context().kv_cache_vec`. Declaration example (`minicpm_sala`, see `csrc/models/minicpm_sala/minicpm_sala_for_causal_lm.cpp` for implementation): 
+
+```cpp
+void MiniCPMSALAForCausalLM::reset_cache(const cache::CacheConfig *cache_config);
+// Process summary: if cache_config is nullptr, delegate to base class reset_cache(nullptr);
+// otherwise, perform a unique_copy of cache_config, clear kv_cache_vec, call
+// minicpm_sala_allocate_kv_cache_tensors(...) and assign the result back.
+```
+
+---
+
+*This document may lag behind code changes; for definitive behavior, refer to the source code in `csrc/models`.*

--- a/MODELS_ZH.md
+++ b/MODELS_ZH.md
@@ -1,0 +1,243 @@
+# InfiniLM 新增模型参考文档
+
+本文介绍如何在 InfiniLM C++推理框架中添加新模型 。
+
+
+---
+
+## 1. 主要内容
+
+### 1.1 `InfinilmModel` 抽象类
+
+推理模型需要继承 `infinilm::InfinilmModel`（`csrc/models/infinilm_model.hpp`），并至少实现：
+
+- **`Output forward(const Input &input) const`（纯虚）**  
+  前向计算入口：由 `Input` 得到 **`Output`**。
+
+- **`void reset_cache(const cache::CacheConfig *cache_config)`（可重写，默认实现见基类）**  
+  依据 `cache_config` **分配或重建各层 KV 张量**。
+
+
+---
+
+### 1.2 模型结构
+
+- **模型目录**：每种模型有一个自己的目录，例如 `csrc/models/qwen3/`、`csrc/models/qwen3_next/`，目录名与 `config.json` 里的 `model_type` 命名对应。
+- **模块拆分**：按模块分文件，常见包括 `<name>_for_causal_lm.hpp/.cpp`、`<name>_attention.*`、`<name>_decoderLayer.*`、`<name>_allocate_kv_cache_tensors.cpp`（仅自定义 KV 时需要）。
+- **复用**：考虑使用 `csrc/layers/` 提供的 `TextDecoderLayer`、`TextModel`、`TextCausalLM`、`MLP` 等组件。
+
+---
+
+### 1.3 KV cache
+
+- **实现和调用**： kv cache的实现在`default_allocate_kv_cache_tensors`函数中 或 **自定义 `<name>_allocate_kv_cache_tensors`** 函数中；调用在 `reset_cache(cache_config)`函数中。
+- **自定义实现**：当默认kv cache的实现不适用时，可参考 `qwen3_next_allocate_kv_cache_tensors`、`minicpm_sala_allocate_kv_cache_tensors`等函数实现自己的函数。
+
+---
+
+### 1.4 `ModelConfig`对象
+
+- **`ModelConfig`**对象 由  **`config.json`** 构造。
+- **`create_<架构>_model_config`** 函数用于 **校验** `model_type`、**补全**缺失内容（如 `head_dim`、`layer_types`）。
+
+---
+
+### 1.5 模型注册
+
+- 通过宏 **`INFINILM_REGISTER_CAUSAL_LM_MODEL(...)`** 注册 **模型信息** 。
+- **位置**：注册调用位于 **`<name>_for_causal_lm.cpp` 末尾** 的匿名命名空间中。
+- **约束**：注册所用字符串须与 **`config.json` 中 `model_type`** 一致。
+
+
+---
+
+## 2. 注意事项
+
+### 2.1 命名规范
+新增模型建议遵循下列约定：
+
+- **目录名**：`csrc/models/<model_type>/`，与 `config.json` 中 `model_type` 一致（如 `qwen3`）。
+- **命名空间**：`namespace infinilm::models::<model_type> { ... }`，以降低不同模型间的命名冲突。
+- **核心文件**：
+  - `<model_type>_for_causal_lm.hpp/.cpp`：顶层模型与注册入口。
+  - `<model_type>_attention.hpp/.cpp`：自定义 attention（在不满足通用实现时新增）。
+  - `<model_type>_decoderLayer.hpp/.cpp`：自定义 decoder layer（在模板不够用时新增）。
+  - `<model_type>_allocate_kv_cache_tensors.cpp`：自定义 KV 创建（在默认实现不适配时新增）。
+- **配置后处理函数**：`create_<model_type>_model_config(...)`，名称与注册宏中的函数保持一致。
+- **注册宏写法**：`INFINILM_REGISTER_CAUSAL_LM_MODEL(qwen3, Qwen3ForCausalLM, create_qwen3_model_config)`（示例）。
+
+### 2.2 代码复用
+- **第一层：`csrc/layers/`**
+  - 建议采用 `TextDecoderLayer`、`TextModel`、`TextCausalLM` 等模板。
+  - 建议采用 `infinilm::layers::MLP`、`ReplicatedLinear`、通用 `AttentionLayer` 等模块。
+  - 例：`using Qwen3MLP = infinilm::layers::MLP;`
+
+- **第二层：同系列 `csrc/models/` 模块**
+  - 与既有模型架构一致时，建议复用已稳定模块。
+  - 例：`qwen3_moe` 通过 `using Qwen3MoeAttention = qwen3::Qwen3Attention` 的方式复用了已有的 `Qwen3Attention`模块。
+
+- **第三层：新增实现**
+  - 在所需模块与现有实现不兼容时，可以自定义 attention、decoder 或 cache 等相关代码。
+
+### 2.3 避免修改框架
+新增模型实现应集中于本模型目录（涉及到的代码包括：`模型结构搭建`、`forward`、`reset_cache`、`create_<name>_model_config`、模型注册），**非必要不修改**公共框架代码。
+
+- **范围**：非必要不修改 `csrc/layers/`、`csrc/models/infinilm_model.*`、`models_registry.*`、`model_factory.*` 等。
+
+- **变更说明**：如果必须对模型目录外文件的修改，则表明框架能力或接口不足以覆盖需求。这部分改动会被详细考虑，并可能需要加入框架级修改后rebase。
+
+### 2.4 不参考/修改/使用 llama_legacy 目录
+
+`csrc/models/llama_legacy/` 中的接入方式**非本仓库当前推荐路径**，可能会在一段时间后删除；新增模型实现请以 §3 所列模型为主要参照。
+
+`python/infinilm/auto_config.py` 通常不需要任何修改。
+
+---
+
+## 3. 按参考模型选型
+
+### 3.1 `fm9g`：已有模块组合
+
+- **Attention**：通用 `infinilm::layers::attention::Attention`（依赖关系见 `common_modules.hpp` 与 `attention` 模块）。
+- **MLP**：`infinilm::layers::MLP`。
+- **类型别名**：`TextDecoderLayer<FM9GAttention, FM9GMLP>` → `TextModel` → `TextCausalLM`。
+- **配置**：`create_fm9g_model_config` 可对 JSON 补全（如由维度推导 `head_dim`）。
+
+
+**文件**：`csrc/models/fm9g/fm9g_for_causal_lm.hpp`、`.cpp`。
+
+### 3.2 `qwen3`：自定义 Attention + 标准 MLP
+
+- **Attention**：`Qwen3Attention`（`qwen3_attention.hpp`、`.cpp`）。
+- **MLP**：`infinilm::layers::MLP`。
+- **顶层**：`TextCausalLM<Qwen3Model>`。
+
+**文件**：`csrc/models/qwen3/qwen3_for_causal_lm.hpp`、`.cpp`，以及 `qwen3_attention.*`。
+
+
+
+### 3.3 `minicpm_sala`：自定义 KV 分配
+
+- `MiniCPMSALAForCausalLM` 继承 `InfinilmModel`；`reset_cache` 调用 **`minicpm_sala_allocate_kv_cache_tensors`**。
+
+**文件**：`csrc/models/minicpm_sala/minicpm_sala_for_causal_lm.hpp`、`.cpp`，`minicpm_sala_allocate_kv_cache_tensors.cpp` 等。
+
+
+
+---
+
+## 4. 实现步骤（C++）
+
+### 4.1 新建目录
+
+在 `csrc/models/<your_model>/` 下组织头文件与实现。下列为以 `qwen3` 为例的目录布局，可按实际需求增删文件：
+
+```text
+csrc/models/qwen3/
+├── qwen3_for_causal_lm.hpp  
+├── qwen3_for_causal_lm.cpp   
+├── qwen3_attention.hpp
+└── qwen3_attention.cpp
+```
+
+- `<name>_for_causal_lm.hpp` / `.cpp`：顶层 `ForCausalLM` 或 `TextCausalLM` 组合、**注册宏**所在翻译单元。
+- 存在自定义子模块时，可增加 `<name>_attention.*`、`<name>_decoderLayer.*`、`<name>_allocate_kv_cache_tensors.cpp` 等。
+
+### 4.2 实现 Decoder 模块
+
+**（1）类型别名组合 `TextModel` / `TextCausalLM`（稠密模型示例：`qwen3`）**
+
+```7:15:csrc/models/qwen3/qwen3_for_causal_lm.hpp
+using Qwen3MLP = infinilm::layers::MLP;
+
+using Qwen3Attention = infinilm::models::qwen3::Qwen3Attention;
+
+using Qwen3DecoderLayer = infinilm::layers::causal_lm_templates::TextDecoderLayer<Qwen3Attention, Qwen3MLP>;
+
+using Qwen3Model = infinilm::layers::causal_lm_templates::TextModel<Qwen3DecoderLayer>;
+
+using Qwen3ForCausalLM = infinilm::layers::causal_lm_templates::TextCausalLM<Qwen3Model>;
+```
+
+**（2）子模块构造函数约定：`TextDecoderLayer` 要求 `Attention` 与 `MLP`（或 MoE 块）按固定参数注册**（完整实现见 `csrc/layers/causal_lm_templates/text_decoder_layer.hpp`）
+
+```cpp
+// 接口摘要（实现见源文件）
+template <typename Attention, typename MLP>
+class TextDecoderLayer : public infinicore::nn::Module {
+public:
+    TextDecoderLayer(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+                     size_t layer_idx,
+                     const infinicore::Device &device);
+    // 内部：register_module<Attention>("self_attn", model_config, layer_idx, device);
+    //       register_module<MLP>("mlp", model_config, device);
+};
+```
+
+自定义 `Attention` 需提供与上述一致的构造函数 `(model_config, layer_idx, device)`；FFN 位需提供 `(model_config, device)`。
+
+**（3）`TextCausalLM`：注册 `model` 与 `lm_head`，`forward` 为 hidden → logits**（完整实现见 `csrc/layers/causal_lm_templates/text_causal_lm.hpp`）
+
+```cpp
+// 接口摘要（构造函数与 forward 实现见源文件）
+template <typename Model>
+class TextCausalLM : public InfinilmModel {
+public:
+    TextCausalLM(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+                 const infinicore::Device &device);
+    Output forward(const Input &input) const override;
+};
+```
+
+若无法直接使用 `TextCausalLM` 作为顶层，须自定义子类并显式执行 `INFINICORE_NN_MODULE_INIT(model, ...)` 与 `lm_head` 初始化。
+
+### 4.3 配置后处理 `create_<name>_model_config`
+
+签名为 `std::shared_ptr<infinilm::config::ModelConfig> create_<name>_model_config(std::shared_ptr<infinilm::config::ModelConfig>)`（见 `models_registry.hpp`）。
+
+**仅校验 `model_type`（示例：`qwen3`）**（`csrc/models/qwen3/qwen3_for_causal_lm.cpp`）；
+**补全 JSON 字段（示例：`fm9g` 推导 `head_dim`）**（`csrc/models/fm9g/fm9g_for_causal_lm.cpp`）：
+```cpp
+std::shared_ptr<infinilm::config::ModelConfig> create_qwen3_model_config(
+    std::shared_ptr<infinilm::config::ModelConfig> model_config);
+```
+
+
+
+### 4.4 静态注册
+
+在 **`qwen3_for_causal_lm.cpp`** 末尾使用匿名命名空间，并 `#include` `models_registry.hpp`。结构示意（以 `qwen3` 为例，完整代码见 `csrc/models/qwen3/qwen3_for_causal_lm.cpp`）：
+
+```cpp
+#include "<name>_for_causal_lm.hpp"
+#include "../models_registry.hpp"  // 相对路径依目录深度调整
+
+namespace infinilm::models::qwen3 {
+std::shared_ptr<infinilm::config::ModelConfig> create_qwen3_model_config(
+    std::shared_ptr<infinilm::config::ModelConfig> model_config);
+// create_xxx：model_type 校验等逻辑
+} // namespace infinilm::models::qwen3
+
+namespace {
+INFINILM_REGISTER_CAUSAL_LM_MODEL(
+    qwen3,
+    infinilm::models::qwen3::Qwen3ForCausalLM,
+    infinilm::models::qwen3::create_qwen3_model_config);
+}
+```
+
+### 4.5 KV Cache
+
+- **默认路径**：未重写 `reset_cache` 时，基类 `InfinilmModel::reset_cache` 调用 `default_allocate_kv_cache_tensors`（`infinilm_model.cpp`）。
+- **KV 元素 dtype** 由 **`model_config_->get_kv_cache_dtype()`** 取得。
+- **自定义路径**：子类重写 `reset_cache`，清空并写入 `global_state::get_forward_context().kv_cache_vec`。声明示例（`minicpm_sala`，实现见 `csrc/models/minicpm_sala/minicpm_sala_for_causal_lm.cpp`）：
+
+```cpp
+void MiniCPMSALAForCausalLM::reset_cache(const cache::CacheConfig *cache_config);
+// 流程概要：cache_config 为空指针时转调基类 reset_cache(nullptr)；
+// 否则对 cache_config 做 unique_copy、清空 kv_cache_vec、调用 minicpm_sala_allocate_kv_cache_tensors(...) 并赋值回写
+```
+
+---
+
+*本文档随代码库变更可能滞后；具体行为以 `csrc/models` 源码为准。*

--- a/scripts/format.py
+++ b/scripts/format.py
@@ -1,0 +1,204 @@
+import argparse
+import subprocess
+import os
+from pathlib import Path
+from colorama import Fore, Style
+
+# Supported file types and their corresponding formatter categories
+SUPPORTED_FILES = {
+    ".h": "c",
+    ".hh": "c",
+    ".hpp": "c",
+    ".c": "c",
+    ".cc": "c",
+    ".cpp": "c",
+    ".cxx": "c",
+    ".cu": "c",
+    ".cuh": "c",
+    ".mlu": "c",
+    ".cl": "c",
+    ".py": "py",
+}
+
+
+def format_file(file: Path, check: bool, formatter) -> bool:
+    formatter = formatter.get(SUPPORTED_FILES.get(file.suffix, None), None)
+    if not formatter:
+        return True  # Unsupported file type, skip
+
+    try:
+        cmd = []
+        if formatter.startswith("clang-format"):
+            cmd = [formatter, "-style=file", "-i", file]
+            if check:
+                cmd.insert(2, "-dry-run")
+                process = subprocess.run(
+                    cmd,
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                )
+                if process.stderr:
+                    print(f"{Fore.YELLOW}{file} is not formatted.{Style.RESET_ALL}")
+                    print(
+                        f"Use {Fore.CYAN}{formatter} -style=file -i {file}{Style.RESET_ALL} to format it."
+                    )
+                    return False
+            else:
+                subprocess.run(
+                    cmd,
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                )
+                print(f"{Fore.CYAN}Formatted: {file}{Style.RESET_ALL}")
+        elif formatter == "black":
+            cmd = [formatter, file]
+            if check:
+                cmd.insert(1, "--check")
+                process = subprocess.run(
+                    cmd,
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                )
+                if process.returncode != 0:
+                    print(f"{Fore.YELLOW}{file} is not formatted.{Style.RESET_ALL}")
+                    print(
+                        f"Use {Fore.CYAN}{formatter} {file}{Style.RESET_ALL} to format it."
+                    )
+                    return False
+            else:
+                subprocess.run(
+                    cmd,
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                )
+                print(f"{Fore.CYAN}Formatted: {file}{Style.RESET_ALL}")
+    except FileNotFoundError:
+        print(
+            f"{Fore.RED}Formatter {formatter} not found, {file} skipped.{Style.RESET_ALL}"
+        )
+    except subprocess.CalledProcessError as e:
+        print(f"{Fore.RED}Formatter {formatter} failed: {e}{Style.RESET_ALL}")
+
+    return True
+
+
+def git_added_files():
+    """Get all staged files"""
+    try:
+        # Use git diff --cached --name-only to get all files added to staging area
+        result = subprocess.run(
+            ["git", "diff", "--cached", "--diff-filter=AMR", "--name-only"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        for file in result.stdout.splitlines():
+            yield Path(file.strip())
+    except subprocess.CalledProcessError as e:
+        print(f"{Fore.RED}Git diff failed: {e}{Style.RESET_ALL}")
+
+
+def git_modified_since_ref(ref):
+    """Get list of files modified from the specified Git reference to the current state"""
+    try:
+        result = subprocess.run(
+            ["git", "diff", f"{ref}..", "--diff-filter=AMR", "--name-only"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        for file in result.stdout.splitlines():
+            yield Path(file.strip())
+    except subprocess.CalledProcessError as e:
+        print(f"{Fore.RED}Git diff failed: {e}{Style.RESET_ALL}")
+
+
+def list_files(paths):
+    """Recursively get all files under the specified paths"""
+    files = []
+    for path in paths:
+        if path.is_file():
+            yield path
+        elif path.is_dir():
+            for dirpath, _, filenames in os.walk(path):
+                for name in filenames:
+                    yield Path(dirpath) / name
+        else:
+            print(
+                f"{Fore.RED}Error: {path} is not a file or directory.{Style.RESET_ALL}"
+            )
+
+
+def filter_in_path(file: Path, path) -> bool:
+    """Check if file is within the specified paths"""
+    for p in path:
+        if file.is_relative_to(p):
+            return True
+    return False
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--ref", type=str, help="Git reference (commit hash) to compare against."
+    )
+    parser.add_argument(
+        "--path", nargs="*", type=Path, help="Files to format or check."
+    )
+    parser.add_argument(
+        "--check", action="store_true", help="Check files without modifying them."
+    )
+    parser.add_argument(
+        "--c", default="clang-format-16", help="C formatter (default: clang-format-16)"
+    )
+    parser.add_argument(
+        "--py", default="black", help="Python formatter (default: black)"
+    )
+    args = parser.parse_args()
+
+    if args.ref is None and args.path is None:
+        # Last commit.
+        print(f"{Fore.GREEN}Formatting git staged files.{Style.RESET_ALL}")
+        files = git_added_files()
+
+    else:
+        if args.ref is None:
+            print(f"{Fore.GREEN}Formatting files in {args.path}.{Style.RESET_ALL}")
+            files = list_files(args.path)
+        elif args.path is None:
+            print(
+                f"{Fore.GREEN}Formatting git modified files from {args.ref}.{Style.RESET_ALL}"
+            )
+            files = git_modified_since_ref(args.ref)
+        else:
+            print(
+                f"{Fore.GREEN}Formatting git modified files from {args.ref} in {args.path}.{Style.RESET_ALL}"
+            )
+            files = (
+                file
+                for file in git_modified_since_ref(args.ref)
+                if filter_in_path(file, args.path)
+            )
+
+    formatted = True
+    for file in files:
+        if not format_file(
+            file,
+            args.check,
+            {
+                "c": args.c,
+                "py": args.py,
+            },
+        ):
+            formatted = False
+
+    if not formatted:
+        exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<!--
Thanks for contributing to InfiniLM! Please read `CONTRIBUTING.md` before
opening a pull request and fill out every section below. Delete any section
that is genuinely not applicable (and note why), but do not delete the
"Checklist" section — it must be filled in for every PR.

The PR title MUST follow Conventional Commits, e.g.
  feat: support Llama 3 models
  fix: correct linear attention calculations
See: https://www.conventionalcommits.org/
-->

## Summary

<!--
A concise description of **what** this PR changes. Prefer bullet points over
prose. Reference files with backtick-fenced paths (e.g. `csrc/models/llama/*`).
-->

- 增加格式化工具
- 增加模型适配说明
- 增加贡献指南
- 增加pr模板

## Motivation

<!--
Explain **why** this change is needed. Link to any related issue, bug, or
discussion. If this is a performance change, include before/after numbers
(hardware, shape, dtype, and the measurement methodology).
-->

Closes #358 

## Type of Change

<!-- Tick one or more. -->

- [ ] `feat` — new feature / new operator / new platform
- [ ] `fix` — bug fix
- [ ] `perf` — performance improvement (no behavioral change)
- [ ] `refactor` — code restructuring without behavior change
- [ ] `test` — adding or fixing tests only
- [x] `docs` — documentation only
- [ ] `build` / `ci` — build system or CI configuration
- [x] `chore` — tooling, formatting, or other non-code changes
- [ ] Breaking change

## Test Results on Supported Platforms

<!--
For now, provide the screenshots for involved tests performed on platforms supposed to support the changes.

Tests that might be involved:
Single request test: examples/test_infer.py
Offline performance: examples/bench.py
Sanity test: test/bench/test_benchmark.py
Service: python/infinilm/server/inference_server.py + scripts/test_perf.py

Model adaptations may involve all four tests, unless specifying partial support for vastly new structures and confirmed with admin.
Python level changes may involve less tests depending on which files/features are modified. 
-->
No code changes
## Benchmark / Performance Impact

<!--
Required for `perf` PRs; optional otherwise. Describe the benchmark harness,
shapes, dtypes, hardware, and include baseline vs. new numbers. If the PR is
not performance-sensitive, write "N/A".
-->
No performance changes
## Notes for Reviewers

<!--
Anything reviewers should focus on: subtle invariants, known trade-offs,
follow-up work intentionally left out of scope, etc.
-->
纯文本修改
---

## Checklist

> Every contributor **must** verify every item below before requesting
> review. Tick each box only after the check has actually been performed —
> do not tick speculatively. If an item truly does not apply, replace the
> checkbox with `N/A` and briefly explain why in an inline comment.

### Title, Branch, and Commits

- [x] PR **title** follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(nvidia): …`, `fix(cuda/gemm): …`).
- [x] Branch name follows `<type>/xxx-yyyy-zzzz` where `<type>` matches the PR title's Conventional Commits type and words are joined with hyphens (see `CONTRIBUTING.md` §Branches).
- [x] Each **commit** message follows Conventional Commits.
- [x] Small PR is a **single squashable commit**; or, for a large PR, every commit is meaningful, well-formed, and independently reviewable (see `CONTRIBUTING.md` §Pull Requests).
- [x] No stray merge commits from `main` — the branch is rebased cleanly on top of the current `main`.
- [x] No `fixup!` / `squash!` / `wip` commits remain.
- N/A Existing PR/branch/commit that followed the legacy issue format.

### Scope and Design

- [x] Changes are **minimal** — nothing unrelated to the stated motivation was added (`CONTRIBUTING.md` §Code/General).
- [x] No dead code, commented-out blocks, debug prints, `printf`/`std::cout`/`print(...)` left behind, or `TODO` without an owner and issue link.
- [x] No unrelated formatting churn that would obscure the diff.
- N/A Public API changes (if any) are intentional, documented, and reflected in affected callers/tests.

### General Code Hygiene (applies to all languages)

- [x] The code is self-explanatory; comments were added **only** where the *why* is non-obvious (`CONTRIBUTING.md` §Code/General).
- [x] Every modified or added file **ends with a single trailing newline** (`CONTRIBUTING.md` §Code/General).
- [x] No trailing whitespace, tab/space mixing, or stray BOMs.
- [x] Identifiers in comments and error messages are wrapped in backticks (e.g. ``the `seqlens_k` tensor``) (`CONTRIBUTING.md` §Code/General).
- [x] All comments and error messages are in **English** (`CONTRIBUTING.md` §Code/General).
- [x] Comments and error messages are complete sentences — capitalized first letter, terminal punctuation — **unless** the language/framework convention says otherwise (`CONTRIBUTING.md` §Code/General; §Python).

### C++ Specific (if C++ files changed)

- N/A Code follows the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) strictly.
- N/A Error and warning message wording follows the [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html#error-and-warning-messages) (`CONTRIBUTING.md` §C++).
- N/A Constructor **initializer list order matches member declaration order** (`CONTRIBUTING.md` §C++).
- N/A No raw `new`/`delete`; RAII / smart pointers / existing allocators are used.
- N/A Changed files are formatted by `scripts/format.py`.
- N/A No changes/reference to `csrc/models/llama_legacy/`.

### Python Specific (if Python files changed)

- N/A Code is [PEP 8](https://peps.python.org/pep-0008/) compliant.
- N/A Comments are complete English sentences, starting with a capital letter and ending with punctuation; Markdown backticks are used for code references (`CONTRIBUTING.md` §Python).
- N/A Docstrings (if any) follow [PEP 257](https://peps.python.org/pep-0257/) (`CONTRIBUTING.md` §Python).
- N/A Changed files are formatted by `scripts/format.py`.
- N/A No changes/reference to `python/infinilm/auto_config.py`.

### Testing

- N/A For any platform that could not be tested, an explicit reason is given in the table and a reviewer with access has been tagged.
- N/A Passed single request test (`examples/test_infer.py`), or specify the reason for skipping.
- N/A Passed offline performance test (`examples/bench.py`), or specify the reason for skipping.
- N/A Passed sanity test (`test/bench/test_benchmark.py`), or specify the reason for skipping.
- N/A Passed service test (`python/infinilm/server/inference_server.py` + `scripts/test_perf.py`), or specify the reason for skipping.

### Build, CI, and Tooling

- N/A The project builds cleanly from a fresh directory on at least one affected platform.

### Documentation

- N/A `README.md`, `CONTRIBUTING.md`, or inline docs updated when behavior, build flags, or developer workflow changed.
- N/A Any user-visible breaking change is called out explicitly under "Motivation" **and** in the commit/PR title with a `!` or `BREAKING CHANGE:` footer.

### Security and Safety

- N/A No secrets, access tokens, internal URLs, customer data, or personal hardware identifiers have been committed.
- N/A Third-party code is license-compatible and attributed.
- N/A No unsafe pointer arithmetic, uninitialized reads, or missing bounds checks were introduced.
