### PR TITLE
issue/349 - Support GLM4 model

### DIFF
--- a/csrc/layers/rotary_embedding/rotary_embedding.cpp
+++ b/csrc/layers/rotary_embedding/rotary_embedding.cpp
@@ -1,17 +1,48 @@
 #include "rotary_embedding.hpp"
 #include <string>
 #include <unordered_map>
+#include <cmath>       // std::llround
+#include <algorithm>   // std::clamp
 
 namespace infinilm::layers::rotary_embedding {
 namespace {
 thread_local std::unordered_map<std::string, std::shared_ptr<infinicore::nn::RoPE>> _ROPE_DICT;
-
 } // namespace
 
+size_t get_rotary_dim(size_t head_dim, double partial_rotary_factor) {
+    if (partial_rotary_factor <= 0.0 || partial_rotary_factor >= 1.0) {
+        return head_dim;
+    }
+
+    size_t rotary_dim = static_cast<size_t>(std::llround(
+        static_cast<double>(head_dim) * partial_rotary_factor));
+    rotary_dim = std::clamp(rotary_dim, static_cast<size_t>(2), head_dim);
+
+    // RoPE operates on complex pairs, so the rotary dimension must be even
+    if (rotary_dim % 2 != 0) {
+        rotary_dim -= 1;
+    }
+    return std::max(rotary_dim, static_cast<size_t>(2));
+}
+
 std::shared_ptr<infinicore::nn::RoPE> get_rope(const std::shared_ptr<infinilm::config::ModelConfig> &model_config,
-                                               const infinicore::Device &device) {
+                                               const infinicore::Device &device,
+					       infinicore::nn::RoPE::Algo algo) {
+    // 1. Get head dimension
+    size_t head_dim = model_config->get_head_dim();
+
+    // 2. Safely get partial_rotary_factor, defaulting to 1.0 (full rotation)
+    double partial_rotary_factor = model_config->get_or<double>("partial_rotary_factor", 1.0);
+
+    // 3. Compute the actual rotary dimension
+    size_t rotary_dim = get_rotary_dim(head_dim, partial_rotary_factor);
+
+
+    // 4. Cache key must include rotary_dim to avoid reusing the same RoPE instance
+    //    across models with different partial_rotary_factor values
     const std::string scaling_type = "default";
-    auto it = _ROPE_DICT.find(scaling_type);
+    std::string cache_key = scaling_type + "_rope_dim_" + std::to_string(rotary_dim);
+    auto it = _ROPE_DICT.find(cache_key);
     if (it != _ROPE_DICT.end()) {
         return it->second;
     }
@@ -19,11 +50,11 @@ std::shared_ptr<infinicore::nn::RoPE> get_rope(const std::shared_ptr<infinilm::c
     const auto &dtype = model_config->get_dtype();
     size_t max_position_embeddings = model_config->get<size_t>("max_position_embeddings");
     double rope_theta = model_config->get<double>("rope_theta");
-    auto rope = std::make_shared<infinicore::nn::RoPE>(model_config->get_head_dim(), max_position_embeddings, rope_theta,
-                                                       infinicore::nn::RoPE::Algo::GPT_NEOX, dtype, device,
+    auto rope = std::make_shared<infinicore::nn::RoPE>(rotary_dim, max_position_embeddings, rope_theta,
+                                                       algo, dtype, device,
                                                        model_config->get_rope_scaling());
 
-    _ROPE_DICT.emplace(scaling_type, rope);
+    _ROPE_DICT.emplace(cache_key, rope);
     return rope;
 }
 

--- a/csrc/layers/rotary_embedding/rotary_embedding.hpp
+++ b/csrc/layers/rotary_embedding/rotary_embedding.hpp
@@ -1,11 +1,17 @@
 #pragma once
 
-#include "../../config/model_config.hpp"
 #include <memory>
+#include "infinicore/nn/rope.hpp"
+#include "../../config/model_config.hpp"
 
 namespace infinilm::layers::rotary_embedding {
 
+// Compute the actual number of dimensions involved in rotary position embedding.
+// For partial rotation, the dimension is clamped to [2, head_dim] and must be even.
+size_t get_rotary_dim(size_t head_dim, double partial_rotary_factor);
+
 std::shared_ptr<infinicore::nn::RoPE> get_rope(const std::shared_ptr<infinilm::config::ModelConfig> &model_config,
-                                               const infinicore::Device &device);
+                                               const infinicore::Device &device,
+                                               infinicore::nn::RoPE::Algo algo = infinicore::nn::RoPE::Algo::GPT_NEOX);
 
 } // namespace infinilm::layers::rotary_embedding

--- a/csrc/models/glm4/glm4_attention.cpp
+++ b/csrc/models/glm4/glm4_attention.cpp
@@ -1,0 +1,200 @@
+#include "glm4_attention.hpp"
+#include "../../global_state/global_state.hpp" 
+#include "../../layers/rotary_embedding/rotary_embedding.hpp"
+#include "../../utils.hpp"
+#include "infinicore/nn/linear.hpp"
+#include "infinicore/nn/rope.hpp"
+#include "infinicore/ops.hpp"
+
+#include <cmath>
+#include <spdlog/spdlog.h>
+#include <stdexcept>
+
+namespace infinilm::models::glm4 {
+
+Glm4Attention::Glm4Attention(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+                             size_t layer_idx,
+                             const infinicore::Device &device)
+    : model_config_(model_config),
+      layer_idx_(layer_idx),
+      hidden_size_(model_config->get<size_t>("hidden_size")),
+      num_attention_heads_(model_config->get<size_t>("num_attention_heads")),
+      num_key_value_heads_(model_config->get<size_t>("num_key_value_heads")),
+      head_dim_(model_config->get_head_dim()),
+      rotary_dim_(infinilm::layers::rotary_embedding::get_rotary_dim(model_config->get_head_dim(), model_config->get_or<double>("partial_rotary_factor", 1.0))),
+      use_bias_(model_config->get_or<bool>("attention_bias", true)),
+      use_output_bias_(model_config->get_or<bool>("attention_output_bias", false)) {
+      
+    const auto &dtype{model_config_->get_dtype()};
+
+    const engine::distributed::RankInfo &g_rank_info = infinilm::global_state::get_tensor_model_parallel_rank_info();
+    int tp_rank = infinilm::global_state::get_tensor_model_parallel_rank();
+    int tp_size = infinilm::global_state::get_tensor_model_parallel_world_size();
+
+    if ((num_key_value_heads_ >= tp_size) && (0 == (num_key_value_heads_ % tp_size))) {
+        num_attention_heads_ /= tp_size;
+        num_key_value_heads_ /= tp_size;
+    } else {
+        throw std::runtime_error("Glm4Attention: num_key_value_heads must be divisible by tp_size");
+    }
+    scaling_ = 1.0f / std::sqrt(static_cast<float>(head_dim_));
+
+    // Linear layer initialization
+    auto quant_scheme = this->model_config_->get_quant_scheme();
+    switch (quant_scheme) {
+    case infinicore::quantization::QuantScheme::COMPRESSED_TENSOR_W8A8I8:
+        INFINILM_QKV_LINEAR_W8A8_INIT(qkv_proj, "q_proj", "k_proj", "v_proj", hidden_size_, head_dim_, model_config_->get<size_t>("num_attention_heads"), model_config_->get<size_t>("num_key_value_heads"), this->model_config_->get_quantization_method(), use_bias_, dtype, device, g_rank_info);
+        INFINICORE_NN_MODULE_INIT(o_proj, model_config_->get<size_t>("num_attention_heads") * head_dim_, hidden_size_, this->model_config_->get_quantization_method(), use_output_bias_, dtype, device, tp_rank, tp_size, g_rank_info.comm);
+        break;
+    case infinicore::quantization::QuantScheme::AWQ_W4A16: {
+        INFINILM_QKV_LINEAR_W4A16AWQ_INIT(qkv_proj, "q_proj", "k_proj", "v_proj", hidden_size_, head_dim_, model_config_->get<size_t>("num_attention_heads"), model_config_->get<size_t>("num_key_value_heads"), this->model_config_->get_quantization_method(), use_bias_, dtype, device, g_rank_info);
+        INFINICORE_NN_MODULE_INIT(o_proj, model_config_->get<size_t>("num_attention_heads") * head_dim_, hidden_size_, this->model_config_->get_quantization_method(), use_output_bias_, dtype, device, tp_rank, tp_size, g_rank_info.comm);
+        break;
+    }
+    case infinicore::quantization::QuantScheme::GPTQ_W4A16_QY: {
+        INFINILM_QKV_LINEAR_W4A16GPTQ_INIT(qkv_proj, "q_proj", "k_proj", "v_proj", hidden_size_, head_dim_, model_config_->get<size_t>("num_attention_heads"), model_config_->get<size_t>("num_key_value_heads"), this->model_config_->get_quantization_method(), use_bias_, dtype, device, g_rank_info);
+        INFINICORE_NN_MODULE_INIT(o_proj, model_config_->get<size_t>("num_attention_heads") * head_dim_, hidden_size_, this->model_config_->get_quantization_method(), use_output_bias_, dtype, device, tp_rank, tp_size, g_rank_info.comm);
+        break;
+    }
+    default:
+        INFINILM_QKV_LINEAR_INIT(qkv_proj, "q_proj", "k_proj", "v_proj", hidden_size_, head_dim_, model_config_->get<size_t>("num_attention_heads"), model_config_->get<size_t>("num_key_value_heads"), this->model_config_->get_quantization_method(), use_bias_, dtype, device, g_rank_info);
+        INFINICORE_NN_MODULE_INIT(o_proj, model_config_->get<size_t>("num_attention_heads") * head_dim_, hidden_size_, this->model_config_->get_quantization_method(), use_output_bias_, dtype, device, tp_rank, tp_size, g_rank_info.comm);
+        break;
+    }
+
+    // RoPE initialization
+    attention_backend_ = infinilm::global_state::get_infinilm_config().attention_backend;
+    rotary_emb_ = infinilm::layers::rotary_embedding::get_rope(model_config, device, infinicore::nn::RoPE::Algo::GPT_J);
+    
+    attn_ = std::make_shared<infinilm::layers::attention::AttentionLayer>(
+        num_attention_heads_, head_dim_, scaling_,
+        num_key_value_heads_, layer_idx_,
+        kv_cache_k_scale_, kv_cache_v_scale_, attention_backend_);
+
+    // KV Cache quantization scale initialization
+    auto kv_quant_scheme = infinilm::global_state::get_infinilm_config().model_config->get_kv_quant_scheme();
+    if (kv_quant_scheme == infinicore::quantization::KVQuantAlgo::INT8) {
+        INFINICORE_NN_PARAMETER_INIT(kv_cache_k_scale, ({1}, infinicore::DataType::F32, device, 0, 0, 1));
+        INFINICORE_NN_PARAMETER_INIT(kv_cache_v_scale, ({1}, infinicore::DataType::F32, device, 0, 0, 1));
+    }
+}
+
+infinicore::Tensor Glm4Attention::forward(const infinicore::Tensor &positions,
+                                          infinicore::Tensor &hidden_states) {
+    if (::infinilm::backends::AttentionBackend::STATIC_ATTN == attention_backend_) {
+        return forward_static_(positions, hidden_states);
+    }
+    return forward_paged_(positions, hidden_states);
+}
+
+infinicore::Tensor Glm4Attention::forward_paged_(const infinicore::Tensor &positions,
+                                                 infinicore::Tensor &hidden_states) {
+    if (!rotary_emb_) {
+        throw std::runtime_error("Glm4Attention: rotary_emb not configured");
+    }
+
+    auto shape = hidden_states->shape();
+    size_t batch_size = shape[0];
+    size_t seq_len = shape[1];
+
+    // Paged mode strictly requires batch_size == 1 due to continuous batching scheduler flattening
+    if (batch_size != 1) {
+        throw std::runtime_error("Glm4Attention::forward_paged_ expects batch_size == 1");
+    }
+
+    // 1. QKV Projection
+    auto [q, k, v] = qkv_proj_->forward_split(hidden_states);
+
+    // Reshape to 3D [sl, nh, hd] - Native layout required by Paged KV Cache update
+    // DO NOT transpose K and V, otherwise do_kv_cache_update will cause segmentation fault!
+    q = q->view({seq_len, num_attention_heads_, head_dim_});
+    k = k->view({seq_len, num_key_value_heads_, head_dim_});
+    v = v->view({seq_len, num_key_value_heads_, head_dim_});
+
+    // 2. Position IDs
+    infinicore::Tensor pos_ids_for_rope;
+    if (positions->shape().size() == 2) {
+        // Squeeze the batch dimension directly to 1D [seq_len]
+        pos_ids_for_rope = positions->narrow({{0, 0, 1}})->view({seq_len});
+    } else if (positions->shape().size() == 1) {
+        pos_ids_for_rope = positions;
+    } else {
+        throw std::runtime_error("Unexpected position_ids shape in forward_paged_");
+    }
+
+    // 3. Rotary Position Embedding (RoPE)
+    // Apply in-place on 3D tensors. Dimension is now 2 (hd) instead of 3 in 4D tensors.
+    rotary_emb_->forward(q->narrow({{2, 0, rotary_dim_}}), pos_ids_for_rope, true);
+    rotary_emb_->forward(k->narrow({{2, 0, rotary_dim_}}), pos_ids_for_rope, true);
+
+    // 4. Attention computation
+    // Pass 3D Q, K, V directly. PagedAttention backend handles KV cache updating internally.
+    auto attn_output = attn_->forward(q, k, v);
+
+    // 5. Output Projection
+    // Reshape attention output to 2D [seq_len, hidden_size] for the linear projection
+    auto output_2d = attn_output->view({seq_len, num_attention_heads_ * head_dim_});
+    auto output = o_proj_->forward(output_2d);
+
+    // Restore 3D [1, seq_len, hidden_size] to match the input hidden_states shape
+    return output->view({1, seq_len, hidden_size_});
+}
+
+infinicore::Tensor Glm4Attention::forward_static_(const infinicore::Tensor &positions,
+                                                  infinicore::Tensor &hidden_states) {
+    if (!rotary_emb_) {
+        throw std::runtime_error("Glm4Attention: rotary_emb not configured");
+    }
+
+    auto shape = hidden_states->shape();
+    size_t batch_size = shape[0];
+    size_t seq_len = shape[1];
+    size_t num_tokens = batch_size * seq_len;
+
+    // 1. QKV Projection -> [bs, sl, nh, hd]
+    auto [q, k, v] = qkv_proj_->forward_split(hidden_states);
+    q = q->contiguous()->view({batch_size, seq_len, num_attention_heads_, head_dim_});
+    k = k->contiguous()->view({batch_size, seq_len, num_key_value_heads_, head_dim_});
+    v = v->contiguous()->view({batch_size, seq_len, num_key_value_heads_, head_dim_});
+
+    // 2. Position IDs
+    infinicore::Tensor pos_ids_for_rope;
+    if (positions->shape().size() == 2) {
+        pos_ids_for_rope = positions->narrow({{0, 0, 1}})->contiguous()->view({seq_len});
+    } else if (positions->shape().size() == 1) {
+        pos_ids_for_rope = positions->contiguous();
+    } else {
+        throw std::runtime_error("Unexpected position_ids shape");
+    }
+
+    // 3. Rotary Position Embedding (RoPE)
+    // Use `true` to perform in-place modification on non-contiguous narrow views
+    rotary_emb_->forward(q->narrow({{3, 0, rotary_dim_}}), pos_ids_for_rope, true);
+    rotary_emb_->forward(k->narrow({{3, 0, rotary_dim_}}), pos_ids_for_rope, true);
+
+    // Trick: Create tensor with target physical layout [bs, nh, sl, hd],
+    // permute to logical layout [bs, sl, nh, hd], and copy data.
+    // This satisfies the Attention backend's memory format requirement without realigning data.
+    auto q_in = infinicore::Tensor::empty({batch_size, num_attention_heads_, seq_len, head_dim_}, q->dtype(), q->device())
+                    ->permute({0, 2, 1, 3});
+    q_in->copy_from(q);
+
+    auto k_in = infinicore::Tensor::empty({batch_size, num_key_value_heads_, seq_len, head_dim_}, k->dtype(), k->device())
+                    ->permute({0, 2, 1, 3});
+    k_in->copy_from(k);
+
+    auto v_in = infinicore::Tensor::empty({batch_size, num_key_value_heads_, seq_len, head_dim_}, v->dtype(), v->device())
+                    ->permute({0, 2, 1, 3});
+    v_in->copy_from(v);
+
+    // 4. Attention computation (q, k, v)
+    auto attn_output = attn_->forward(q_in, k_in, v_in);
+
+    // 5. Output Projection
+    auto output_2d = attn_output->contiguous()->view({num_tokens, num_attention_heads_ * head_dim_});
+    auto output = o_proj_->forward(output_2d);
+    return output->view({batch_size, seq_len, hidden_size_});
+}
+
+} // namespace infinilm::models::glm4
+

--- a/csrc/models/glm4/glm4_attention.hpp
+++ b/csrc/models/glm4/glm4_attention.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "../../layers/common_modules.hpp"
+
+namespace infinilm::layers::attention {
+class AttentionLayer;
+}
+
+namespace infinilm::models::glm4 {
+
+class Glm4Attention : public infinicore::nn::Module {
+public:
+    Glm4Attention(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+                  size_t layer_idx,
+                  const infinicore::Device &device);
+
+    infinicore::Tensor forward(const infinicore::Tensor &positions, infinicore::Tensor &hidden_states);
+
+    void set_rotary_emb(const std::shared_ptr<infinicore::nn::RoPE> &rotary_emb);
+
+protected:
+    // Operator layers
+    INFINICORE_NN_MODULE(infinilm::layers::linear::QKVParallelLinear, qkv_proj);
+    INFINICORE_NN_MODULE(infinilm::layers::linear::RowParallelLinear, o_proj);
+    std::shared_ptr<infinilm::layers::attention::AttentionLayer> attn_;
+    ::infinilm::backends::AttentionBackend attention_backend_;
+    std::shared_ptr<infinicore::nn::RoPE> rotary_emb_;
+    std::shared_ptr<infinilm::config::ModelConfig> model_config_;
+
+    // Model parameters
+    size_t layer_idx_;
+    size_t hidden_size_;
+    size_t num_attention_heads_;
+    size_t num_key_value_heads_;
+    size_t head_dim_;
+    size_t rotary_dim_;
+    bool use_bias_;
+    bool use_output_bias_;
+    float scaling_;
+
+    // KV Cache quantization
+    INFINICORE_NN_PARAMETER(kv_cache_k_scale);
+    INFINICORE_NN_PARAMETER(kv_cache_v_scale);
+private:
+    infinicore::Tensor forward_static_(const infinicore::Tensor &positions, infinicore::Tensor &hidden_states);
+    infinicore::Tensor forward_paged_(const infinicore::Tensor &positions, infinicore::Tensor &hidden_states);
+};
+
+} // namespace infinilm::models::glm4
+

--- a/csrc/models/glm4/glm4_decoder_layer.cpp
+++ b/csrc/models/glm4/glm4_decoder_layer.cpp
@@ -1,0 +1,75 @@
+#include "glm4_decoder_layer.hpp"
+#include "infinicore/ops.hpp" // 包含 add 等算子
+
+namespace infinilm::models::glm4 {
+
+Glm4DecoderLayer::Glm4DecoderLayer(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+                                   size_t layer_idx,
+                                   const infinicore::Device &device) {
+    const auto &dtype = model_config->get_dtype();
+    size_t hidden_size = model_config->get<size_t>("hidden_size");
+    double rms_norm_eps = model_config->get<double>("rms_norm_eps");
+
+    self_attn_ = this->register_module<Glm4Attention>(
+        "self_attn", model_config, layer_idx, device);
+
+    mlp_ = this->register_module<infinilm::layers::mlp::MLP>(
+        "mlp", model_config, device); 
+
+    input_layernorm_ = this->register_module<infinicore::nn::RMSNorm>(
+        "input_layernorm", hidden_size, rms_norm_eps, dtype, device);
+    
+    post_attention_layernorm_ = this->register_module<infinicore::nn::RMSNorm>(
+        "post_attention_layernorm", hidden_size, rms_norm_eps, dtype, device);
+
+    post_self_attn_layernorm_ = this->register_module<infinicore::nn::RMSNorm>(
+        "post_self_attn_layernorm", hidden_size, rms_norm_eps, dtype, device);
+
+    post_mlp_layernorm_ = this->register_module<infinicore::nn::RMSNorm>(
+        "post_mlp_layernorm", hidden_size, rms_norm_eps, dtype, device);
+}
+
+std::tuple<infinicore::Tensor, infinicore::Tensor> Glm4DecoderLayer::forward(
+    const infinicore::Tensor &positions,
+    infinicore::Tensor &hidden_states,
+    infinicore::Tensor &residual) {
+
+    // 1. Attention Block
+    residual = hidden_states;
+    hidden_states = input_layernorm_->forward(hidden_states);
+    hidden_states = self_attn_->forward(positions, hidden_states); 
+    hidden_states = post_self_attn_layernorm_->forward(hidden_states);
+    hidden_states = infinicore::op::add(residual, hidden_states);
+
+    // 2. MLP Block
+    residual = hidden_states;
+    hidden_states = post_attention_layernorm_->forward(hidden_states);
+    hidden_states = mlp_->forward(hidden_states);
+    hidden_states = post_mlp_layernorm_->forward(hidden_states);
+    hidden_states = infinicore::op::add(residual, hidden_states);
+
+    return std::make_tuple(hidden_states, residual);
+}
+
+infinicore::Tensor Glm4DecoderLayer::forward(
+    const infinicore::Tensor &positions,
+    infinicore::Tensor &hidden_states) {
+    
+    auto residual = hidden_states;
+    hidden_states = input_layernorm_->forward(hidden_states);
+    hidden_states = self_attn_->forward(positions, hidden_states);
+    //hidden_states = post_attention_layernorm_->forward(hidden_states);
+    hidden_states = post_self_attn_layernorm_->forward(hidden_states);
+    hidden_states = infinicore::op::add(residual, hidden_states);
+
+    residual = hidden_states;
+    hidden_states = post_attention_layernorm_->forward(hidden_states);
+    hidden_states = mlp_->forward(hidden_states);
+    hidden_states = post_mlp_layernorm_->forward(hidden_states);
+    hidden_states = infinicore::op::add(residual, hidden_states);
+
+    return hidden_states;
+}
+
+} // namespace infinilm::models::glm4
+

--- a/csrc/models/glm4/glm4_decoder_layer.hpp
+++ b/csrc/models/glm4/glm4_decoder_layer.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "../../config/model_config.hpp"
+#include "../../backends/attention_backends.hpp"
+#include "../../engine/distributed/distributed.hpp"
+#include "glm4_attention.hpp"
+#include "infinicore/nn/module.hpp"
+#include "infinicore/nn/rmsnorm.hpp"
+#include "../../layers/mlp/mlp.hpp"
+
+namespace infinilm::models::glm4 {
+
+class Glm4DecoderLayer : public infinicore::nn::Module {
+public:
+    Glm4DecoderLayer(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+                     size_t layer_idx,
+                     const infinicore::Device &device);
+
+    std::tuple<infinicore::Tensor, infinicore::Tensor> forward(
+        const infinicore::Tensor &positions,
+        infinicore::Tensor &hidden_states,
+        infinicore::Tensor &residual);
+
+    infinicore::Tensor forward(
+        const infinicore::Tensor &positions,
+        infinicore::Tensor &hidden_states);
+
+private:
+    INFINICORE_NN_MODULE(Glm4Attention, self_attn);
+    INFINICORE_NN_MODULE(infinilm::layers::mlp::MLP, mlp);
+    INFINICORE_NN_MODULE(infinicore::nn::RMSNorm, input_layernorm);
+    INFINICORE_NN_MODULE(infinicore::nn::RMSNorm, post_self_attn_layernorm);
+    INFINICORE_NN_MODULE(infinicore::nn::RMSNorm, post_attention_layernorm);
+    INFINICORE_NN_MODULE(infinicore::nn::RMSNorm, post_mlp_layernorm);
+};
+
+} // namespace infinilm::models::glm4
+

--- a/csrc/models/glm4/glm4_for_causal_lm.cpp
+++ b/csrc/models/glm4/glm4_for_causal_lm.cpp
@@ -1,0 +1,33 @@
+#include "glm4_for_causal_lm.hpp"
+#include "../models_registry.hpp"
+#include <stdexcept>
+
+namespace infinilm::models::glm4 {
+
+std::shared_ptr<infinilm::config::ModelConfig> create_glm4_model_config(
+    std::shared_ptr<infinilm::config::ModelConfig> model_config) {
+    const std::string &model_type = model_config->get<std::string>("model_type");
+    if ("glm4" != model_type) {
+        throw std::runtime_error(
+            "infinilm::models::glm4::create_glm4_model_config: model_type is not glm4");
+    }
+
+    nlohmann::json &config_json = model_config->get_config_json();
+
+    if (!config_json.contains("attention_bias")) {
+        config_json["attention_bias"] = false;
+    }
+
+    return model_config;
+}
+
+} // namespace infinilm::models::glm4
+
+namespace {
+
+INFINILM_REGISTER_CAUSAL_LM_MODEL(
+    glm4,
+    infinilm::models::glm4::Glm4ForCausalLM,
+    infinilm::models::glm4::create_glm4_model_config);
+} // namespace
+

--- a/csrc/models/glm4/glm4_for_causal_lm.hpp
+++ b/csrc/models/glm4/glm4_for_causal_lm.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "glm4_decoder_layer.hpp"
+#include <memory>
+
+namespace infinilm::models::glm4 {
+
+using Glm4Model = infinilm::layers::causal_lm_templates::TextModel<Glm4DecoderLayer>;
+
+using Glm4ForCausalLM = infinilm::layers::causal_lm_templates::TextCausalLM<Glm4Model>;
+
+std::shared_ptr<infinilm::config::ModelConfig> create_glm4_model_config(
+    std::shared_ptr<infinilm::config::ModelConfig> model_config);
+
+} // namespace infinilm::models::glm4
+

--- a/python/infinilm/modeling_utils.py
+++ b/python/infinilm/modeling_utils.py
@@ -1,6 +1,6 @@
 import os
 import json
-from typing import Dict, Union
+from typing import Dict, Union, Optional, List
 import time
 import torch
 from safetensors import safe_open
@@ -170,6 +170,8 @@ def load_model_state_dict_by_file(
     print(" load weights ......")
     t1 = time.time()
 
+    model_type = model.hf_config.get("model_type", "")
+
     torch_device = "cpu"
     torch_dtype = infinicore.utils.to_torch_dtype(dtype)
     model_keys = model.state_dict_keyname()
@@ -189,6 +191,12 @@ def load_model_state_dict_by_file(
             model_param = load_state_dict(
                 file_path, device=torch_device, dtype=torch_dtype
             )
+
+            # Apply model-specific weight remapping
+            remapper = _WEIGHT_REMAPPER.get(model_type)
+            if remapper is not None:
+                model_param = remapper(model_param)
+
             already_loaded_keys.extend(model_param.keys())
 
             # --------------------------------------------------------- #
@@ -213,6 +221,11 @@ def load_model_state_dict_by_file(
     elif os.path.exists(os.path.join(model_path, "pytorch_model.bin")):
         file_path = os.path.join(model_path, "pytorch_model.bin")
         model_params = torch.load(file_path, weights_only=True, map_location="cpu")
+
+        # Apply model-specific weight remapping
+        remapper = _WEIGHT_REMAPPER.get(model_type)
+        if remapper is not None:
+            model_params = remapper(model_params)
 
         # Scale embed_tokens on torch side before converting
         if "model.embed_tokens.weight" in model_params:
@@ -312,3 +325,92 @@ def load_model_state_dict_by_tensor(
 
     t2 = time.time()
     print(f" load weights over! {(t2 - t1) * 1000} ms \n")
+
+# ============================================================================
+# Common weight transformation utilities
+# ============================================================================
+
+def split_fused_weight(
+    state_dict: Dict[str, torch.Tensor],
+    fused_key: str,
+    output_names: List[str],
+    split_dim: int = 0,
+    split_ratios: Optional[List[float]] = None,
+) -> Dict[str, torch.Tensor]:
+    """Split fused weight tensors into separate weights.
+
+    Args:
+        state_dict: Original state dict from HuggingFace safetensors.
+        fused_key: Substring to match in key names (e.g. "gate_up_proj").
+        output_names: Names of the split outputs (e.g. ["gate_proj", "up_proj"]).
+        split_dim: Dimension along which to split. Default 0.
+        split_ratios: Optional ratios. If None, split equally.
+
+    Returns:
+        New state dict with fused keys replaced by split keys.
+    """
+    result = {}
+    for key, tensor in state_dict.items():
+        if fused_key not in key:
+            result[key] = tensor
+            continue
+
+        base_key = key.replace(f".{fused_key}.weight", "")
+        dim_size = tensor.shape[split_dim]
+        num_splits = len(output_names)
+
+        if split_ratios is not None:
+            total_ratio = sum(split_ratios)
+            sizes = [int(dim_size * r / total_ratio) for r in split_ratios[:-1]]
+            sizes.append(dim_size - sum(sizes))
+        else:
+            chunk = dim_size // num_splits
+            sizes = [chunk] * (num_splits - 1)
+            sizes.append(dim_size - chunk * (num_splits - 1))
+
+        splits = torch.split(tensor, sizes, dim=split_dim)
+        for name, split_tensor in zip(output_names, splits):
+            result[f"{base_key}.{name}.weight"] = split_tensor
+
+    return result
+
+
+def rename_keys(
+    state_dict: Dict[str, torch.Tensor],
+    mapping: Dict[str, str],
+) -> Dict[str, torch.Tensor]:
+    """Rename weight keys according to a substring mapping."""
+    result = {}
+    for key, tensor in state_dict.items():
+        new_key = key
+        for old_str, new_str in mapping.items():
+            new_key = new_key.replace(old_str, new_str)
+        result[new_key] = tensor
+    return result
+
+
+# ============================================================================
+# Model-specific remap functions
+# ============================================================================
+
+def _remap_glm4(state_dict):
+    """Split GLM-4 fused gate_up_proj into gate_proj + up_proj."""
+    return split_fused_weight(
+        state_dict,
+        fused_key="gate_up_proj",
+        output_names=["gate_proj", "up_proj"],
+    )
+
+
+# Add more model remap functions here as needed:
+#
+# def _remap_qwen3(state_dict):
+#     state_dict = split_fused_weight(state_dict, "gate_up_proj", ["gate_proj", "up_proj"])
+#     state_dict = rename_keys(state_dict, {"model.layers": "decoder.layers"})
+#     return state_dict
+
+# Model type → remap function mapping
+_WEIGHT_REMAPPER = {
+    "glm4": _remap_glm4,
+    # "qwen3": _remap_qwen3,
+}


### PR DESCRIPTION
根据https://github.com/InfiniTensor/InfiniLM/pull/352 这个PR里面的检视意见以及本次PR之committer的检视意见，进行了重构
建议参考一下修改点
1、新增模型不应该修改已有模型代码，不要修改llama_legacy文件中的代码。
2、删除config_factory.cpp和rank_worker.cpp的改动
3、参考已有代码实现（非llama_legacy文件夹），mlp model causual_lm 应该可以使用现有的模块。
4、在glm4文件添加如下文件 glm4_decoder_layer.cpp/hpp + glm4_for_causal_lm.cpp/hpp。
5、csrc/models/glm4/glm4_for_causal_lm.cpp中，需要定义一个自己的Glm4ForCausalLM类，不要使用nfinilm::models::llama::LlamaForCausalLM。
6、RoPE类型问题：csrc/layers/rotary_embedding/rotary_embedding.cpp中get_rope函数的功能，在这个函数中处理GPT_J类型和"partial_rotary_factor"超参数。
7、使用字典模式设计weights remap
8、同时支持atention_static和attention_paged
9、中文注释改成英文注释
10、using Glm4ForCausalLM = infinilm::layers::causal_lm_templates::TextCausalLM;复用已有模块
11、删除reset_cache重载


1、模型test_infer.py测试截图：
命令：python examples/test_infer.py --device nvidia --model=/data/rubik/models/GLM-4-9B-0414/
<img width="1494" height="588" alt="image" src="https://github.com/user-attachments/assets/8826424e-253e-4e29-be07-03c14d85bbe7" />
2、推理服务启动
命令：python python/infinilm/server/inference_server.py --device nvidia --model=/data/rubik/models/GLM-4-9B-0414/
<img width="1485" height="918" alt="9935ba401a8cf8fa2231e3859dbd0fd5" src="https://github.com/user-attachments/assets/4c38b7d6-04f7-4ddf-a983-60630922011e" />
客户端命令：python scripts/test_perf.py --verbose
客户端部分输出截图：
<img width="1481" height="917" alt="f86a09cfbd5c50da66238ebf02c4f7ae" src="https://github.com/user-attachments/assets/96cb6f79-778f-4539-abe1-2a0346d97875" />
<img width="1490" height="875" alt="98d11eebab0edb1277c98440870cb57f" src="https://github.com/user-attachments/assets/0dcbb293-8994-4a0e-a5d1-baaaf09001b6" />
<img width="1484" height="688" alt="92bc919e118dae545126d76cfee63a90" src="https://github.com/user-attachments/assets/f1636edf-293f-44e3-a75c-d5a2d2a13eb1" />
<img width="1486" height="713" alt="f2d15507f83601b54089455da652b5e4" src="https://github.com/user-attachments/assets/d166b429-6e7f-417a-baf8-e1723e6875da" />
<img width="1515" height="853" alt="2aa026aa1dcf8e1420154d6fd21be30f" src="https://github.com/user-attachments/assets/8bd5e7ea-b74f-484d-935b-1904e48d6557" />


另外由于修改了csrc/layers/rotary_embedding/rotary_embedding.cpp中的代码，algo默认参数为infinicore::nn::RoPE::Algo algo = infinicore::nn::RoPE::Algo::GPT_NEOX，逻辑跟原来一样。
跑两个之前的ok的模型进行验证：
<img width="1493" height="788" alt="b89e6d56b60f1964e0e77bec054bc1d7" src="https://github.com/user-attachments/assets/8eca9515-7709-473c-920e-afa5c6789ba2" />
<img width="1498" height="673" alt="image" src="https://github.com/user-attachments/assets/5c52aa0a-6ad9-4bf1-8d37-d350248d10d5" />


根据检视意见修改后在进行验证，加上enable_paged
测试命令：python examples/test_infer.py --device nvidia --model=/data/rubik/models/GLM-4-9B-0414/ --enable-paged-attn
输出：
<img width="1489" height="619" alt="image" src="https://github.com/user-attachments/assets/9e8ef72e-b520-4a04-a5ae-6da8a7ac3817" />

模型服务测试：python python/infinilm/server/inference_server.py --device nvidia --model=/data/rubik/models/GLM-4-9B-0414/ --enable-paged-attn
<img width="1496" height="854" alt="image" src="https://github.com/user-attachments/assets/78665063-d669-40be-9a85-974d1a33183e" />

客户端部分输出截图：
<img width="1492" height="793" alt="image" src="https://github.com/user-attachments/assets/0ba366bb-4220-414a-8ddb-9733940a00cd" />

<img width="1490" height="914" alt="image" src="https://github.com/user-attachments/assets/49315bf1-92f9-4af6-bc65-5c9a8b2e871b" />


tp并行测试，命令：CUDA_VISIBLE_DEVICES=0,1 python examples/test_infer.py --device nvidia --model=/data/rubik/models/GLM-4-9B-0414/ --enable-paged-attn --tp=2 --prompt="山东最高的山是？"
输出：
<img width="1508" height="588" alt="image" src="https://github.com/user-attachments/assets/d3beb618-3226-4d03-96bd-63e0353128f9" />
命令：CUDA_VISIBLE_DEVICES=0,1 python examples/test_infer.py --device nvidia --model=/data/rubik/models/GLM-4-9B-0414/ --enable-paged-attn --tp=1 --prompt="山东最高的山是？"
输出：
<img width="1471" height="589" alt="image" src="https://github.com/user-attachments/assets/a492953e-8751-4b7a-8b49-ae71f3b9caa3" />

tp并行推理服务启动命令：CUDA_VISIBLE_DEVICES=0,1 python python/infinilm/server/inference_server.py --device nvidia --model=/data/rubik/models/GLM-4-9B-0414/ --enable-paged-attn --tp=2
<img width="1501" height="866" alt="image" src="https://github.com/user-attachments/assets/f1b74102-0b45-494a-bf35-4a39c978fbbe" />
<img width="1497" height="912" alt="image" src="https://github.com/user-attachments/assets/984a5c00-d6b5-40b0-8560-d248e11041df" />




