### PR TITLE
chore: format glm4 code

### DIFF
--- a/csrc/layers/rotary_embedding/rotary_embedding.cpp
+++ b/csrc/layers/rotary_embedding/rotary_embedding.cpp
@@ -1,8 +1,8 @@
 #include "rotary_embedding.hpp"
+#include <algorithm> // std::clamp
+#include <cmath>     // std::llround
 #include <string>
 #include <unordered_map>
-#include <cmath>       // std::llround
-#include <algorithm>   // std::clamp
 
 namespace infinilm::layers::rotary_embedding {
 namespace {
@@ -27,7 +27,7 @@ size_t get_rotary_dim(size_t head_dim, double partial_rotary_factor) {
 
 std::shared_ptr<infinicore::nn::RoPE> get_rope(const std::shared_ptr<infinilm::config::ModelConfig> &model_config,
                                                const infinicore::Device &device,
-					       infinicore::nn::RoPE::Algo algo) {
+                                               infinicore::nn::RoPE::Algo algo) {
     // 1. Get head dimension
     size_t head_dim = model_config->get_head_dim();
 
@@ -36,7 +36,6 @@ std::shared_ptr<infinicore::nn::RoPE> get_rope(const std::shared_ptr<infinilm::c
 
     // 3. Compute the actual rotary dimension
     size_t rotary_dim = get_rotary_dim(head_dim, partial_rotary_factor);
-
 
     // 4. Cache key must include rotary_dim to avoid reusing the same RoPE instance
     //    across models with different partial_rotary_factor values

--- a/csrc/layers/rotary_embedding/rotary_embedding.hpp
+++ b/csrc/layers/rotary_embedding/rotary_embedding.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <memory>
-#include "infinicore/nn/rope.hpp"
 #include "../../config/model_config.hpp"
+#include "infinicore/nn/rope.hpp"
+#include <memory>
 
 namespace infinilm::layers::rotary_embedding {
 

--- a/csrc/models/glm4/glm4_attention.cpp
+++ b/csrc/models/glm4/glm4_attention.cpp
@@ -1,5 +1,5 @@
 #include "glm4_attention.hpp"
-#include "../../global_state/global_state.hpp" 
+#include "../../global_state/global_state.hpp"
 #include "../../layers/rotary_embedding/rotary_embedding.hpp"
 #include "../../utils.hpp"
 #include "infinicore/nn/linear.hpp"
@@ -24,7 +24,7 @@ Glm4Attention::Glm4Attention(std::shared_ptr<infinilm::config::ModelConfig> mode
       rotary_dim_(infinilm::layers::rotary_embedding::get_rotary_dim(model_config->get_head_dim(), model_config->get_or<double>("partial_rotary_factor", 1.0))),
       use_bias_(model_config->get_or<bool>("attention_bias", true)),
       use_output_bias_(model_config->get_or<bool>("attention_output_bias", false)) {
-      
+
     const auto &dtype{model_config_->get_dtype()};
 
     const engine::distributed::RankInfo &g_rank_info = infinilm::global_state::get_tensor_model_parallel_rank_info();
@@ -65,7 +65,7 @@ Glm4Attention::Glm4Attention(std::shared_ptr<infinilm::config::ModelConfig> mode
     // RoPE initialization
     attention_backend_ = infinilm::global_state::get_infinilm_config().attention_backend;
     rotary_emb_ = infinilm::layers::rotary_embedding::get_rope(model_config, device, infinicore::nn::RoPE::Algo::GPT_J);
-    
+
     attn_ = std::make_shared<infinilm::layers::attention::AttentionLayer>(
         num_attention_heads_, head_dim_, scaling_,
         num_key_value_heads_, layer_idx_,
@@ -197,4 +197,3 @@ infinicore::Tensor Glm4Attention::forward_static_(const infinicore::Tensor &posi
 }
 
 } // namespace infinilm::models::glm4
-

--- a/csrc/models/glm4/glm4_attention.hpp
+++ b/csrc/models/glm4/glm4_attention.hpp
@@ -41,10 +41,10 @@ protected:
     // KV Cache quantization
     INFINICORE_NN_PARAMETER(kv_cache_k_scale);
     INFINICORE_NN_PARAMETER(kv_cache_v_scale);
+
 private:
     infinicore::Tensor forward_static_(const infinicore::Tensor &positions, infinicore::Tensor &hidden_states);
     infinicore::Tensor forward_paged_(const infinicore::Tensor &positions, infinicore::Tensor &hidden_states);
 };
 
 } // namespace infinilm::models::glm4
-

--- a/csrc/models/glm4/glm4_decoder_layer.cpp
+++ b/csrc/models/glm4/glm4_decoder_layer.cpp
@@ -14,11 +14,11 @@ Glm4DecoderLayer::Glm4DecoderLayer(std::shared_ptr<infinilm::config::ModelConfig
         "self_attn", model_config, layer_idx, device);
 
     mlp_ = this->register_module<infinilm::layers::mlp::MLP>(
-        "mlp", model_config, device); 
+        "mlp", model_config, device);
 
     input_layernorm_ = this->register_module<infinicore::nn::RMSNorm>(
         "input_layernorm", hidden_size, rms_norm_eps, dtype, device);
-    
+
     post_attention_layernorm_ = this->register_module<infinicore::nn::RMSNorm>(
         "post_attention_layernorm", hidden_size, rms_norm_eps, dtype, device);
 
@@ -37,7 +37,7 @@ std::tuple<infinicore::Tensor, infinicore::Tensor> Glm4DecoderLayer::forward(
     // 1. Attention Block
     residual = hidden_states;
     hidden_states = input_layernorm_->forward(hidden_states);
-    hidden_states = self_attn_->forward(positions, hidden_states); 
+    hidden_states = self_attn_->forward(positions, hidden_states);
     hidden_states = post_self_attn_layernorm_->forward(hidden_states);
     hidden_states = infinicore::op::add(residual, hidden_states);
 
@@ -54,11 +54,11 @@ std::tuple<infinicore::Tensor, infinicore::Tensor> Glm4DecoderLayer::forward(
 infinicore::Tensor Glm4DecoderLayer::forward(
     const infinicore::Tensor &positions,
     infinicore::Tensor &hidden_states) {
-    
+
     auto residual = hidden_states;
     hidden_states = input_layernorm_->forward(hidden_states);
     hidden_states = self_attn_->forward(positions, hidden_states);
-    //hidden_states = post_attention_layernorm_->forward(hidden_states);
+    // hidden_states = post_attention_layernorm_->forward(hidden_states);
     hidden_states = post_self_attn_layernorm_->forward(hidden_states);
     hidden_states = infinicore::op::add(residual, hidden_states);
 
@@ -72,4 +72,3 @@ infinicore::Tensor Glm4DecoderLayer::forward(
 }
 
 } // namespace infinilm::models::glm4
-

--- a/csrc/models/glm4/glm4_decoder_layer.hpp
+++ b/csrc/models/glm4/glm4_decoder_layer.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
-#include "../../config/model_config.hpp"
 #include "../../backends/attention_backends.hpp"
+#include "../../config/model_config.hpp"
 #include "../../engine/distributed/distributed.hpp"
+#include "../../layers/mlp/mlp.hpp"
 #include "glm4_attention.hpp"
 #include "infinicore/nn/module.hpp"
 #include "infinicore/nn/rmsnorm.hpp"
-#include "../../layers/mlp/mlp.hpp"
 
 namespace infinilm::models::glm4 {
 
@@ -35,4 +35,3 @@ private:
 };
 
 } // namespace infinilm::models::glm4
-

--- a/csrc/models/glm4/glm4_for_causal_lm.cpp
+++ b/csrc/models/glm4/glm4_for_causal_lm.cpp
@@ -30,4 +30,3 @@ INFINILM_REGISTER_CAUSAL_LM_MODEL(
     infinilm::models::glm4::Glm4ForCausalLM,
     infinilm::models::glm4::create_glm4_model_config);
 } // namespace
-

--- a/csrc/models/glm4/glm4_for_causal_lm.hpp
+++ b/csrc/models/glm4/glm4_for_causal_lm.hpp
@@ -13,4 +13,3 @@ std::shared_ptr<infinilm::config::ModelConfig> create_glm4_model_config(
     std::shared_ptr<infinilm::config::ModelConfig> model_config);
 
 } // namespace infinilm::models::glm4
-

--- a/python/infinilm/modeling_utils.py
+++ b/python/infinilm/modeling_utils.py
@@ -140,7 +140,9 @@ def get_model_state_dict(
     if "model.embed_tokens.weight" in model_param:
         embed_tokens_unscaled = model_param["model.embed_tokens.weight"]
         if scale_emb != 1.0:
-            model_param["model.embed_tokens.weight"] = embed_tokens_unscaled * float(scale_emb)
+            model_param["model.embed_tokens.weight"] = embed_tokens_unscaled * float(
+                scale_emb
+            )
 
     if model_param.get("lm_head.weight", None) is None:
         # Use unscaled weight for lm_head (C++ alpha handles dim_model_base scaling)
@@ -205,8 +207,9 @@ def load_model_state_dict_by_file(
             if "model.embed_tokens.weight" in model_param:
                 embed_tokens_torch_unscaled = model_param["model.embed_tokens.weight"]
                 if scale_emb != 1.0:
-                    model_param["model.embed_tokens.weight"] = \
+                    model_param["model.embed_tokens.weight"] = (
                         embed_tokens_torch_unscaled * float(scale_emb)
+                    )
 
             # --------------------------------------------------------- #
             #         model_param_infini references torch.Tensor
@@ -229,10 +232,13 @@ def load_model_state_dict_by_file(
 
         # Scale embed_tokens on torch side before converting
         if "model.embed_tokens.weight" in model_params:
-            embed_tokens_torch_unscaled = model_params["model.embed_tokens.weight"].to(dtype=torch_dtype)
+            embed_tokens_torch_unscaled = model_params["model.embed_tokens.weight"].to(
+                dtype=torch_dtype
+            )
             if scale_emb != 1.0:
-                model_params["model.embed_tokens.weight"] = \
+                model_params["model.embed_tokens.weight"] = (
                     embed_tokens_torch_unscaled * float(scale_emb)
+                )
 
         model_param_infini = {}
         for key in model_params.keys():
@@ -326,9 +332,11 @@ def load_model_state_dict_by_tensor(
     t2 = time.time()
     print(f" load weights over! {(t2 - t1) * 1000} ms \n")
 
+
 # ============================================================================
 # Common weight transformation utilities
 # ============================================================================
+
 
 def split_fused_weight(
     state_dict: Dict[str, torch.Tensor],
@@ -392,6 +400,7 @@ def rename_keys(
 # ============================================================================
 # Model-specific remap functions
 # ============================================================================
+
 
 def _remap_glm4(state_dict):
     """Split GLM-4 fused gate_up_proj into gate_proj + up_proj."""


### PR DESCRIPTION
<!--
Thanks for contributing to InfiniLM! Please read `CONTRIBUTING.md` before
opening a pull request and fill out every section below. Delete any section
that is genuinely not applicable (and note why), but do not delete the
"Checklist" section — it must be filled in for every PR.

The PR title MUST follow Conventional Commits, e.g.
  feat: support Llama 3 models
  fix: correct linear attention calculations
See: https://www.conventionalcommits.org/
-->

## Summary

<!--
A concise description of **what** this PR changes. Prefer bullet points over
prose. Reference files with backtick-fenced paths (e.g. `csrc/models/llama/*`).
-->
格式化
-
-

## Motivation

<!--
Explain **why** this change is needed. Link to any related issue, bug, or
discussion. If this is a performance change, include before/after numbers
(hardware, shape, dtype, and the measurement methodology).
-->
格式化代码，降低沟通成本

Closes #372 

## Type of Change

<!-- Tick one or more. -->

- [ ] `feat` — new feature / new model
- [ ] `fix` — bug fix
- [ ] `perf` — performance improvement (no behavioral change)
- [ ] `refactor` — code restructuring without behavior change
- [ ] `test` — adding or fixing tests only
- [ ] `docs` — documentation only
- [ ] `build` / `ci` — build system or CI configuration
- [x] `chore` — tooling, formatting, or other non-code changes
- [ ] Breaking change

## Test Results of Involved Models on Supported Platforms (Please attach screenshots)

<!--
For now, provide the screenshots for involved tests performed on platforms supposed to support the changes.

Tests that might be involved:
Single request test: examples/test_infer.py
Offline performance: examples/bench.py
Sanity test: test/bench/test_benchmark.py
Service: python/infinilm/server/inference_server.py + scripts/test_perf.py

Model adaptations may involve all four tests, unless specifying partial support for vastly new structures and confirmed with admin.

Python-level changes may involve less tests depending on which files/features are modified. 

Framework-level and Python-level changes may affect different models. Test a few models that might be affected.
-->

## Benchmark / Performance Impact

<!--
Required for `perf` PRs; optional otherwise. Describe the benchmark harness,
shapes, dtypes, hardware, and include baseline vs. new numbers. If the PR is
not performance-sensitive, write "N/A".
-->

## Notes for Reviewers

<!--
Anything reviewers should focus on: subtle invariants, known trade-offs,
follow-up work intentionally left out of scope, etc.
-->

---

## Checklist

> Every contributor **must** verify every item below before requesting
> review. Tick each box only after the check has actually been performed —
> do not tick speculatively. If an item truly does not apply, replace the
> checkbox with `N/A` and briefly explain why in an inline comment.

### Title, Branch, and Commits

- [x] PR **title** follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(nvidia): …`, `fix(cuda/gemm): …`).
- [x] Branch name follows `<type>/xxx-yyyy-zzzz` where `<type>` matches the PR title's Conventional Commits type and words are joined with hyphens (see `CONTRIBUTING.md` §Branches).
- [x] Each **commit** message follows Conventional Commits.
- [x] Small PR is a **single squashable commit**; or, for a large PR, every commit is meaningful, well-formed, and independently reviewable (see `CONTRIBUTING.md` §Pull Requests).
- [x] No stray merge commits from `main` — the branch is rebased cleanly on top of the current `main`.
- [x] No `fixup!` / `squash!` / `wip` commits remain.
- [ ] Existing PR/branch/commit that followed the legacy issue format.

### Scope and Design

- [x] Changes are **minimal** — nothing unrelated to the stated motivation was added (`CONTRIBUTING.md` §Code/General).
- [x] No dead code, commented-out blocks, debug prints, `printf`/`std::cout`/`print(...)` left behind, or `TODO` without an owner and issue link.
- [x] No unrelated formatting churn that would obscure the diff.
- [x] Public API changes (if any) are intentional, documented, and reflected in affected callers/tests.

### General Code Hygiene (applies to all languages)

- [x] The code is self-explanatory; comments were added **only** where the *why* is non-obvious (`CONTRIBUTING.md` §Code/General).
- [x] Every modified or added file **ends with a single trailing newline** (`CONTRIBUTING.md` §Code/General).
- [x] No trailing whitespace, tab/space mixing, or stray BOMs.
- [x] Identifiers in comments and error messages are wrapped in backticks (e.g. ``the `seqlens_k` tensor``) (`CONTRIBUTING.md` §Code/General).
- [x] All comments and error messages are in **English** (`CONTRIBUTING.md` §Code/General).
- [x] Comments and error messages are complete sentences — capitalized first letter, terminal punctuation — **unless** the language/framework convention says otherwise (`CONTRIBUTING.md` §Code/General; §Python).

### C++ Specific (if C++ files changed)

- [x] Code follows the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) strictly.
- [x] Error and warning message wording follows the [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html#error-and-warning-messages) (`CONTRIBUTING.md` §C++).
- [x] Constructor **initializer list order matches member declaration order** (`CONTRIBUTING.md` §C++).
- [x] No raw `new`/`delete`; RAII / smart pointers / existing allocators are used.
- [x] Changed files are formatted by `scripts/format.py`.
- [x] No changes/reference to `csrc/models/llama_legacy/`.

### Python Specific (if Python files changed)

- [x] Code is [PEP 8](https://peps.python.org/pep-0008/) compliant.
- [x] Comments are complete English sentences, starting with a capital letter and ending with punctuation; Markdown backticks are used for code references (`CONTRIBUTING.md` §Python).
- [x] Docstrings (if any) follow [PEP 257](https://peps.python.org/pep-0257/) (`CONTRIBUTING.md` §Python).
- [x] Changed files are formatted by `scripts/format.py`.
- [x] No changes/reference to `python/infinilm/auto_config.py`.

### Testing

- [x] For any platform that could not be tested, an explicit reason is given in the table and a reviewer with access has been tagged.
- [x] Passed single request test (`examples/test_infer.py`), or specify the reason for skipping.
- [x] Passed offline performance test (`examples/bench.py`), or specify the reason for skipping.
- [x] Passed sanity test (`test/bench/test_benchmark.py`), or specify the reason for skipping.
- [x] Passed service test (`python/infinilm/server/inference_server.py` + `scripts/test_perf.py`), or specify the reason for skipping.

### Build, CI, and Tooling

- [x] The project builds cleanly from a fresh directory on at least one affected platform.

### Documentation

- [x] `README.md`, `CONTRIBUTING.md`, or inline docs updated when behavior, build flags, or developer workflow changed.
- [x] Any user-visible breaking change is called out explicitly under "Motivation" **and** in the commit/PR title with a `!` or `BREAKING CHANGE:` footer.

### Security and Safety

- [x] No secrets, access tokens, internal URLs, customer data, or personal hardware identifiers have been committed.
- [x] Third-party code is license-compatible and attributed.
- [x] No unsafe pointer arithmetic, uninitialized reads, or missing bounds checks were introduced.
