### PR TITLE
Refactor/unify linear quantization

### DIFF
--- a/csrc/cache/kv_cache.cpp
+++ b/csrc/cache/kv_cache.cpp
@@ -67,6 +67,7 @@ StaticKVCache::StaticKVCache(
          k_dim_},
         dtype_,
         rank_info.device);
+    set_zeros(k_caches_);
 
     // Allocate V cache
     v_caches_ = infinicore::Tensor::empty(
@@ -77,6 +78,9 @@ StaticKVCache::StaticKVCache(
          v_dim_},
         dtype_,
         rank_info.device);
+    set_zeros(v_caches_);
+
+    infinicore::context::syncStream();
 }
 
 infinicore::Tensor StaticKVCache::create_layer_kv_cache(
@@ -110,6 +114,9 @@ infinicore::Tensor StaticKVCache::create_layer_kv_cache(
          kv_dim},
         dtype,
         rank_info.device);
+    set_zeros(kv_cache);
+
+    infinicore::context::syncStream();
 
     return kv_cache;
 }
@@ -211,6 +218,7 @@ PagedKVCache::PagedKVCache(
          k_dim_},
         dtype_,
         rank_info.device);
+    set_zeros(k_caches_);
 
     // [num_layers, num_blocks, num_rank_v_heads, block_size, v_dim]
     v_caches_ = infinicore::Tensor::empty(
@@ -221,6 +229,9 @@ PagedKVCache::PagedKVCache(
          v_dim_},
         dtype_,
         rank_info.device);
+    set_zeros(v_caches_);
+
+    infinicore::context::syncStream();
 }
 
 infinicore::Tensor PagedKVCache::create_layer_kv_cache(
@@ -256,6 +267,9 @@ infinicore::Tensor PagedKVCache::create_layer_kv_cache(
         kv_shape,
         dtype,
         rank_info.device);
+    set_zeros(kv_cache);
+
+    infinicore::context::syncStream();
 
     return kv_cache;
 }

--- a/csrc/config/model_config.cpp
+++ b/csrc/config/model_config.cpp
@@ -16,12 +16,12 @@ ModelConfig::ModelConfig(const std::string &path) {
     this->quant_config = QuantConfig(config_json["quantization_config"]);
 }
 
-infinicore::quantization::QuantScheme
+infinilm::quantization::QuantScheme
 ModelConfig::get_quant_scheme() const {
-    if (quant_config.get_quant_scheme() != infinicore::quantization::QuantScheme::NONE) {
+    if (quant_config.get_quant_scheme() != infinilm::quantization::QuantScheme::NONE) {
         return quant_config.get_quant_scheme();
     } else {
-        return infinicore::quantization::QuantScheme::NONE;
+        return infinilm::quantization::QuantScheme::NONE;
     }
 }
 

--- a/csrc/config/model_config.hpp
+++ b/csrc/config/model_config.hpp
@@ -62,17 +62,17 @@ public:
         return quant_config;
     }
 
-    std::shared_ptr<infinicore::quantization::BaseQuantization> get_quantization_method() const {
+    std::shared_ptr<infinilm::quantization::BaseQuantization> get_quantization_method() const {
         return quant_config.get_quantization_method();
     }
 
     infinicore::DataType get_dtype() const;
-    infinicore::quantization::QuantScheme get_quant_scheme() const;
+    infinilm::quantization::QuantScheme get_quant_scheme() const;
     std::shared_ptr<infinicore::nn::RoPE::ScalingConfig> get_rope_scaling() const;
     void set_kv_quant_scheme(infinicore::DataType kv_cache_dtype) {
         this->quant_config.set_kv_quant_scheme(kv_cache_dtype);
     }
-    infinicore::quantization::KVQuantAlgo get_kv_quant_scheme() const {
+    infinilm::quantization::KVQuantAlgo get_kv_quant_scheme() const {
         return quant_config.get_kv_quant_scheme();
     }
     infinicore::DataType get_kv_cache_dtype() const {

--- a/csrc/config/quant_config.cpp
+++ b/csrc/config/quant_config.cpp
@@ -5,25 +5,24 @@ QuantConfig::QuantConfig(const nlohmann::json &json) : quantization_config(json)
     this->quantization_method = get_quantization_method();
 }
 
-std::shared_ptr<infinicore::quantization::BaseQuantization>
+std::shared_ptr<infinilm::quantization::BaseQuantization>
 QuantConfig::get_quantization_method() const {
     if (quantization_config.is_null()) {
-        return std::make_shared<infinicore::quantization::NoneQuantization>(quantization_config); // Default case if no matching scheme
+        return std::make_shared<infinilm::quantization::NoneQuantization>(quantization_config); // Default case if no matching scheme
     }
 
     // Determine the quantization scheme from the JSON config
     if (quantization_config["quant_method"] == "compressed-tensors") {
-        return std::make_shared<infinicore::quantization::CompressedTensors>(quantization_config);
+        return std::make_shared<infinilm::quantization::CompressedTensors>(quantization_config);
     } else if (quantization_config["quant_method"] == "awq") {
-        return std::make_shared<infinicore::quantization::AWQ>(quantization_config);
+        return std::make_shared<infinilm::quantization::AWQ>(quantization_config);
     } else if (quantization_config["quant_method"] == "gptq") {
-        // return std::make_shared<infinicore::quantization::GPTQ_QY>(quantization_config);
-        return std::make_shared<infinicore::quantization::GPTQ>(quantization_config);
+        return std::make_shared<infinilm::quantization::GPTQ>(quantization_config);
     } else {
-        return std::make_shared<infinicore::quantization::NoneQuantization>(quantization_config);
+        return std::make_shared<infinilm::quantization::NoneQuantization>(quantization_config);
     }
     // Add other schemes as needed
 
-    return std::make_shared<infinicore::quantization::NoneQuantization>(quantization_config); // Default case if no matching scheme
+    return std::make_shared<infinilm::quantization::NoneQuantization>(quantization_config); // Default case if no matching scheme
 }
 } // namespace infinilm::config

--- a/csrc/config/quant_config.hpp
+++ b/csrc/config/quant_config.hpp
@@ -1,6 +1,6 @@
 #pragma once
 #include "../utils.hpp"
-#include "infinicore/quantization.hpp"
+#include "../layers/quantization/quantization.hpp"
 #include "nlohmann/json.hpp"
 #include <optional>
 #include <spdlog/spdlog.h>
@@ -14,13 +14,13 @@ public:
     QuantConfig() = default;
     QuantConfig(const nlohmann::json &json);
 
-    std::shared_ptr<infinicore::quantization::BaseQuantization> get_quantization_method() const;
+    std::shared_ptr<infinilm::quantization::BaseQuantization> get_quantization_method() const;
 
-    infinicore::quantization::QuantScheme get_quant_scheme() const {
+    infinilm::quantization::QuantScheme get_quant_scheme() const {
         if (quantization_method != nullptr) {
             return quantization_method->get_quant_scheme();
         } else {
-            return infinicore::quantization::QuantScheme::NONE;
+            return infinilm::quantization::QuantScheme::NONE;
         }
     }
 
@@ -29,22 +29,22 @@ public:
             this->kv_cache_dtype_ = std::make_optional(kv_cache_dtype);
             switch (kv_cache_dtype) {
             case infinicore::DataType::I8: {
-                this->kv_quant_scheme = infinicore::quantization::KVQuantAlgo::INT8;
+                this->kv_quant_scheme = infinilm::quantization::KVQuantAlgo::INT8;
                 break;
             }
             default: {
                 spdlog::warn("Unsupported kv_cache_dtype: '{}', fallback to NONE", infinicore::toString(kv_cache_dtype));
-                this->kv_quant_scheme = infinicore::quantization::KVQuantAlgo::NONE;
+                this->kv_quant_scheme = infinilm::quantization::KVQuantAlgo::NONE;
                 break;
             }
             }
         } catch (const std::exception &e) {
             spdlog::error("Failed to parse kv_cache_dtype '{}': {}", infinicore::toString(kv_cache_dtype), e.what());
-            this->kv_quant_scheme = infinicore::quantization::KVQuantAlgo::NONE;
+            this->kv_quant_scheme = infinilm::quantization::KVQuantAlgo::NONE;
         }
     }
 
-    infinicore::quantization::KVQuantAlgo get_kv_quant_scheme() const {
+    infinilm::quantization::KVQuantAlgo get_kv_quant_scheme() const {
         return kv_quant_scheme;
     }
 
@@ -57,9 +57,9 @@ public:
 
 private:
     nlohmann::json quantization_config;
-    std::shared_ptr<infinicore::quantization::BaseQuantization> quantization_method;
+    std::shared_ptr<infinilm::quantization::BaseQuantization> quantization_method;
 
-    infinicore::quantization::KVQuantAlgo kv_quant_scheme = infinicore::quantization::KVQuantAlgo::NONE;
+    infinilm::quantization::KVQuantAlgo kv_quant_scheme = infinilm::quantization::KVQuantAlgo::NONE;
     std::optional<infinicore::DataType> kv_cache_dtype_ = std::nullopt;
 };
 

--- a/csrc/engine/compiler/paged_compiler.cpp
+++ b/csrc/engine/compiler/paged_compiler.cpp
@@ -1,20 +1,7 @@
 #include "paged_compiler.hpp"
 #include "../../global_state/global_state.hpp"
+#include "../../utils.hpp"
 
-namespace {
-// Todo: replace with Tensor::zeros when it is available
-inline void set_zeros(infinicore::Tensor &tensor) {
-    std::vector<uint8_t> zeros(tensor->nbytes(), 0);
-    infinicore::context::memcpyH2D(tensor->data(), zeros.data(), tensor->nbytes(), false);
-}
-
-inline void set_minus_one(infinicore::Tensor &tensor) {
-    // For int32 tensors, 0xFF bytes correspond to -1 in two's complement.
-    std::vector<uint8_t> minus_one(tensor->nbytes(), 0xFF);
-    infinicore::context::memcpyH2D(tensor->data(), minus_one.data(), tensor->nbytes(), false);
-}
-
-} // namespace
 namespace infinilm::engine {
 PagedCompiler::PagedCompiler(const std::shared_ptr<InfinilmModel> &model, RankBarrier *barrier)
     : GraphCompiler(model, barrier) {

--- a/csrc/engine/infer_engine.cpp
+++ b/csrc/engine/infer_engine.cpp
@@ -7,49 +7,6 @@ namespace infinilm::engine {
 //------------------------------------------------------
 // Constructor
 //------------------------------------------------------
-/**
- * @deprecated This function is deprecated and will be REMOVED in the next major release (v0.2.0).
- *
- * ⚠️ DEVELOPMENT POLICY:
- *   - NO new development or feature additions permitted on this interface
- *   - Only critical bug fixes (security/stability) allowed until removal
- *   - All new code MUST migrate to the polymorphic overload below
- *
- * Replacement: Use the polymorphic overload of this same function name with updated signature
- * Reason: Legacy signature lacks support for dynamic quantization modes.
- * Removal target: v0.2.0 (Q2 2026)
- */
-InferEngine::InferEngine(
-    const InfinilmModel::Config &config,
-    const distributed::DistConfig &distributed_config,
-    infinicore::Device::Type device_type,
-    const cache::CacheConfig *cache_config,
-    bool enable_graph_compiling,
-    backends::AttentionBackend attention_backend) // Changed parameter
-    : communication_group_(distributed_config, device_type),
-      legacy_model_config_(config),
-      attention_backend_(attention_backend) {
-    if (cache_config != nullptr) {
-        cache_config_ = cache_config->unique_copy();
-    }
-    // Create one RankWorker per rank
-    int world_size = communication_group_.get_world_size();
-    barrier_ = std::make_unique<RankBarrier>((size_t)world_size);
-    workers_.reserve(world_size);
-    for (int r = 0; r < world_size; ++r) {
-        workers_.emplace_back(std::make_unique<RankWorker>(
-            legacy_model_config_,
-            communication_group_.get_rank_info(r),
-            cache_config_ != nullptr ? cache_config_.get() : nullptr,
-            barrier_.get(),
-            enable_graph_compiling,
-            attention_backend_));
-    }
-
-    // Compile the model on all workers
-    this->compile();
-}
-
 InferEngine::InferEngine(
     const std::string &config_str,
     const distributed::DistConfig &distributed_config,

--- a/csrc/engine/infer_engine.hpp
+++ b/csrc/engine/infer_engine.hpp
@@ -3,7 +3,6 @@
 #include "../config/model_config.hpp"
 #include "../global_state/global_state.hpp"
 #include "../models/infinilm_model.hpp"
-#include "../models/llama_legacy/llama_config.hpp"
 #include "distributed/distributed.hpp"
 #include "infinicore/tensor.hpp"
 #include "rank_barrier.hpp"
@@ -21,26 +20,6 @@ public:
     using Output = RankWorker::Output;
 
     // Updated constructor: accept CacheConfig instead of CacheType
-    /**
-     * @deprecated This function is deprecated and will be REMOVED in the next major release (v0.2.0).
-     *
-     * ⚠️ DEVELOPMENT POLICY:
-     *   - NO new development or feature additions permitted on this interface
-     *   - Only critical bug fixes (security/stability) allowed until removal
-     *   - All new code MUST migrate to the polymorphic overload below
-     *
-     * Replacement: Use the polymorphic overload of this same function name with updated signature
-     * Reason: Legacy signature lacks support for dynamic quantization modes.
-     * Removal target: v0.2.0 (Q2 2026)
-     */
-    InferEngine(
-        const InfinilmModel::Config &config,
-        const distributed::DistConfig &distributed_config = distributed::DistConfig(),
-        infinicore::Device::Type device_type = infinicore::context::getDevice().getType(),
-        const cache::CacheConfig *cache_config = nullptr,
-        bool enable_graph_compiling = false,
-        backends::AttentionBackend attention_backend = backends::AttentionBackend::Default);
-
     InferEngine(
         const std::string &config_str,
         const distributed::DistConfig &distributed_config = distributed::DistConfig(),
@@ -78,7 +57,6 @@ protected:
     std::unique_ptr<RankBarrier> barrier_;
     distributed::CommunicationGroup communication_group_;
     std::unique_ptr<cache::CacheConfig> cache_config_;
-    const InfinilmModel::Config &legacy_model_config_ = InfinilmModel::Config();
     std::shared_ptr<infinilm::config::ModelConfig> model_config_;
     backends::AttentionBackend attention_backend_ = backends::AttentionBackend::Default;
 };

--- a/csrc/engine/rank_worker.cpp
+++ b/csrc/engine/rank_worker.cpp
@@ -10,46 +10,6 @@
 
 namespace infinilm::engine {
 
-/**
- * @deprecated This function is deprecated and will be REMOVED in the next major release (v0.2.0).
- *
- * ⚠️ DEVELOPMENT POLICY:
- *   - NO new development or feature additions permitted on this interface
- *   - Only critical bug fixes (security/stability) allowed until removal
- *   - All new code MUST migrate to the polymorphic overload below
- *
- * Replacement: Use the polymorphic overload of this same function name with updated signature
- * Reason: Legacy signature lacks support for dynamic quantization modes.
- * Removal target: v0.2.0 (Q2 2026)
- */
-RankWorker::RankWorker(const InfinilmModel::Config &model_config,
-                       const distributed::RankInfo &rank_info,
-                       const cache::CacheConfig *cache_config,
-                       RankBarrier *barrier,
-                       bool enable_graph_compiling,
-                       backends::AttentionBackend attention_backend)
-    : legacy_model_config_(model_config),
-      rank_info_(rank_info),
-      attention_backend_(attention_backend),
-      enable_graph_compiling_(enable_graph_compiling),
-      job_cmd_(Command::INIT),
-      has_job_(false),
-      job_done_(false),
-      should_exit_(false),
-      init_done_(false),
-      rng_(std::random_device{}()),
-      barrier_(barrier) {
-    if (cache_config != nullptr) {
-        pending_cache_config_ = cache_config->unique_copy();
-    }
-    // start the thread
-    thread_ = std::thread(&RankWorker::thread_loop, this);
-
-    // Wait until the worker thread finishes initialization (model created)
-    std::unique_lock<std::mutex> lk(mutex_);
-    cv_.wait(lk, [&] { return init_done_; });
-}
-
 RankWorker::RankWorker(
     std::shared_ptr<infinilm::global_state::InfinilmConfig> infinilm_config,
     const distributed::RankInfo &rank_info,
@@ -269,15 +229,6 @@ void RankWorker::thread_loop() {
             infinilm::global_state::initialize_infinilm_config(infinilm_config_);
 
             // Create model using factory (may be expensive)
-            if (model_config_ == nullptr) {
-                // model_ = InfinilmModelFactory::createModel(
-                //     legacy_model_config_,
-                //     rank_info_,
-                //     pending_cache_config_ != nullptr ? pending_cache_config_.get() : nullptr,
-                //     attention_backend_);
-                throw std::runtime_error("RankWorker::thread_loop(): the way of creating models using LlamaConfig is no longer supported !!!");
-            }
-
             const std::string &model_type = model_config_->get<std::string>("model_type");
             const auto &model_map = models::get_causal_lm_model_map();
             auto it = model_map.find(model_type);

--- a/csrc/engine/rank_worker.hpp
+++ b/csrc/engine/rank_worker.hpp
@@ -70,13 +70,6 @@ public:
         infinicore::Tensor output_ids;
     };
 
-    RankWorker(const InfinilmModel::Config &model_config,
-               const distributed::RankInfo &rank_info,
-               const cache::CacheConfig *cache_config,
-               RankBarrier *barrier,
-               bool enable_graph_compiling,
-               backends::AttentionBackend attention_backend);
-
     RankWorker(std::shared_ptr<infinilm::global_state::InfinilmConfig> infinilm_config,
                const distributed::RankInfo &rank_info,
                const cache::CacheConfig *cache_config,
@@ -118,7 +111,6 @@ private:
 
 private:
     // Worker properties
-    const InfinilmModel::Config &legacy_model_config_ = InfinilmModel::Config();
     std::shared_ptr<infinilm::global_state::InfinilmConfig> infinilm_config_;
     std::shared_ptr<infinilm::config::ModelConfig> model_config_;
     engine::distributed::RankInfo rank_info_;

--- a/csrc/layers/attention/attention.cpp
+++ b/csrc/layers/attention/attention.cpp
@@ -26,52 +26,15 @@ Attention::Attention(std::shared_ptr<infinilm::config::ModelConfig> model_config
     num_attention_heads_ = total_num_heads / tp_size;
     num_key_value_heads_ = total_num_kv_heads < tp_size ? 1 : total_num_kv_heads / tp_size;
 
-    auto quant_scheme = model_config->get_quant_scheme();
     auto quantization_method = model_config->get_quantization_method();
-    switch (quant_scheme) {
-    case infinicore::quantization::QuantScheme::NONE: {
-        INFINILM_QKV_LINEAR_INIT(qkv_proj, "q_proj", "k_proj", "v_proj", hidden_size_, head_dim_, total_num_heads, total_num_kv_heads,
-                                 quantization_method, use_bias, dtype, device, rank_info);
-        INFINICORE_NN_MODULE_INIT(o_proj, total_num_heads * head_dim_, hidden_size_, quantization_method,
-                                  use_output_bias, dtype, device, tp_rank, tp_size, rank_info.comm);
-        break;
-    }
-    case infinicore::quantization::QuantScheme::COMPRESSED_TENSOR_W8A8I8: {
-        INFINILM_QKV_LINEAR_W8A8_INIT(qkv_proj, "q_proj", "k_proj", "v_proj", hidden_size_, head_dim_, total_num_heads, total_num_kv_heads,
-                                      quantization_method, use_bias, dtype, device, rank_info);
-        INFINICORE_NN_MODULE_INIT(o_proj, total_num_heads * head_dim_, hidden_size_, quantization_method,
-                                  use_output_bias, dtype, device, tp_rank, tp_size, rank_info.comm);
-        break;
-    }
-    case infinicore::quantization::QuantScheme::AWQ_W4A16: {
-        INFINILM_QKV_LINEAR_W4A16AWQ_INIT(qkv_proj, "q_proj", "k_proj", "v_proj", hidden_size_, head_dim_, total_num_heads, total_num_kv_heads,
-                                          quantization_method, use_bias, dtype, device, rank_info);
-        INFINICORE_NN_MODULE_INIT(o_proj, total_num_heads * head_dim_, hidden_size_, quantization_method,
-                                  use_output_bias, dtype, device, tp_rank, tp_size, rank_info.comm);
-        break;
-    }
-    case infinicore::quantization::QuantScheme::GPTQ_W4A16_QY: {
-        INFINILM_QKV_LINEAR_W4A16GPTQ_INIT(qkv_proj, "q_proj", "k_proj", "v_proj", hidden_size_, head_dim_, total_num_heads, total_num_kv_heads, quantization_method, use_bias,
-                                           dtype, device, rank_info);
-        INFINICORE_NN_MODULE_INIT(o_proj, total_num_heads * head_dim_, hidden_size_, quantization_method, use_output_bias,
-                                  dtype, device, tp_rank, tp_size, rank_info.comm);
-        break;
-    }
-    case infinicore::quantization::QuantScheme::GPTQ_W4A16: {
-
-        INFINILM_QKV_LINEAR_W4A16GPTQ_INIT(qkv_proj, "q_proj", "k_proj", "v_proj", hidden_size_, head_dim_, total_num_heads, total_num_kv_heads, quantization_method, use_bias,
-                                           dtype, device, rank_info);
-
-        INFINICORE_NN_MODULE_INIT(o_proj, total_num_heads * head_dim_, hidden_size_, quantization_method, use_output_bias,
-                                  dtype, device, tp_rank, tp_size, rank_info.comm);
-
-        break;
-    }
-    default: {
-        throw std::runtime_error("infinilm::layers::attention::Attention: unsupported quantization scheme");
-        break;
-    }
-    }
+    auto register_fn = [this](const std::string &n, infinicore::nn::Parameter p) { this->register_parameter(n, std::move(p)); };
+    qkv_proj_ = std::make_shared<layers::linear::QKVParallelLinear>(
+        hidden_size_, head_dim_, total_num_heads, total_num_kv_heads,
+        "q_proj", "k_proj", "v_proj", register_fn,
+        quantization_method, use_bias, dtype, device, rank_info);
+    o_proj_ = this->register_module<layers::linear::RowParallelLinear>(
+        "o_proj", total_num_heads * head_dim_, hidden_size_, quantization_method,
+        use_output_bias, dtype, device, tp_rank, tp_size, rank_info.comm);
 
     rotary_emb_ = infinilm::layers::rotary_embedding::get_rope(model_config, device);
 
@@ -79,21 +42,7 @@ Attention::Attention(std::shared_ptr<infinilm::config::ModelConfig> model_config
     attn_ = std::make_shared<AttentionLayer>(num_attention_heads_, head_dim_, scaling, num_key_value_heads_, layer_idx_,
                                              kv_cache_k_scale_, kv_cache_v_scale_, attention_backend_);
 
-    auto kv_quant_scheme = infinilm::global_state::get_infinilm_config().model_config->get_kv_quant_scheme();
-    switch (kv_quant_scheme) {
-    case (infinicore::quantization::KVQuantAlgo::NONE): {
-        break;
-    }
-    case (infinicore::quantization::KVQuantAlgo::INT8): {
-        INFINICORE_NN_PARAMETER_INIT(kv_cache_k_scale, ({1}, infinicore::DataType::F32, device, 0, 0, 1));
-        INFINICORE_NN_PARAMETER_INIT(kv_cache_v_scale, ({1}, infinicore::DataType::F32, device, 0, 0, 1));
-        break;
-    }
-    default: {
-        throw std::runtime_error("infinilm::layers::attention: unsupported kv_quant_scheme");
-        break;
-    }
-    }
+    init_kv_cache_quant_params(register_fn, device, kv_cache_k_scale_, kv_cache_v_scale_);
 }
 
 infinicore::Tensor Attention::forward(const infinicore::Tensor &positions,
@@ -186,6 +135,25 @@ infinicore::Tensor Attention::forward_paged_(const infinicore::Tensor &position_
     // 6. Project output
     auto output = o_proj_->forward(attn_output);
     return output;
+}
+
+void init_kv_cache_quant_params(std::function<void(const std::string &, infinicore::nn::Parameter)> register_fn,
+                                const infinicore::Device &device,
+                                infinicore::nn::Parameter &kv_cache_k_scale,
+                                infinicore::nn::Parameter &kv_cache_v_scale) {
+    auto kv_quant_scheme = infinilm::global_state::get_infinilm_config().model_config->get_kv_quant_scheme();
+    switch (kv_quant_scheme) {
+    case infinilm::quantization::KVQuantAlgo::NONE:
+        break;
+    case infinilm::quantization::KVQuantAlgo::INT8:
+        kv_cache_k_scale = infinicore::nn::Parameter({1}, infinicore::DataType::F32, device, 0, 0, 1);
+        register_fn("kv_cache_k_scale", kv_cache_k_scale);
+        kv_cache_v_scale = infinicore::nn::Parameter({1}, infinicore::DataType::F32, device, 0, 0, 1);
+        register_fn("kv_cache_v_scale", kv_cache_v_scale);
+        break;
+    default:
+        throw std::runtime_error("unsupported kv_quant_scheme");
+    }
 }
 
 } // namespace infinilm::layers::attention

--- a/csrc/layers/attention/attention.hpp
+++ b/csrc/layers/attention/attention.hpp
@@ -20,6 +20,10 @@ public:
     infinicore::Tensor forward(const infinicore::Tensor &positions,
                                const infinicore::Tensor &hidden_states) const;
 
+    void process_fused_weights_after_loading() {
+        qkv_proj_->process_weights_after_loading();
+    }
+
     size_t layer_idx() const { return layer_idx_; }
     size_t num_heads() const { return num_attention_heads_; }
     size_t num_kv_heads() const { return num_key_value_heads_; }
@@ -34,8 +38,8 @@ private:
                                       const infinicore::Tensor &hidden_states) const;
 
 protected:
-    INFINICORE_NN_MODULE(infinilm::layers::linear::QKVParallelLinear, qkv_proj);
-    INFINICORE_NN_MODULE(infinilm::layers::linear::RowParallelLinear, o_proj);
+    std::shared_ptr<infinilm::layers::linear::QKVParallelLinear> qkv_proj_;
+    std::shared_ptr<infinilm::layers::linear::RowParallelLinear> o_proj_;
     std::shared_ptr<infinicore::nn::RoPE> rotary_emb_;
 
     std::shared_ptr<AttentionLayer> attn_;
@@ -50,4 +54,8 @@ protected:
     INFINICORE_NN_PARAMETER(kv_cache_k_scale);
     INFINICORE_NN_PARAMETER(kv_cache_v_scale);
 };
+void init_kv_cache_quant_params(std::function<void(const std::string &, infinicore::nn::Parameter)> register_fn,
+                              const infinicore::Device &device,
+                              infinicore::nn::Parameter &kv_cache_k_scale,
+                              infinicore::nn::Parameter &kv_cache_v_scale);
 } // namespace infinilm::layers::attention

--- a/csrc/layers/attention/backends/static_attn.cpp
+++ b/csrc/layers/attention/backends/static_attn.cpp
@@ -30,7 +30,7 @@ infinicore::Tensor StaticAttentionImpl::forward(const AttentionLayer &layer,
 
     auto k_scale = layer.get_k_scale();
     auto v_scale = layer.get_v_scale();
-    if (infinicore::quantization::KVQuantAlgo::NONE != this->kv_quant_scheme_) {
+    if (infinilm::quantization::KVQuantAlgo::NONE != this->kv_quant_scheme_) {
         infinilm::KVQuantUtils::quantize(
             k_reshaped, v_reshaped,
             this->kv_quant_scheme_,
@@ -65,7 +65,7 @@ infinicore::Tensor StaticAttentionImpl::forward(const AttentionLayer &layer,
     } else {
         size_t total_seq_len = reinterpret_cast<int32_t *>(total_sequence_lengths.value()->to(infinicore::Device::cpu())->data())[0];
 
-        if (infinicore::quantization::KVQuantAlgo::NONE != this->kv_quant_scheme_) {
+        if (infinilm::quantization::KVQuantAlgo::NONE != this->kv_quant_scheme_) {
             infinilm::KVQuantUtils::dequantize(
                 k_total, v_total,
                 this->kv_quant_scheme_,

--- a/csrc/layers/attention/backends/static_attn.hpp
+++ b/csrc/layers/attention/backends/static_attn.hpp
@@ -41,6 +41,6 @@ private:
     size_t layer_idx_;
     size_t head_dim_; // Note: head_dim equals to head_size
 
-    infinicore::quantization::KVQuantAlgo kv_quant_scheme_;
+    infinilm::quantization::KVQuantAlgo kv_quant_scheme_;
 };
 } // namespace infinilm::layers::attention::backends

--- a/csrc/layers/linear/base_linear.cpp
+++ b/csrc/layers/linear/base_linear.cpp
@@ -1,0 +1,133 @@
+#include "base_linear.hpp"
+#include "infinicore/ops.hpp"
+#include <spdlog/spdlog.h>
+
+namespace infinilm::nn {
+
+BaseLinear::BaseLinear(size_t in_features, size_t out_features,
+                       std::shared_ptr<infinilm::quantization::BaseQuantization> quantization,
+                       bool bias,
+                       const infinicore::DataType &dtype, const infinicore::Device &device,
+                       int split_dim, int tp_rank, int tp_size,
+                       int tp_num_heads)
+    : in_features_(in_features),
+      out_features_(out_features),
+      has_bias_(bias),
+      dtype_(dtype),
+      split_dim_(split_dim),
+      quantization_(quantization) {
+
+    device_ = device;
+
+    auto layout = quantization_->get_param_layout(
+        in_features, out_features, split_dim, tp_rank, tp_size,
+        tp_num_heads, dtype, bias);
+
+    for (const auto &desc : layout) {
+        infinicore::nn::Parameter param(
+            desc.shape, desc.dtype, device,
+            desc.split_dim, desc.tp_rank, desc.tp_size,
+            desc.tp_num_heads >= 0 ? desc.tp_num_heads : 0);
+        this->register_parameter(desc.name, param);
+    }
+}
+
+infinicore::Tensor BaseLinear::compute_linear(infinicore::Tensor &input) const {
+    // Build params map from direct parameters only (not state_dict which uses a
+    // static local and is not thread-safe across RankWorker threads).
+    infinilm::quantization::ParamsMap params;
+    for (const auto &[name, param] : parameters_) {
+        params[name] = static_cast<const infinicore::Tensor &>(param);
+    }
+
+    return quantization_->forward(params, input, has_bias_, alpha_);
+}
+
+infinicore::Tensor BaseLinear::forward(infinicore::Tensor &input) const {
+    return compute_linear(input);
+}
+
+infinicore::Tensor BaseLinear::forward(infinicore::Tensor &input, infinicore::Tensor &residual) const {
+    auto output = compute_linear(input);
+    infinicore::op::add_(output, output, residual);
+    return output;
+}
+
+void BaseLinear::process_weights_after_loading() {
+    infinilm::quantization::ParamsMap params;
+    for (const auto &[name, param] : parameters_) {
+        params[name] = static_cast<const infinicore::Tensor &>(param);
+    }
+
+    auto new_quant = quantization_->process_weights_after_loading(params, device_);
+    if (!new_quant) return;
+
+    for (auto &[name, param] : parameters_) {
+        param = infinicore::nn::Parameter();
+    }
+
+    for (const auto &[name, tensor] : params) {
+        auto it = parameters_.find(name);
+        if (it == parameters_.end()) continue;
+        it->second = infinicore::nn::Parameter(tensor);
+    }
+
+    quantization_ = std::move(new_quant);
+}
+
+// Backward compatible accessors
+
+infinicore::Tensor BaseLinear::weight() const {
+    auto it = parameters_.find("weight");
+    if (it != parameters_.end()) return it->second;
+    it = parameters_.find("qweight");
+    if (it != parameters_.end()) return it->second;
+    return infinicore::Tensor();
+}
+
+infinicore::Tensor BaseLinear::bias() const {
+    auto it = parameters_.find("bias");
+    if (it != parameters_.end()) return it->second;
+    return infinicore::Tensor();
+}
+
+infinicore::Tensor BaseLinear::weight_scale() const {
+    auto it = parameters_.find("weight_scale");
+    if (it != parameters_.end()) return it->second;
+    it = parameters_.find("scales");
+    if (it != parameters_.end()) return it->second;
+    return infinicore::Tensor();
+}
+
+infinicore::Tensor BaseLinear::weight_zeros() const {
+    auto it = parameters_.find("weight_zeros");
+    if (it != parameters_.end()) return it->second;
+    it = parameters_.find("qzeros");
+    if (it != parameters_.end()) return it->second;
+    return infinicore::Tensor();
+}
+
+infinicore::Tensor BaseLinear::gidx() const {
+    auto it = parameters_.find("g_idx");
+    if (it != parameters_.end()) return it->second;
+    return infinicore::Tensor();
+}
+
+infinicore::Tensor BaseLinear::get_param(const std::string &name) const {
+    auto it = parameters_.find(name);
+    if (it != parameters_.end()) return it->second;
+    return infinicore::Tensor();
+}
+
+const infinicore::nn::Parameter &BaseLinear::get_parameter_ref(const std::string &name) const {
+    return parameters_.at(name);
+}
+
+std::vector<infinilm::quantization::SplitParam> BaseLinear::split_params(
+    const std::vector<infinilm::quantization::SplitInfo> &splits,
+    int tp_rank, int tp_size, int tp_num_heads) const {
+    return quantization_->split_params(
+        parameters_, splits, split_dim_, tp_rank, tp_size, tp_num_heads);
+}
+
+} // namespace infinilm::nn

--- a/csrc/layers/linear/base_linear.hpp
+++ b/csrc/layers/linear/base_linear.hpp
@@ -1,0 +1,70 @@
+#pragma once
+
+#include "infinicore/ops.hpp"
+#include "../quantization/quantization.hpp"
+#include "infinicore/nn/module.hpp"
+#include <infiniccl.h>
+#include <optional>
+
+namespace infinilm::nn {
+
+using namespace infinicore::nn;
+
+class BaseLinear : public infinicore::nn::Module {
+public:
+    BaseLinear(size_t in_features, size_t out_features,
+               std::shared_ptr<infinilm::quantization::BaseQuantization> quantization = std::make_shared<infinilm::quantization::NoneQuantization>(nullptr),
+               bool bias = true,
+               const infinicore::DataType &dtype = infinicore::DataType::F32,
+               const infinicore::Device &device = infinicore::Device(),
+               int split_dim = -1, int tp_rank = 0, int tp_size = 1,
+               int tp_num_heads = -1);
+
+    // Forward pass: output = input @ weight.T + bias
+    infinicore::Tensor forward(infinicore::Tensor &input) const;
+
+    // Forward pass with residual connection
+    infinicore::Tensor forward(infinicore::Tensor &input, infinicore::Tensor &residual) const;
+
+    // Module information
+    size_t in_features() const { return in_features_; }
+    size_t out_features() const { return out_features_; }
+    bool has_bias() const { return has_bias_; }
+    infinicore::DataType dtype() const { return dtype_; }
+    float alpha() const { return alpha_; }
+    void set_alpha(float alpha) { alpha_ = alpha; }
+
+    // Accessors for parameters (backward compatible)
+    infinicore::Tensor weight() const;
+    infinicore::Tensor bias() const;
+    infinicore::Tensor weight_scale() const;
+    infinicore::Tensor weight_zeros() const;
+    infinicore::Tensor gidx() const;
+
+    // Get parameter by name
+    infinicore::Tensor get_param(const std::string &name) const;
+
+    std::shared_ptr<infinilm::quantization::BaseQuantization> get_quantization() const { return quantization_; }
+    virtual void process_weights_after_loading();
+
+    // Split fused linear parameters into named sub-parameters
+    std::vector<infinilm::quantization::SplitParam> split_params(
+        const std::vector<infinilm::quantization::SplitInfo> &splits,
+        int tp_rank, int tp_size, int tp_num_heads) const;
+
+    // Allow subclasses to access the raw parameters map
+    const infinicore::nn::Parameter &get_parameter_ref(const std::string &name) const;
+
+protected:
+    infinicore::Tensor compute_linear(infinicore::Tensor &input) const;
+
+    size_t in_features_;
+    size_t out_features_;
+    bool has_bias_;
+    infinicore::DataType dtype_;
+    int split_dim_ = -1;
+    float alpha_ = 1.0f;
+    std::shared_ptr<infinilm::quantization::BaseQuantization> quantization_;
+};
+
+} // namespace infinilm::nn

--- a/csrc/layers/linear/fused_linear.cpp
+++ b/csrc/layers/linear/fused_linear.cpp
@@ -6,74 +6,11 @@ namespace infinilm::layers::linear {
 // ---------------------------------------------------------
 // QKV Parallel Linear
 // ---------------------------------------------------------
-/**
- * @deprecated This function is deprecated and will be REMOVED in the next major release (v0.2.0).
- *
- * ⚠️ DEVELOPMENT POLICY:
- *   - NO new development or feature additions permitted on this interface
- *   - Only critical bug fixes (security/stability) allowed until removal
- *   - All new code MUST migrate to the polymorphic overload below
- *
- * Replacement: Use the polymorphic overload of this same function name with updated signature
- * Reason: Legacy signature lacks support for dynamic quantization modes.
- * Removal target: v0.2.0 (Q2 2026)
- */
 QKVParallelLinear::QKVParallelLinear(size_t hidden_size,
                                      size_t head_dim,
                                      size_t num_q_head,
                                      size_t num_kv_head,
-                                     bool bias,
-                                     const infinicore::DataType &dtype,
-                                     const infinicore::Device &device,
-                                     engine::distributed::RankInfo rank_info)
-    : QKVParallelLinear(hidden_size,
-                        head_dim, head_dim, head_dim,
-                        num_q_head, num_kv_head, num_kv_head,
-                        bias, bias, bias,
-                        dtype, device, rank_info) {}
-
-QKVParallelLinear::QKVParallelLinear(size_t hidden_size,
-                                     size_t q_dim, size_t k_dim, size_t v_dim,
-                                     size_t num_q_head, size_t num_k_head, size_t num_v_head,
-                                     bool q_bias, bool k_bias, bool v_bias,
-                                     const infinicore::DataType &dtype,
-                                     const infinicore::Device &device,
-                                     engine::distributed::RankInfo rank_info)
-    : infinicore::nn::ColumnParallelLinear(
-          hidden_size,
-          num_q_head * q_dim + num_k_head * k_dim + num_v_head * v_dim,
-          (q_bias || k_bias || v_bias),
-          dtype,
-          device,
-          rank_info.tp_rank,
-          rank_info.tp_size),
-      q_dim_(q_dim),
-      k_dim_(k_dim),
-      v_dim_(v_dim),
-      num_q_head_(num_q_head),
-      num_k_head_(num_k_head),
-      num_v_head_(num_v_head),
-      q_bias_(q_bias),
-      k_bias_(k_bias),
-      v_bias_(v_bias) {
-    if (num_q_head % tp_size_ != 0 || num_k_head % tp_size_ != 0 || num_v_head % tp_size_ != 0) {
-        throw std::runtime_error("QKVParallelLinear: num_[q|k|v]_head must be divisible by tp_size");
-    }
-
-    if ((q_bias_ != k_bias_) || (k_bias_ != v_bias_)) {
-        throw std::runtime_error("q_bias, k_bias, v_bias must all match");
-    }
-
-    q_out_size_ = num_q_head_ * q_dim_ / tp_size_;
-    k_out_size_ = num_k_head_ * k_dim_ / tp_size_;
-    v_out_size_ = num_v_head_ * v_dim_ / tp_size_;
-}
-
-QKVParallelLinear::QKVParallelLinear(size_t hidden_size,
-                                     size_t head_dim,
-                                     size_t num_q_head,
-                                     size_t num_kv_head,
-                                     std::shared_ptr<infinicore::quantization::BaseQuantization> quantization,
+                                     std::shared_ptr<infinilm::quantization::BaseQuantization> quantization,
                                      bool bias,
                                      const infinicore::DataType &dtype,
                                      const infinicore::Device &device,
@@ -89,11 +26,11 @@ QKVParallelLinear::QKVParallelLinear(size_t hidden_size,
                                      size_t q_dim, size_t k_dim, size_t v_dim,
                                      size_t num_q_head, size_t num_k_head, size_t num_v_head,
                                      bool q_bias, bool k_bias, bool v_bias,
-                                     std::shared_ptr<infinicore::quantization::BaseQuantization> quantization,
+                                     std::shared_ptr<infinilm::quantization::BaseQuantization> quantization,
                                      const infinicore::DataType &dtype,
                                      const infinicore::Device &device,
                                      engine::distributed::RankInfo rank_info)
-    : infinicore::nn::ColumnParallelLinear(
+    : infinilm::nn::ColumnParallelLinear(
           hidden_size,
           calculate_out_feature_size(num_q_head, q_dim, num_k_head, k_dim, num_v_head, v_dim, rank_info),
           quantization,
@@ -133,194 +70,57 @@ QKVParallelLinear::forward_split(infinicore::Tensor &input) {
     return std::make_tuple(q_out, k_out, v_out);
 }
 
-infinicore::nn::Parameter QKVParallelLinear::get_q_weight() const {
-    return infinicore::nn::Parameter(
-        weight_->narrow({{0, 0, q_out_size_}}),
-        0, tp_rank_, tp_size_);
-}
-
-infinicore::nn::Parameter QKVParallelLinear::get_k_weight() const {
-    return infinicore::nn::Parameter(
-        weight_->narrow({{0, q_out_size_, k_out_size_}}),
-        0, tp_rank_, tp_size_, num_k_head_);
-}
-
-infinicore::nn::Parameter QKVParallelLinear::get_v_weight() const {
-    return infinicore::nn::Parameter(
-        weight_->narrow({{0, q_out_size_ + k_out_size_, v_out_size_}}),
-        0, tp_rank_, tp_size_, num_v_head_);
-}
-
-infinicore::nn::Parameter QKVParallelLinear::get_q_weight_scale() const {
-    return infinicore::nn::Parameter(
-        weight_scale_->narrow({{0, 0, q_out_size_}}), 0, tp_rank_, tp_size_);
-}
-
-infinicore::nn::Parameter QKVParallelLinear::get_k_weight_scale() const {
-    return infinicore::nn::Parameter(
-        weight_scale_->narrow({{0, q_out_size_, k_out_size_}}),
-        0, tp_rank_, tp_size_, num_k_head_);
-}
-
-infinicore::nn::Parameter QKVParallelLinear::get_v_weight_scale() const {
-    return infinicore::nn::Parameter(
-        weight_scale_->narrow({{0, q_out_size_ + k_out_size_, v_out_size_}}),
-        0, tp_rank_, tp_size_, num_k_head_);
-}
-
-infinicore::nn::Parameter QKVParallelLinear::get_q_weight_awq(int scaling_factor) const {
-    return infinicore::nn::Parameter(
-        weight_->narrow({{1, 0, q_out_size_ / scaling_factor}}),
-        1, tp_rank_, tp_size_);
-}
-
-infinicore::nn::Parameter QKVParallelLinear::get_k_weight_awq(int scaling_factor) const {
-    return infinicore::nn::Parameter(
-        weight_->narrow({{1, q_out_size_ / scaling_factor, k_out_size_ / scaling_factor}}),
-        1, tp_rank_, tp_size_, num_k_head_);
-}
-
-infinicore::nn::Parameter QKVParallelLinear::get_v_weight_awq(int scaling_factor) const {
-    return infinicore::nn::Parameter(
-        weight_->narrow({{1, (q_out_size_ + k_out_size_) / scaling_factor, v_out_size_ / scaling_factor}}),
-        1, tp_rank_, tp_size_, num_k_head_);
-}
-
-infinicore::nn::Parameter QKVParallelLinear::get_q_weight_scale_awq(int scaling_factor) const {
-    return infinicore::nn::Parameter(
-        weight_scale_->narrow({{1, 0, q_out_size_ / scaling_factor}}), 1, tp_rank_, tp_size_);
-}
-
-infinicore::nn::Parameter QKVParallelLinear::get_k_weight_scale_awq(int scaling_factor) const {
-    return infinicore::nn::Parameter(
-        weight_scale_->narrow({{1, q_out_size_ / scaling_factor, k_out_size_ / scaling_factor}}),
-        1, tp_rank_, tp_size_, num_k_head_);
-}
-
-infinicore::nn::Parameter QKVParallelLinear::get_v_weight_scale_awq(int scaling_factor) const {
-    return infinicore::nn::Parameter(
-        weight_scale_->narrow({{1, (q_out_size_ + k_out_size_) / scaling_factor, v_out_size_ / scaling_factor}}),
-        1, tp_rank_, tp_size_, num_k_head_);
-}
-
-infinicore::nn::Parameter QKVParallelLinear::get_q_weight_zeros_awq(int scaling_factor) const {
-    return infinicore::nn::Parameter(
-        weight_zeros_->narrow({{1, 0, q_out_size_ / scaling_factor}}), 1, tp_rank_, tp_size_);
-}
-
-infinicore::nn::Parameter QKVParallelLinear::get_k_weight_zeros_awq(int scaling_factor) const {
-    return infinicore::nn::Parameter(
-        weight_zeros_->narrow({{1, q_out_size_ / scaling_factor, k_out_size_ / scaling_factor}}),
-        1, tp_rank_, tp_size_, num_k_head_);
-}
-
-infinicore::nn::Parameter QKVParallelLinear::get_v_weight_zeros_awq(int scaling_factor) const {
-    return infinicore::nn::Parameter(
-        weight_zeros_->narrow({{1, (q_out_size_ + k_out_size_) / scaling_factor, v_out_size_ / scaling_factor}}),
-        1, tp_rank_, tp_size_, num_k_head_);
-}
-
-infinicore::nn::Parameter QKVParallelLinear::get_q_weight_zeros() const {
-    return infinicore::nn::Parameter(
-        weight_zeros_->narrow({{0, 0, q_out_size_}}), 0, tp_rank_, tp_size_);
-}
-
-infinicore::nn::Parameter QKVParallelLinear::get_k_weight_zeros() const {
-    return infinicore::nn::Parameter(
-        weight_zeros_->narrow({{0, q_out_size_, k_out_size_}}),
-        0, tp_rank_, tp_size_, num_k_head_);
-}
-
-infinicore::nn::Parameter QKVParallelLinear::get_v_weight_zeros() const {
-    return infinicore::nn::Parameter(
-        weight_zeros_->narrow({{0, q_out_size_ + k_out_size_, v_out_size_}}),
-        0, tp_rank_, tp_size_, num_k_head_);
-}
-
-infinicore::nn::Parameter QKVParallelLinear::get_q_bias() const {
-    if (!q_bias_) {
-        return infinicore::nn::Parameter();
-    }
-    return infinicore::nn::Parameter(
-        bias_->narrow({{0, 0, q_out_size_}}),
-        0, tp_rank_, tp_size_);
-}
-
-infinicore::nn::Parameter QKVParallelLinear::get_k_bias() const {
-    if (!k_bias_) {
-        return infinicore::nn::Parameter();
-    }
-    return infinicore::nn::Parameter(
-        bias_->narrow({{0, q_out_size_, k_out_size_}}),
-        0, tp_rank_, tp_size_);
-}
-
-infinicore::nn::Parameter QKVParallelLinear::get_v_bias() const {
-    if (!v_bias_) {
-        return infinicore::nn::Parameter();
-    }
-    return infinicore::nn::Parameter(
-        bias_->narrow({{0, q_out_size_ + k_out_size_, v_out_size_}}),
-        0, tp_rank_, tp_size_);
-}
-
-infinicore::nn::Parameter QKVParallelLinear::get_q_g_idx_gptq() const {
-    return infinicore::nn::Parameter(gidx_->narrow({{0, 0, in_features_ / tp_size_}}), 0, tp_rank_, tp_size_);
-}
-
-infinicore::nn::Parameter QKVParallelLinear::get_k_g_idx_gptq() const {
-    return infinicore::nn::Parameter(gidx_->narrow({{0, 0, in_features_ / tp_size_}}), 0, tp_rank_, tp_size_, num_k_head_);
-}
-
-infinicore::nn::Parameter QKVParallelLinear::get_v_g_idx_gptq() const {
-    return infinicore::nn::Parameter(gidx_->narrow({{0, 0, in_features_ / tp_size_}}), 0, tp_rank_, tp_size_, num_k_head_);
-}
-
 bool QKVParallelLinear::has_q_bias() const { return q_bias_; }
 bool QKVParallelLinear::has_k_bias() const { return k_bias_; }
 bool QKVParallelLinear::has_v_bias() const { return v_bias_; }
 
-// ---------------------------------------------------------
-// Gate-Up Parallel Linear
-// ---------------------------------------------------------
-/**
- * @deprecated This function is deprecated and will be REMOVED in the next major release (v0.2.0).
- *
- * ⚠️ DEVELOPMENT POLICY:
- *   - NO new development or feature additions permitted on this interface
- *   - Only critical bug fixes (security/stability) allowed until removal
- *   - All new code MUST migrate to the polymorphic overload below
- *
- * Replacement: Use the polymorphic overload of this same function name with updated signature
- * Reason: Legacy signature lacks support for dynamic quantization modes.
- * Removal target: v0.2.0 (Q2 2026)
- */
-GateUpParallelLinear::GateUpParallelLinear(size_t hidden_size, size_t intermediate_size, bool bias,
-                                           const infinicore::DataType &dtype, const infinicore::Device &device,
-                                           engine::distributed::RankInfo rank_info)
-    : GateUpParallelLinear(hidden_size, intermediate_size, bias, bias, dtype, device, rank_info) {
-}
-
-GateUpParallelLinear::GateUpParallelLinear(size_t hidden_size, size_t intermediate_size, bool gate_bias, bool up_bias,
-                                           const infinicore::DataType &dtype, const infinicore::Device &device,
-                                           engine::distributed::RankInfo rank_info)
-    : infinicore::nn::ColumnParallelLinear(hidden_size, intermediate_size * 2, gate_bias || up_bias, dtype, device, rank_info.tp_rank, rank_info.tp_size), gate_bias_(gate_bias), up_bias_(up_bias) {
-    if (gate_bias_ != up_bias_) {
-        throw std::runtime_error("Not supported yet: gate_bias and up_bias should be given at the same time");
+QKVParallelLinear::QKVParallelLinear(size_t hidden_size,
+                                     size_t head_dim,
+                                     size_t num_q_head, size_t num_kv_head,
+                                     const std::string &q_name, const std::string &k_name, const std::string &v_name,
+                                     RegisterParamFn register_fn,
+                                     std::shared_ptr<infinilm::quantization::BaseQuantization> quantization,
+                                     bool bias,
+                                     const infinicore::DataType &dtype,
+                                     const infinicore::Device &device,
+                                     engine::distributed::RankInfo rank_info)
+    : QKVParallelLinear(hidden_size, head_dim, num_q_head, num_kv_head, quantization, bias, dtype, device, rank_info) {
+    register_fn_ = register_fn;
+    split_infos_ = {
+        {q_name, 0, q_out_size_, 0},
+        {k_name, q_out_size_, k_out_size_, num_k_head_},
+        {v_name, q_out_size_ + k_out_size_, v_out_size_, num_v_head_},
+    };
+    auto params = this->split_params(split_infos_, tp_rank_, tp_size_, num_k_head_);
+    for (auto &sp : params) {
+        register_fn_(sp.full_name, std::move(sp.param));
     }
 }
 
-GateUpParallelLinear::GateUpParallelLinear(size_t hidden_size, size_t intermediate_size, std::shared_ptr<infinicore::quantization::BaseQuantization> quantization, bool bias,
+void QKVParallelLinear::process_weights_after_loading() {
+    BaseLinear::process_weights_after_loading();
+    if (register_fn_ && !split_infos_.empty()) {
+        auto params = this->split_params(split_infos_, tp_rank_, tp_size_, num_k_head_);
+        for (auto &sp : params) {
+            register_fn_(sp.full_name, std::move(sp.param));
+        }
+    }
+}
+
+// ---------------------------------------------------------
+// Gate-Up Parallel Linear
+// ---------------------------------------------------------
+GateUpParallelLinear::GateUpParallelLinear(size_t hidden_size, size_t intermediate_size, std::shared_ptr<infinilm::quantization::BaseQuantization> quantization, bool bias,
                                            const infinicore::DataType &dtype, const infinicore::Device &device,
                                            engine::distributed::RankInfo rank_info)
     : GateUpParallelLinear(hidden_size, intermediate_size, bias, bias, quantization, dtype, device, rank_info) {
 }
 
 GateUpParallelLinear::GateUpParallelLinear(size_t hidden_size, size_t intermediate_size, bool gate_bias, bool up_bias,
-                                           std::shared_ptr<infinicore::quantization::BaseQuantization> quantization,
+                                           std::shared_ptr<infinilm::quantization::BaseQuantization> quantization,
                                            const infinicore::DataType &dtype, const infinicore::Device &device,
                                            engine::distributed::RankInfo rank_info)
-    : infinicore::nn::ColumnParallelLinear(hidden_size, intermediate_size * 2, quantization, gate_bias || up_bias, dtype, device, rank_info.tp_rank, rank_info.tp_size), gate_bias_(gate_bias), up_bias_(up_bias) {
+    : infinilm::nn::ColumnParallelLinear(hidden_size, intermediate_size * 2, quantization, gate_bias || up_bias, dtype, device, rank_info.tp_rank, rank_info.tp_size), gate_bias_(gate_bias), up_bias_(up_bias) {
     if (gate_bias_ != up_bias_) {
         throw std::runtime_error("Not supported yet: gate_bias and up_bias should be given at the same time");
     }
@@ -334,85 +134,41 @@ std::tuple<infinicore::Tensor, infinicore::Tensor> GateUpParallelLinear::forward
     return std::make_tuple(gate_output, up_output);
 }
 
-infinicore::nn::Parameter GateUpParallelLinear::get_gate_weight() const {
-    return infinicore::nn::Parameter(weight_->narrow({{0, 0, weight_->size(0) / 2}}), 0, tp_rank_, tp_size_);
-}
+bool GateUpParallelLinear::has_gate_bias() const { return gate_bias_; }
+bool GateUpParallelLinear::has_up_bias() const { return up_bias_; }
 
-infinicore::nn::Parameter GateUpParallelLinear::get_gate_bias() const {
-    if (!gate_bias_) {
-        return infinicore::nn::Parameter();
-    } else {
-        return infinicore::nn::Parameter(bias_->narrow({{0, 0, bias_->size(0) / 2}}), 0, tp_rank_, tp_size_);
+GateUpParallelLinear::GateUpParallelLinear(size_t hidden_size, size_t intermediate_size,
+                                           const std::string &gate_name, const std::string &up_name,
+                                           RegisterParamFn register_fn,
+                                           std::shared_ptr<infinilm::quantization::BaseQuantization> quantization,
+                                           bool bias,
+                                           const infinicore::DataType &dtype, const infinicore::Device &device,
+                                           engine::distributed::RankInfo rank_info)
+    : GateUpParallelLinear(hidden_size, intermediate_size, quantization, bias, dtype, device, rank_info) {
+    const std::string &key_name = parameters_.count("qweight") ? "qweight" : "weight";
+    const auto &key_param = get_parameter_ref(key_name);
+    int fused_dim = this->get_quantization()->get_fused_split_dim();
+    size_t logical_output = this->get_quantization()->get_logical_dim_size(key_param->size(fused_dim));
+    size_t half_size = logical_output / 2;
+    register_fn_ = register_fn;
+    split_infos_ = {
+        {gate_name, 0, half_size},
+        {up_name, half_size, half_size},
+    };
+    auto params = this->split_params(split_infos_, tp_rank_, tp_size_, -1);
+    for (auto &sp : params) {
+        register_fn_(sp.full_name, std::move(sp.param));
     }
 }
 
-infinicore::nn::Parameter GateUpParallelLinear::get_up_weight() const {
-    return infinicore::nn::Parameter(weight_->narrow({{0, weight_->size(0) / 2, weight_->size(0) / 2}}), 0, tp_rank_, tp_size_);
-}
-
-infinicore::nn::Parameter GateUpParallelLinear::get_up_bias() const {
-    if (!up_bias_) {
-        return infinicore::nn::Parameter();
-    } else {
-        return infinicore::nn::Parameter(bias_->narrow({{0, bias_->size(0) / 2, bias_->size(0) / 2}}),
-                                         0, tp_rank_, tp_size_);
+void GateUpParallelLinear::process_weights_after_loading() {
+    BaseLinear::process_weights_after_loading();
+    if (register_fn_ && !split_infos_.empty()) {
+        auto params = this->split_params(split_infos_, tp_rank_, tp_size_, -1);
+        for (auto &sp : params) {
+            register_fn_(sp.full_name, std::move(sp.param));
+        }
     }
-}
-
-infinicore::nn::Parameter GateUpParallelLinear::get_gate_weight_scale() const {
-    return infinicore::nn::Parameter(weight_scale_->narrow({{0, 0, weight_scale_->size(0) / 2}}), 0, tp_rank_, tp_size_);
-}
-
-infinicore::nn::Parameter GateUpParallelLinear::get_up_weight_scale() const {
-    return infinicore::nn::Parameter(weight_scale_->narrow({{0, weight_scale_->size(0) / 2, weight_scale_->size(0) / 2}}), 0, tp_rank_, tp_size_);
-}
-
-infinicore::nn::Parameter GateUpParallelLinear::get_gate_weight_zeros() const {
-    return infinicore::nn::Parameter(weight_zeros_->narrow({{0, 0, weight_zeros_->size(0) / 2}}), 0, tp_rank_, tp_size_);
-}
-
-infinicore::nn::Parameter GateUpParallelLinear::get_up_weight_zeros() const {
-    return infinicore::nn::Parameter(weight_zeros_->narrow({{0, weight_zeros_->size(0) / 2, weight_zeros_->size(0) / 2}}), 0, tp_rank_, tp_size_);
-}
-
-bool GateUpParallelLinear::has_gate_bias() const {
-    return gate_bias_;
-}
-
-bool GateUpParallelLinear::has_up_bias() const {
-    return up_bias_;
-}
-
-infinicore::nn::Parameter GateUpParallelLinear::get_gate_weight_awq() const {
-    return infinicore::nn::Parameter(weight_->narrow({{1, 0, weight_->size(1) / 2}}), 1, tp_rank_, tp_size_);
-}
-
-infinicore::nn::Parameter GateUpParallelLinear::get_up_weight_awq() const {
-    return infinicore::nn::Parameter(weight_->narrow({{1, weight_->size(1) / 2, weight_->size(1) / 2}}), 1, tp_rank_, tp_size_);
-}
-
-infinicore::nn::Parameter GateUpParallelLinear::get_gate_weight_scale_awq() const {
-    return infinicore::nn::Parameter(weight_scale_->narrow({{1, 0, weight_scale_->size(1) / 2}}), 1, tp_rank_, tp_size_);
-}
-
-infinicore::nn::Parameter GateUpParallelLinear::get_up_weight_scale_awq() const {
-    return infinicore::nn::Parameter(weight_scale_->narrow({{1, weight_scale_->size(1) / 2, weight_scale_->size(1) / 2}}), 1, tp_rank_, tp_size_);
-}
-
-infinicore::nn::Parameter GateUpParallelLinear::get_gate_weight_zeros_awq() const {
-    return infinicore::nn::Parameter(weight_zeros_->narrow({{1, 0, weight_zeros_->size(1) / 2}}), 1, tp_rank_, tp_size_);
-}
-
-infinicore::nn::Parameter GateUpParallelLinear::get_up_weight_zeros_awq() const {
-    return infinicore::nn::Parameter(weight_zeros_->narrow({{1, weight_zeros_->size(1) / 2, weight_zeros_->size(1) / 2}}), 1, tp_rank_, tp_size_);
-}
-
-infinicore::nn::Parameter GateUpParallelLinear::get_gate_g_idx_gptq() const {
-    return infinicore::nn::Parameter(gidx_->narrow({{0, 0, gidx_->size(0)}}), 0, tp_rank_, tp_size_);
-}
-
-infinicore::nn::Parameter GateUpParallelLinear::get_up_g_idx_gptq() const {
-    return infinicore::nn::Parameter(gidx_->narrow({{0, 0, gidx_->size(0)}}), 0, tp_rank_, tp_size_);
 }
 
 } // namespace infinilm::layers::linear

--- a/csrc/layers/linear/fused_linear.hpp
+++ b/csrc/layers/linear/fused_linear.hpp
@@ -1,85 +1,47 @@
 #pragma once
 #include "../../engine/distributed/communication_group.hpp"
-#include "infinicore/nn/linear.hpp"
-#include "infinicore/quantization.hpp"
-#include <iostream>
+#include "linear.hpp"
+#include "../quantization/quantization.hpp"
+#include <functional>
 
 namespace infinilm::layers::linear {
-class QKVParallelLinear : public infinicore::nn::ColumnParallelLinear {
+using RegisterParamFn = std::function<void(const std::string &, infinicore::nn::Parameter)>;
+
+class QKVParallelLinear : public infinilm::nn::ColumnParallelLinear {
 public:
     explicit QKVParallelLinear(size_t hidden_size,
                                size_t q_dim, size_t k_dim, size_t v_dim,
                                size_t num_q_head, size_t num_k_head, size_t num_v_head,
                                bool q_bias, bool k_bias, bool v_bias,
+                               std::shared_ptr<infinilm::quantization::BaseQuantization> quantization,
                                const infinicore::DataType &dtype = infinicore::DataType::F32,
                                const infinicore::Device &device = infinicore::Device(),
                                engine::distributed::RankInfo rank_info = engine::distributed::RankInfo());
 
-    // A more common case where all heads have the same dimension
     explicit QKVParallelLinear(size_t hidden_size,
                                size_t head_dim,
                                size_t num_q_head, size_t num_kv_head,
+                               std::shared_ptr<infinilm::quantization::BaseQuantization> quantization,
                                bool bias = false,
                                const infinicore::DataType &dtype = infinicore::DataType::F32,
                                const infinicore::Device &device = infinicore::Device(),
                                engine::distributed::RankInfo rank_info = engine::distributed::RankInfo());
 
-    explicit QKVParallelLinear(size_t hidden_size,
-                               size_t q_dim, size_t k_dim, size_t v_dim,
-                               size_t num_q_head, size_t num_k_head, size_t num_v_head,
-                               bool q_bias, bool k_bias, bool v_bias,
-                               std::shared_ptr<infinicore::quantization::BaseQuantization> quantization,
-                               const infinicore::DataType &dtype = infinicore::DataType::F32,
-                               const infinicore::Device &device = infinicore::Device(),
-                               engine::distributed::RankInfo rank_info = engine::distributed::RankInfo());
+    QKVParallelLinear(size_t hidden_size,
+                      size_t head_dim,
+                      size_t num_q_head, size_t num_kv_head,
+                      const std::string &q_name, const std::string &k_name, const std::string &v_name,
+                      RegisterParamFn register_fn,
+                      std::shared_ptr<infinilm::quantization::BaseQuantization> quantization,
+                      bool bias = false,
+                      const infinicore::DataType &dtype = infinicore::DataType::F32,
+                      const infinicore::Device &device = infinicore::Device(),
+                      engine::distributed::RankInfo rank_info = engine::distributed::RankInfo());
 
-    // A more common case where all heads have the same dimension
-    explicit QKVParallelLinear(size_t hidden_size,
-                               size_t head_dim,
-                               size_t num_q_head, size_t num_kv_head,
-                               std::shared_ptr<infinicore::quantization::BaseQuantization> quantization,
-                               bool bias = false,
-                               const infinicore::DataType &dtype = infinicore::DataType::F32,
-                               const infinicore::Device &device = infinicore::Device(),
-                               engine::distributed::RankInfo rank_info = engine::distributed::RankInfo());
+    void process_weights_after_loading() override;
 
     std::tuple<infinicore::Tensor, infinicore::Tensor, infinicore::Tensor>
     forward_split(infinicore::Tensor &input);
-
-    infinicore::nn::Parameter get_q_weight() const;
-    infinicore::nn::Parameter get_k_weight() const;
-    infinicore::nn::Parameter get_v_weight() const;
-
-    infinicore::nn::Parameter get_q_weight_scale() const;
-    infinicore::nn::Parameter get_k_weight_scale() const;
-    infinicore::nn::Parameter get_v_weight_scale() const;
-
-    infinicore::nn::Parameter get_q_weight_zeros() const;
-    infinicore::nn::Parameter get_k_weight_zeros() const;
-    infinicore::nn::Parameter get_v_weight_zeros() const;
-
-    // For computing the packing factor in awq quantization:
-    // Returns the number of low-bit elements packed into a single high-bit container element.
-    // For example: int4 → int32 yields a packing factor of 8 (32 bits / 4 bits = 8 int4 values per int32).
-    infinicore::nn::Parameter get_q_weight_awq(int scaling_factor) const;
-    infinicore::nn::Parameter get_k_weight_awq(int scaling_factor) const;
-    infinicore::nn::Parameter get_v_weight_awq(int scaling_factor) const;
-
-    infinicore::nn::Parameter get_q_weight_scale_awq(int scaling_factor) const;
-    infinicore::nn::Parameter get_k_weight_scale_awq(int scaling_factor) const;
-    infinicore::nn::Parameter get_v_weight_scale_awq(int scaling_factor) const;
-
-    infinicore::nn::Parameter get_q_weight_zeros_awq(int scaling_factor) const;
-    infinicore::nn::Parameter get_k_weight_zeros_awq(int scaling_factor) const;
-    infinicore::nn::Parameter get_v_weight_zeros_awq(int scaling_factor) const;
-
-    infinicore::nn::Parameter get_q_bias() const;
-    infinicore::nn::Parameter get_k_bias() const;
-    infinicore::nn::Parameter get_v_bias() const;
-
-    infinicore::nn::Parameter get_q_g_idx_gptq() const;
-    infinicore::nn::Parameter get_k_g_idx_gptq() const;
-    infinicore::nn::Parameter get_v_g_idx_gptq() const;
 
     bool has_q_bias() const;
     bool has_k_bias() const;
@@ -111,206 +73,49 @@ private:
     bool q_bias_;
     bool k_bias_;
     bool v_bias_;
-    size_t q_out_size_; // num_q_head * q_dim / tp_size
-    size_t k_out_size_; // num_k_head * k_dim / tp_size
-    size_t v_out_size_; // num_v_head * v_dim / tp_size
+    size_t q_out_size_;
+    size_t k_out_size_;
+    size_t v_out_size_;
 
     size_t num_kv_head_replicas_ = 1;
+    RegisterParamFn register_fn_;
+    std::vector<infinilm::quantization::SplitInfo> split_infos_;
 };
 
-class GateUpParallelLinear : public infinicore::nn::ColumnParallelLinear {
+class GateUpParallelLinear : public infinilm::nn::ColumnParallelLinear {
 public:
-    /**
-     * @deprecated This function is deprecated and will be REMOVED in the next major release (v0.2.0).
-     *
-     * ⚠️ DEVELOPMENT POLICY:
-     *   - NO new development or feature additions permitted on this interface
-     *   - Only critical bug fixes (security/stability) allowed until removal
-     *   - All new code MUST migrate to the polymorphic overload below
-     *
-     * Replacement: Use the polymorphic overload of this same function name with updated signature
-     * Reason: Legacy signature lacks support for dynamic quantization modes.
-     * Removal target: v0.2.0 (Q2 2026)
-     */
-    GateUpParallelLinear(size_t hidden_size, size_t intermediate_size, bool bias = false,
-                         const infinicore::DataType &dtype = infinicore::DataType::F32, const infinicore::Device &device = infinicore::Device(),
-                         engine::distributed::RankInfo rank_info = engine::distributed::RankInfo());
-
-    GateUpParallelLinear(size_t hidden_size, size_t intermediate_size, bool gate_bias, bool up_bias,
-                         const infinicore::DataType &dtype = infinicore::DataType::F32, const infinicore::Device &device = infinicore::Device(),
-                         engine::distributed::RankInfo rank_info = engine::distributed::RankInfo());
-
-    GateUpParallelLinear(size_t hidden_size, size_t intermediate_size, std::shared_ptr<infinicore::quantization::BaseQuantization> quantization,
+    GateUpParallelLinear(size_t hidden_size, size_t intermediate_size, std::shared_ptr<infinilm::quantization::BaseQuantization> quantization,
                          bool bias = false,
                          const infinicore::DataType &dtype = infinicore::DataType::F32,
                          const infinicore::Device &device = infinicore::Device(),
                          engine::distributed::RankInfo rank_info = engine::distributed::RankInfo());
 
     GateUpParallelLinear(size_t hidden_size, size_t intermediate_size, bool gate_bias, bool up_bias,
-                         std::shared_ptr<infinicore::quantization::BaseQuantization> quantization,
+                         std::shared_ptr<infinilm::quantization::BaseQuantization> quantization,
                          const infinicore::DataType &dtype = infinicore::DataType::F32, const infinicore::Device &device = infinicore::Device(),
                          engine::distributed::RankInfo rank_info = engine::distributed::RankInfo());
 
+    GateUpParallelLinear(size_t hidden_size, size_t intermediate_size,
+                         const std::string &gate_name, const std::string &up_name,
+                         RegisterParamFn register_fn,
+                         std::shared_ptr<infinilm::quantization::BaseQuantization> quantization,
+                         bool bias = false,
+                         const infinicore::DataType &dtype = infinicore::DataType::F32,
+                         const infinicore::Device &device = infinicore::Device(),
+                         engine::distributed::RankInfo rank_info = engine::distributed::RankInfo());
+
+    void process_weights_after_loading() override;
+
     std::tuple<infinicore::Tensor, infinicore::Tensor> forward_split(infinicore::Tensor &input);
 
-    infinicore::nn::Parameter get_gate_weight() const;
-
-    infinicore::nn::Parameter get_gate_weight_scale() const;
-
-    infinicore::nn::Parameter get_gate_weight_zeros() const;
-
-    infinicore::nn::Parameter get_gate_bias() const;
-
-    infinicore::nn::Parameter get_up_weight() const;
-
-    infinicore::nn::Parameter get_up_weight_scale() const;
-
-    infinicore::nn::Parameter get_up_weight_zeros() const;
-
-    infinicore::nn::Parameter get_up_bias() const;
-
-    infinicore::nn::Parameter get_gate_weight_awq() const;
-
-    infinicore::nn::Parameter get_up_weight_awq() const;
-
-    infinicore::nn::Parameter get_up_weight_scale_awq() const;
-
-    infinicore::nn::Parameter get_up_weight_zeros_awq() const;
-
-    infinicore::nn::Parameter get_gate_weight_scale_awq() const;
-
-    infinicore::nn::Parameter get_gate_weight_zeros_awq() const;
-
-    infinicore::nn::Parameter get_gate_g_idx_gptq() const;
-
-    infinicore::nn::Parameter get_up_g_idx_gptq() const;
-
     bool has_gate_bias() const;
-
     bool has_up_bias() const;
 
 private:
     bool gate_bias_;
     bool up_bias_;
+    RegisterParamFn register_fn_;
+    std::vector<infinilm::quantization::SplitInfo> split_infos_;
 };
 
-#define INFINILM_QKV_LINEAR_INIT(name, q_name, k_name, v_name, ...)                     \
-    name##_ = std::make_shared<layers::linear::QKVParallelLinear>(__VA_ARGS__);         \
-    this->register_parameter(std::string(q_name) + ".weight", name##_->get_q_weight()); \
-    this->register_parameter(std::string(k_name) + ".weight", name##_->get_k_weight()); \
-    this->register_parameter(std::string(v_name) + ".weight", name##_->get_v_weight()); \
-    if (name##_->has_q_bias())                                                          \
-        this->register_parameter(std::string(q_name) + ".bias", name##_->get_q_bias()); \
-    if (name##_->has_k_bias())                                                          \
-        this->register_parameter(std::string(k_name) + ".bias", name##_->get_k_bias()); \
-    if (name##_->has_v_bias())                                                          \
-        this->register_parameter(std::string(v_name) + ".bias", name##_->get_v_bias());
-
-#define INFINILM_GATE_UP_LINEAR_INIT(name, gate_name, up_name, ...)                           \
-    name##_ = std::make_shared<layers::linear::GateUpParallelLinear>(__VA_ARGS__);            \
-    this->register_parameter(std::string(gate_name) + ".weight", name##_->get_gate_weight()); \
-    this->register_parameter(std::string(up_name) + ".weight", name##_->get_up_weight());     \
-    if (name##_->has_gate_bias())                                                             \
-        this->register_parameter(std::string(gate_name) + ".bias", name##_->get_gate_bias()); \
-    if (name##_->has_up_bias())                                                               \
-        this->register_parameter(std::string(up_name) + ".bias", name##_->get_up_bias());
-
-// ========================= QKV Quantization ==================================
-#define INFINILM_QKV_LINEAR_W8A8_INIT(name, q_name, k_name, v_name, ...)                            \
-    name##_ = std::make_shared<layers::linear::QKVParallelLinear>(__VA_ARGS__);                     \
-    this->register_parameter(std::string(q_name) + ".weight", name##_->get_q_weight());             \
-    this->register_parameter(std::string(q_name) + ".weight_scale", name##_->get_q_weight_scale()); \
-    this->register_parameter(std::string(k_name) + ".weight", name##_->get_k_weight());             \
-    this->register_parameter(std::string(k_name) + ".weight_scale", name##_->get_k_weight_scale()); \
-    this->register_parameter(std::string(v_name) + ".weight", name##_->get_v_weight());             \
-    this->register_parameter(std::string(v_name) + ".weight_scale", name##_->get_v_weight_scale()); \
-    if (name##_->has_q_bias())                                                                      \
-        this->register_parameter(std::string(q_name) + ".bias", name##_->get_q_bias());             \
-    if (name##_->has_k_bias())                                                                      \
-        this->register_parameter(std::string(k_name) + ".bias", name##_->get_k_bias());             \
-    if (name##_->has_v_bias())                                                                      \
-        this->register_parameter(std::string(v_name) + ".bias", name##_->get_v_bias());
-
-#define INFINILM_QKV_LINEAR_W4A16AWQ_INIT(name, q_name, k_name, v_name, ...)                                 \
-    name##_ = std::make_shared<layers::linear::QKVParallelLinear>(__VA_ARGS__);                              \
-    auto awq_ptr = std::static_pointer_cast<infinicore::quantization::AWQ>(name##_->get_quantization());     \
-    int packing_num = awq_ptr->get_packing_num();                                                            \
-    this->register_parameter(std::string(q_name) + ".qweight", name##_->get_q_weight_awq(packing_num));      \
-    this->register_parameter(std::string(q_name) + ".qzeros", name##_->get_q_weight_zeros_awq(packing_num)); \
-    this->register_parameter(std::string(q_name) + ".scales", name##_->get_q_weight_scale_awq(1));           \
-    this->register_parameter(std::string(k_name) + ".qweight", name##_->get_k_weight_awq(packing_num));      \
-    this->register_parameter(std::string(k_name) + ".qzeros", name##_->get_k_weight_zeros_awq(packing_num)); \
-    this->register_parameter(std::string(k_name) + ".scales", name##_->get_k_weight_scale_awq(1));           \
-    this->register_parameter(std::string(v_name) + ".qweight", name##_->get_v_weight_awq(packing_num));      \
-    this->register_parameter(std::string(v_name) + ".qzeros", name##_->get_v_weight_zeros_awq(packing_num)); \
-    this->register_parameter(std::string(v_name) + ".scales", name##_->get_v_weight_scale_awq(1));           \
-    if (name##_->has_q_bias())                                                                               \
-        this->register_parameter(std::string(q_name) + ".bias", name##_->get_q_bias());                      \
-    if (name##_->has_k_bias())                                                                               \
-        this->register_parameter(std::string(k_name) + ".bias", name##_->get_k_bias());                      \
-    if (name##_->has_v_bias())                                                                               \
-        this->register_parameter(std::string(v_name) + ".bias", name##_->get_v_bias());
-
-// ========================= Gate-Up Quantization ==============================
-#define INFINILM_GATE_UP_LINEAR_W8A8_INIT(name, gate_name, up_name, ...)                                  \
-    name##_ = std::make_shared<layers::linear::GateUpParallelLinear>(__VA_ARGS__);                        \
-    this->register_parameter(std::string(gate_name) + ".weight", name##_->get_gate_weight());             \
-    this->register_parameter(std::string(gate_name) + ".weight_scale", name##_->get_gate_weight_scale()); \
-    this->register_parameter(std::string(up_name) + ".weight", name##_->get_up_weight());                 \
-    this->register_parameter(std::string(up_name) + ".weight_scale", name##_->get_up_weight_scale());     \
-    if (name##_->has_gate_bias())                                                                         \
-        this->register_parameter(std::string(gate_name) + ".bias", name##_->get_gate_bias());             \
-    if (name##_->has_up_bias())                                                                           \
-        this->register_parameter(std::string(up_name) + ".bias", name##_->get_up_bias());
-
-#define INFINILM_GATE_UP_LINEAR_W4A16AWQ_INIT(name, gate_name, up_name, ...)                            \
-    name##_ = std::make_shared<layers::linear::GateUpParallelLinear>(__VA_ARGS__);                      \
-    this->register_parameter(std::string(gate_name) + ".qweight", name##_->get_gate_weight_awq());      \
-    this->register_parameter(std::string(gate_name) + ".qzeros", name##_->get_gate_weight_zeros_awq()); \
-    this->register_parameter(std::string(gate_name) + ".scales", name##_->get_gate_weight_scale_awq()); \
-    this->register_parameter(std::string(up_name) + ".qweight", name##_->get_up_weight_awq());          \
-    this->register_parameter(std::string(up_name) + ".qzeros", name##_->get_up_weight_zeros_awq());     \
-    this->register_parameter(std::string(up_name) + ".scales", name##_->get_up_weight_scale_awq());     \
-    if (name##_->has_gate_bias())                                                                       \
-        this->register_parameter(std::string(gate_name) + ".bias", name##_->get_gate_bias());           \
-    if (name##_->has_up_bias())                                                                         \
-        this->register_parameter(std::string(up_name) + ".bias", name##_->get_up_bias());
-
-#define INFINILM_QKV_LINEAR_W4A16GPTQ_INIT(name, q_name, k_name, v_name, ...)                                 \
-    name##_ = std::make_shared<layers::linear::QKVParallelLinear>(__VA_ARGS__);                               \
-    auto gptq_ptr = std::static_pointer_cast<infinicore::quantization::GPTQ_QY>(name##_->get_quantization()); \
-    int packing_num = gptq_ptr->get_packing_num();                                                            \
-    this->register_parameter(std::string(q_name) + ".qweight", name##_->get_q_weight_awq(1));                 \
-    this->register_parameter(std::string(q_name) + ".qzeros", name##_->get_q_weight_zeros_awq(8));            \
-    this->register_parameter(std::string(q_name) + ".scales", name##_->get_q_weight_scale_awq(1));            \
-    this->register_parameter(std::string(q_name) + ".g_idx", name##_->get_q_g_idx_gptq());                    \
-    this->register_parameter(std::string(k_name) + ".qweight", name##_->get_k_weight_awq(1));                 \
-    this->register_parameter(std::string(k_name) + ".qzeros", name##_->get_k_weight_zeros_awq(8));            \
-    this->register_parameter(std::string(k_name) + ".scales", name##_->get_k_weight_scale_awq(1));            \
-    this->register_parameter(std::string(k_name) + ".g_idx", name##_->get_k_g_idx_gptq());                    \
-    this->register_parameter(std::string(v_name) + ".qweight", name##_->get_v_weight_awq(1));                 \
-    this->register_parameter(std::string(v_name) + ".qzeros", name##_->get_v_weight_zeros_awq(8));            \
-    this->register_parameter(std::string(v_name) + ".scales", name##_->get_v_weight_scale_awq(1));            \
-    this->register_parameter(std::string(v_name) + ".g_idx", name##_->get_v_g_idx_gptq());                    \
-    if (name##_->has_q_bias())                                                                                \
-        this->register_parameter(std::string(q_name) + ".bias", name##_->get_q_bias());                       \
-    if (name##_->has_k_bias())                                                                                \
-        this->register_parameter(std::string(k_name) + ".bias", name##_->get_k_bias());                       \
-    if (name##_->has_v_bias())                                                                                \
-        this->register_parameter(std::string(v_name) + ".bias", name##_->get_v_bias());
-
-#define INFINILM_GATE_UP_LINEAR_W4A16GPTQ_INIT(name, gate_name, up_name, ...)                           \
-    name##_ = std::make_shared<layers::linear::GateUpParallelLinear>(__VA_ARGS__);                      \
-    this->register_parameter(std::string(gate_name) + ".qweight", name##_->get_gate_weight_awq());      \
-    this->register_parameter(std::string(gate_name) + ".qzeros", name##_->get_gate_weight_zeros_awq()); \
-    this->register_parameter(std::string(gate_name) + ".scales", name##_->get_gate_weight_scale_awq()); \
-    this->register_parameter(std::string(gate_name) + ".g_idx", name##_->get_gate_g_idx_gptq());        \
-    this->register_parameter(std::string(up_name) + ".qweight", name##_->get_up_weight_awq());          \
-    this->register_parameter(std::string(up_name) + ".qzeros", name##_->get_up_weight_zeros_awq());     \
-    this->register_parameter(std::string(up_name) + ".scales", name##_->get_up_weight_scale_awq());     \
-    this->register_parameter(std::string(up_name) + ".g_idx", name##_->get_up_g_idx_gptq());            \
-    if (name##_->has_gate_bias())                                                                       \
-        this->register_parameter(std::string(gate_name) + ".bias", name##_->get_gate_bias());           \
-    if (name##_->has_up_bias())                                                                         \
-        this->register_parameter(std::string(up_name) + ".bias", name##_->get_up_bias());
 } // namespace infinilm::layers::linear

--- a/csrc/layers/linear/linear.cpp
+++ b/csrc/layers/linear/linear.cpp
@@ -1,0 +1,100 @@
+#include "linear.hpp"
+#include "infinicore/ops.hpp"
+#include "infinicore/ops/distributed/allreduce.hpp"
+#include <optional>
+
+namespace infinilm::nn {
+
+// ---- Linear ----
+
+Linear::Linear(size_t in_features, size_t out_features, bool bias,
+               const infinicore::DataType &dtype, const infinicore::Device &device)
+    : BaseLinear(in_features, out_features,
+                 std::make_shared<infinilm::quantization::NoneQuantization>(nullptr),
+                 bias, dtype, device, -1, 0, 1) {
+}
+
+Linear::Linear(size_t in_features, size_t out_features,
+               std::shared_ptr<infinilm::quantization::BaseQuantization> quantization,
+               bool bias, const infinicore::DataType &dtype, const infinicore::Device &device)
+    : BaseLinear(in_features, out_features, quantization, bias, dtype, device, -1, 0, 1) {
+}
+
+infinicore::Tensor Linear::forward(infinicore::Tensor &input) const {
+    return BaseLinear::forward(input);
+}
+
+std::string Linear::extra_repr() const {
+    return "Linear(in_features=" + std::to_string(in_features_) + ", out_features=" + std::to_string(out_features_) + ", bias=" + (has_bias_ ? "true" : "false") + ", dtype=" + std::to_string(static_cast<int>(dtype_)) + ")";
+}
+
+// ---- ColumnParallelLinear ----
+
+ColumnParallelLinear::ColumnParallelLinear(size_t in_features, size_t out_features, bool bias,
+                                           const infinicore::DataType &dtype, const infinicore::Device &device,
+                                           infinicore::Size tp_rank, infinicore::Size tp_size,
+                                           int tp_num_heads)
+    : BaseLinear(in_features, out_features,
+                 std::make_shared<infinilm::quantization::NoneQuantization>(nullptr),
+                 bias, dtype, device, 0, tp_rank, tp_size, tp_num_heads),
+      tp_rank_(tp_rank),
+      tp_size_(tp_size) {
+}
+
+ColumnParallelLinear::ColumnParallelLinear(size_t in_features, size_t out_features,
+                                           std::shared_ptr<infinilm::quantization::BaseQuantization> quantization,
+                                           bool bias, const infinicore::DataType &dtype, const infinicore::Device &device,
+                                           infinicore::Size tp_rank, infinicore::Size tp_size,
+                                           int tp_num_heads)
+    : BaseLinear(in_features, out_features, quantization, bias, dtype, device,
+                 0, tp_rank, tp_size, tp_num_heads),
+      tp_rank_(tp_rank),
+      tp_size_(tp_size) {
+}
+
+infinicore::Tensor ColumnParallelLinear::forward(infinicore::Tensor &input) const {
+    return BaseLinear::forward(input);
+}
+
+std::string ColumnParallelLinear::extra_repr() const {
+    return "ColumnParallelLinear(in_features=" + std::to_string(in_features_) + ", out_features=" + std::to_string(out_features_) + ", bias=" + (has_bias_ ? "true" : "false") + ", dtype=" + std::to_string(static_cast<int>(dtype_)) + ")";
+}
+
+// ---- RowParallelLinear ----
+
+RowParallelLinear::RowParallelLinear(size_t in_features, size_t out_features, bool bias,
+                                     const infinicore::DataType &dtype, const infinicore::Device &device,
+                                     infinicore::Size tp_rank, infinicore::Size tp_size,
+                                     infinicclComm_t communicator)
+    : BaseLinear(in_features, out_features,
+                 std::make_shared<infinilm::quantization::NoneQuantization>(nullptr),
+                 bias, dtype, device, 1, tp_rank, tp_size),
+      tp_rank_(tp_rank),
+      tp_size_(tp_size), communicator_(communicator) {
+}
+
+RowParallelLinear::RowParallelLinear(size_t in_features, size_t out_features,
+                                     std::shared_ptr<infinilm::quantization::BaseQuantization> quantization,
+                                     bool bias, const infinicore::DataType &dtype, const infinicore::Device &device,
+                                     infinicore::Size tp_rank, infinicore::Size tp_size,
+                                     infinicclComm_t communicator)
+    : BaseLinear(in_features, out_features, quantization, bias, dtype, device,
+                 1, tp_rank, tp_size),
+      tp_rank_(tp_rank),
+      tp_size_(tp_size), communicator_(communicator) {
+}
+
+infinicore::Tensor RowParallelLinear::forward(infinicore::Tensor &input) const {
+    auto output = BaseLinear::forward(input);
+
+    if ((tp_size_ > 1) && (communicator_ != nullptr)) {
+        infinicore::op::distributed::allreduce_(output, output, INFINICCL_SUM, communicator_);
+    }
+    return output;
+}
+
+std::string RowParallelLinear::extra_repr() const {
+    return "RowParallelLinear(in_features=" + std::to_string(in_features_) + ", out_features=" + std::to_string(out_features_) + ", bias=" + (has_bias_ ? "true" : "false") + ", dtype=" + std::to_string(static_cast<int>(dtype_)) + ")";
+}
+
+} // namespace infinilm::nn

--- a/csrc/layers/linear/linear.hpp
+++ b/csrc/layers/linear/linear.hpp
@@ -1,12 +1,92 @@
 #pragma once
+
+#include "../quantization/quantization.hpp"
+#include "base_linear.hpp"
+#include "infinicore/nn/module.hpp"
+#include "infinicore/ops.hpp"
+#include <infiniccl.h>
+#include <optional>
+
+namespace infinilm::nn {
+
+class Linear : public BaseLinear {
+public:
+    // Without quantization (backward compat)
+    Linear(size_t in_features, size_t out_features, bool bias,
+           const infinicore::DataType &dtype = infinicore::DataType::F32,
+           const infinicore::Device &device = infinicore::Device());
+
+    // With quantization
+    Linear(size_t in_features, size_t out_features,
+           std::shared_ptr<infinilm::quantization::BaseQuantization> quantization,
+           bool bias = true,
+           const infinicore::DataType &dtype = infinicore::DataType::F32,
+           const infinicore::Device &device = infinicore::Device());
+
+    infinicore::Tensor forward(infinicore::Tensor &input) const;
+    std::string extra_repr() const;
+};
+
+class ColumnParallelLinear : public BaseLinear {
+public:
+    // Without quantization (backward compat)
+    ColumnParallelLinear(size_t in_features, size_t out_features, bool bias,
+                         const infinicore::DataType &dtype, const infinicore::Device &device,
+                         infinicore::Size tp_rank = 0, infinicore::Size tp_size = 1,
+                         int tp_num_heads = -1);
+
+    // With quantization
+    ColumnParallelLinear(size_t in_features, size_t out_features,
+                         std::shared_ptr<infinilm::quantization::BaseQuantization> quantization,
+                         bool bias = true,
+                         const infinicore::DataType &dtype = infinicore::DataType::F32,
+                         const infinicore::Device &device = infinicore::Device(),
+                         infinicore::Size tp_rank = 0, infinicore::Size tp_size = 1,
+                         int tp_num_heads = -1);
+
+    infinicore::Tensor forward(infinicore::Tensor &input) const;
+    std::string extra_repr() const;
+
+protected:
+    infinicore::Size tp_rank_ = 0;
+    infinicore::Size tp_size_ = 1;
+};
+
+class RowParallelLinear : public BaseLinear {
+public:
+    // Without quantization (backward compat)
+    RowParallelLinear(size_t in_features, size_t out_features, bool bias,
+                      const infinicore::DataType &dtype, const infinicore::Device &device,
+                      infinicore::Size tp_rank = 0, infinicore::Size tp_size = 1,
+                      infinicclComm_t communicator = nullptr);
+
+    // With quantization
+    RowParallelLinear(size_t in_features, size_t out_features,
+                      std::shared_ptr<infinilm::quantization::BaseQuantization> quantization,
+                      bool bias = true,
+                      const infinicore::DataType &dtype = infinicore::DataType::F32,
+                      const infinicore::Device &device = infinicore::Device(),
+                      infinicore::Size tp_rank = 0, infinicore::Size tp_size = 1,
+                      infinicclComm_t communicator = nullptr);
+
+    infinicore::Tensor forward(infinicore::Tensor &input) const;
+    std::string extra_repr() const;
+
+protected:
+    infinicore::Size tp_rank_ = 0;
+    infinicore::Size tp_size_ = 1;
+    infinicclComm_t communicator_;
+};
+
+} // namespace infinilm::nn
+
 #include "fused_linear.hpp"
 
 namespace infinilm::layers::linear {
 
-using QKVParallelLinear = infinilm::layers::linear::QKVParallelLinear;
-using ReplicatedLinear = infinicore::nn::Linear;
-using ColumnParallelLinear = infinicore::nn::ColumnParallelLinear;
-using RowParallelLinear = infinicore::nn::RowParallelLinear;
-using GateUpParallelLinear = infinilm::layers::linear::GateUpParallelLinear;
+using ReplicatedLinear = infinilm::nn::Linear;
+using ColumnParallelLinear = infinilm::nn::ColumnParallelLinear;
+using RowParallelLinear = infinilm::nn::RowParallelLinear;
+using BaseLinear = infinilm::nn::BaseLinear;
 
 } // namespace infinilm::layers::linear

--- a/csrc/layers/mlp/mlp.cpp
+++ b/csrc/layers/mlp/mlp.cpp
@@ -16,49 +16,14 @@ MLP::MLP(std::shared_ptr<infinilm::config::ModelConfig> model_config,
     int tp_rank = rank_info.tp_rank;
     int tp_size = rank_info.tp_size;
 
-    auto quant_scheme = model_config->get_quant_scheme();
     auto quantization_method = model_config->get_quantization_method();
-    switch (quant_scheme) {
-    case infinicore::quantization::QuantScheme::NONE: {
-        INFINILM_GATE_UP_LINEAR_INIT(gate_up_proj, "gate_proj", "up_proj", hidden_size_, intermediate_size_, quantization_method,
-                                     use_bias_, dtype, device, rank_info);
-        INFINICORE_NN_MODULE_INIT(down_proj, intermediate_size_, hidden_size_, quantization_method,
-                                  use_bias_, dtype, device, tp_rank, tp_size, rank_info.comm);
-        break;
-    }
-    case infinicore::quantization::QuantScheme::COMPRESSED_TENSOR_W8A8I8: {
-        INFINILM_GATE_UP_LINEAR_W8A8_INIT(gate_up_proj, "gate_proj", "up_proj", hidden_size_, intermediate_size_, quantization_method,
-                                          use_bias_, dtype, device, rank_info);
-        INFINICORE_NN_MODULE_INIT(down_proj, intermediate_size_, hidden_size_, quantization_method,
-                                  use_bias_, dtype, device, tp_rank, tp_size, rank_info.comm);
-        break;
-    }
-    case infinicore::quantization::QuantScheme::GPTQ_W4A16: {
-        INFINILM_GATE_UP_LINEAR_W4A16GPTQ_INIT(gate_up_proj, "gate_proj", "up_proj", hidden_size_, intermediate_size_, quantization_method, use_bias_,
-                                               dtype, device, rank_info);
-        INFINICORE_NN_MODULE_INIT(down_proj, intermediate_size_, hidden_size_, quantization_method, use_bias_,
-                                  dtype, device, tp_rank, tp_size, rank_info.comm);
-        break;
-    }
-    case infinicore::quantization::QuantScheme::GPTQ_W4A16_QY: {
-        INFINILM_GATE_UP_LINEAR_W4A16GPTQ_INIT(gate_up_proj, "gate_proj", "up_proj", hidden_size_, intermediate_size_, quantization_method, use_bias_,
-                                               dtype, device, rank_info);
-        INFINICORE_NN_MODULE_INIT(down_proj, intermediate_size_, hidden_size_, quantization_method, use_bias_,
-                                  dtype, device, tp_rank, tp_size, rank_info.comm);
-        break;
-    }
-    case infinicore::quantization::QuantScheme::AWQ_W4A16: {
-        INFINILM_GATE_UP_LINEAR_W4A16AWQ_INIT(gate_up_proj, "gate_proj", "up_proj", hidden_size_, intermediate_size_, quantization_method,
-                                              use_bias_, dtype, device, rank_info);
-        INFINICORE_NN_MODULE_INIT(down_proj, intermediate_size_, hidden_size_, quantization_method,
-                                  use_bias_, dtype, device, tp_rank, tp_size, rank_info.comm);
-        break;
-    }
-    default: {
-        throw std::runtime_error("infinilm::layers::mlp::MLP: unsupported quantization scheme");
-        break;
-    }
-    }
+    auto register_fn = [this](const std::string &n, infinicore::nn::Parameter p) { this->register_parameter(n, std::move(p)); };
+    gate_up_proj_ = std::make_shared<layers::linear::GateUpParallelLinear>(
+        hidden_size_, intermediate_size_, "gate_proj", "up_proj", register_fn,
+        quantization_method, use_bias_, dtype, device, rank_info);
+    down_proj_ = this->register_module<layers::linear::RowParallelLinear>(
+        "down_proj", intermediate_size_, hidden_size_, quantization_method,
+        use_bias_, dtype, device, tp_rank, tp_size, rank_info.comm);
 }
 
 infinicore::Tensor MLP::forward(const infinicore::Tensor &hidden_states) const {

--- a/csrc/layers/mlp/mlp.hpp
+++ b/csrc/layers/mlp/mlp.hpp
@@ -36,13 +36,17 @@ public:
      */
     infinicore::Tensor forward(const infinicore::Tensor &hidden_states) const;
 
+    void process_fused_weights_after_loading() {
+        gate_up_proj_->process_weights_after_loading();
+    }
+
     // Module information
     size_t hidden_size() const { return hidden_size_; }
     size_t intermediate_size() const { return intermediate_size_; }
 
 protected:
-    INFINICORE_NN_MODULE(infinilm::layers::linear::GateUpParallelLinear, gate_up_proj);
-    INFINICORE_NN_MODULE(infinilm::layers::linear::RowParallelLinear, down_proj);
+    std::shared_ptr<infinilm::layers::linear::GateUpParallelLinear> gate_up_proj_;
+    std::shared_ptr<infinilm::layers::linear::RowParallelLinear> down_proj_;
 
     size_t hidden_size_;
     size_t intermediate_size_;

--- a/csrc/layers/mlp/moe_mlp.cpp
+++ b/csrc/layers/mlp/moe_mlp.cpp
@@ -16,23 +16,16 @@ MoeMLP::MoeMLP(std::shared_ptr<infinilm::config::ModelConfig> model_config,
     int tp_rank = rank_info.tp_rank;
     int tp_size = rank_info.tp_size;
 
-    auto quant_scheme = model_config->get_quant_scheme();
     auto quantization_method = model_config->get_quantization_method();
-    switch (quant_scheme) {
-    case infinicore::quantization::QuantScheme::NONE: {
-        INFINICORE_NN_MODULE_INIT(gate_proj, hidden_size_, moe_intermediate_size_, false,
-                                  dtype, device, tp_rank, tp_size);
-        INFINICORE_NN_MODULE_INIT(up_proj, hidden_size_, moe_intermediate_size_, false,
-                                  dtype, device, tp_rank, tp_size);
-        INFINICORE_NN_MODULE_INIT(down_proj, moe_intermediate_size_, hidden_size_, false,
-                                  dtype, device, tp_rank, tp_size, rank_info.comm);
-        break;
-    }
-    default: {
-        throw std::runtime_error("infinilm::layers::moe_mlp::MoeMLP: unsupported quantization scheme");
-        break;
-    }
-    }
+    gate_proj_ = this->register_module<layers::linear::ColumnParallelLinear>(
+        "gate_proj", hidden_size_, moe_intermediate_size_, quantization_method,
+        use_bias_, dtype, device, tp_rank, tp_size);
+    up_proj_ = this->register_module<layers::linear::ColumnParallelLinear>(
+        "up_proj", hidden_size_, moe_intermediate_size_, quantization_method,
+        use_bias_, dtype, device, tp_rank, tp_size);
+    down_proj_ = this->register_module<layers::linear::RowParallelLinear>(
+        "down_proj", moe_intermediate_size_, hidden_size_, quantization_method,
+        use_bias_, dtype, device, tp_rank, tp_size, rank_info.comm);
 }
 
 infinicore::Tensor MoeMLP::forward(const infinicore::Tensor &hidden_states) const {

--- a/csrc/layers/mlp/moe_mlp.hpp
+++ b/csrc/layers/mlp/moe_mlp.hpp
@@ -18,9 +18,9 @@ public:
     void set_alpha(float alpha) { down_proj_->set_alpha(alpha); }
 
 protected:
-    INFINICORE_NN_MODULE(infinilm::layers::linear::ColumnParallelLinear, gate_proj);
-    INFINICORE_NN_MODULE(infinilm::layers::linear::ColumnParallelLinear, up_proj);
-    INFINICORE_NN_MODULE(infinilm::layers::linear::RowParallelLinear, down_proj);
+    std::shared_ptr<infinilm::layers::linear::ColumnParallelLinear> gate_proj_;
+    std::shared_ptr<infinilm::layers::linear::ColumnParallelLinear> up_proj_;
+    std::shared_ptr<infinilm::layers::linear::RowParallelLinear> down_proj_;
 
     size_t hidden_size_;
     size_t moe_intermediate_size_;

--- a/csrc/layers/quantization/awq.cpp
+++ b/csrc/layers/quantization/awq.cpp
@@ -1,0 +1,96 @@
+#include "awq.hpp"
+#include "infinicore/ops/linear_w4a16_awq.hpp"
+#include <optional>
+
+namespace infinilm::quantization {
+
+std::vector<ParamDescriptor> AWQ::get_param_layout(
+    size_t in_features, size_t out_features,
+    int split_dim, int tp_rank, int tp_size,
+    int /*tp_num_heads*/,
+    const infinicore::DataType &dtype,
+    bool bias) const {
+
+    // AWQ weight layout is transposed relative to the standard [out, in]:
+    //   qweight: [in_features, out_features / packing_num]
+    // So the TP split dimension for AWQ is the "other" dimension:
+    //   ColumnParallel (split_dim=0, split output) → AWQ tp_dim=1
+    //   RowParallel    (split_dim=1, split input)  → AWQ tp_dim=0
+    int awq_tp_dim = (split_dim >= 0) ? (1 - split_dim) : -1;
+    int group_size = get_group_size();
+    int packing_num = get_packing_num();
+
+    std::vector<ParamDescriptor> descs;
+    descs.push_back({"qweight", {in_features, out_features / packing_num},
+                     infinicore::DataType::I32, awq_tp_dim, tp_rank, tp_size});
+    descs.push_back({"scales", {in_features / group_size, out_features},
+                     dtype, awq_tp_dim, tp_rank, tp_size});
+    descs.push_back({"qzeros", {in_features / group_size, out_features / packing_num},
+                     infinicore::DataType::I32, awq_tp_dim, tp_rank, tp_size});
+    if (bias) {
+        descs.push_back({"bias", {out_features}, dtype, -1, 0, 1});
+    }
+    return descs;
+}
+
+infinicore::Tensor AWQ::forward(
+    const ParamsMap &params,
+    const infinicore::Tensor &input,
+    bool has_bias,
+    float /*alpha*/) const {
+
+    auto input_contiguous = input->is_contiguous() ? input : input->contiguous();
+    auto qweight = params.at("qweight");
+    auto scales = params.at("scales");
+    auto qzeros = params.at("qzeros");
+
+    std::optional<infinicore::Tensor> bias_opt;
+    if (has_bias) {
+        bias_opt = params.at("bias");
+    }
+
+    return infinicore::op::linear_w4a16_awq(input_contiguous->contiguous(), qweight, scales, qzeros, bias_opt);
+}
+
+std::vector<SplitParam> AWQ::split_params(
+    const std::unordered_map<std::string, infinicore::nn::Parameter> &params,
+    const std::vector<SplitInfo> &splits,
+    int /*narrow_dim*/,
+    int tp_rank, int tp_size, int tp_num_heads) const {
+
+    // AWQ parameters have output dimension on dim1, so fused split is on dim1.
+    int fused_dim = get_fused_split_dim();
+    int packing_num = get_packing_num();
+    std::vector<SplitParam> result;
+    auto qw_it = params.find("qweight");
+    auto sc_it = params.find("scales");
+    auto qz_it = params.find("qzeros");
+    auto bias_it = params.find("bias");
+
+    for (const auto &s : splits) {
+        // qweight: narrow along fused_dim, divide size by packing_num
+        result.push_back({s.prefix + ".qweight",
+                          infinicore::nn::Parameter(
+                              qw_it->second->narrow({{static_cast<size_t>(fused_dim), s.start / packing_num, s.size / packing_num}}),
+                              fused_dim, tp_rank, tp_size, s.num_shards)});
+        // scales: narrow along fused_dim
+        result.push_back({s.prefix + ".scales",
+                          infinicore::nn::Parameter(
+                              sc_it->second->narrow({{static_cast<size_t>(fused_dim), s.start, s.size}}),
+                              fused_dim, tp_rank, tp_size, s.num_shards)});
+        // qzeros: narrow along fused_dim, divide size by packing_num
+        result.push_back({s.prefix + ".qzeros",
+                          infinicore::nn::Parameter(
+                              qz_it->second->narrow({{static_cast<size_t>(fused_dim), s.start / packing_num, s.size / packing_num}}),
+                              fused_dim, tp_rank, tp_size, s.num_shards)});
+        if (bias_it != params.end()) {
+            result.push_back({s.prefix + ".bias",
+                              infinicore::nn::Parameter(
+                                  bias_it->second->narrow({{0, s.start, s.size}}),
+                                  0, tp_rank, tp_size, s.num_shards)});
+        }
+    }
+    return result;
+}
+
+} // namespace infinilm::quantization

--- a/csrc/layers/quantization/awq.hpp
+++ b/csrc/layers/quantization/awq.hpp
@@ -1,0 +1,48 @@
+#pragma once
+#include "base_quantization.hpp"
+namespace infinilm::quantization {
+
+class AWQ : public BaseQuantization {
+public:
+    explicit AWQ(const nlohmann::json &quant_config)
+        : BaseQuantization(quant_config){};
+
+    QuantScheme get_quant_scheme() const override {
+        return QuantScheme::AWQ_W4A16;
+    };
+
+    int get_packing_num() const {
+        return 32 / get_or<int>("bits", 4);
+    }
+
+    int get_group_size() const {
+        return get_or<int>("group_size", 128);
+    }
+
+    std::vector<ParamDescriptor> get_param_layout(
+        size_t in_features, size_t out_features,
+        int split_dim, int tp_rank, int tp_size,
+        int tp_num_heads,
+        const infinicore::DataType &dtype,
+        bool bias) const override;
+
+    int get_fused_split_dim() const override { return 1; }
+
+    size_t get_logical_dim_size(size_t raw_size) const override {
+        return raw_size * get_packing_num();
+    }
+
+    infinicore::Tensor forward(
+        const ParamsMap &params,
+        const infinicore::Tensor &input,
+        bool has_bias,
+        float alpha = 1.0f) const override;
+
+    std::vector<SplitParam> split_params(
+        const std::unordered_map<std::string, infinicore::nn::Parameter> &params,
+        const std::vector<SplitInfo> &splits,
+        int narrow_dim,
+        int tp_rank, int tp_size, int tp_num_heads) const override;
+};
+
+} // namespace infinilm::quantization

--- a/csrc/layers/quantization/base_quantization.hpp
+++ b/csrc/layers/quantization/base_quantization.hpp
@@ -1,0 +1,122 @@
+#pragma once
+#include "infinicore/nn/module.hpp"
+#include "infinicore/tensor.hpp"
+#include "nlohmann/json.hpp"
+#include "quantization_scheme.hpp"
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace infinilm::quantization {
+
+struct ParamDescriptor {
+    std::string name;
+    std::vector<size_t> shape;
+    infinicore::DataType dtype;
+    int split_dim = -1;
+    int tp_rank = 0;
+    int tp_size = 1;
+    int tp_num_heads = -1;
+};
+
+using ParamsMap = std::unordered_map<std::string, infinicore::Tensor>;
+
+// Describes one shard of a fused linear (e.g., Q, K, V or gate, up)
+struct SplitInfo {
+    std::string prefix;    // "q_proj", "k_proj", "v_proj" or "gate_proj", "up_proj"
+    size_t start;          // start offset along narrow_dim
+    size_t size;           // size of this shard along narrow_dim
+    size_t num_shards = 0; // number of logical shards for KV replication (0 = standard TP split)
+};
+
+// A named parameter produced by splitting a fused linear
+struct SplitParam {
+    std::string full_name; // "q_proj.weight", "gate_proj.qweight", etc.
+    infinicore::nn::Parameter param;
+};
+
+class BaseQuantization : public std::enable_shared_from_this<BaseQuantization> {
+public:
+    explicit BaseQuantization(const nlohmann::json &quant_config) : quant_config_(quant_config) {};
+    virtual ~BaseQuantization() = default;
+
+    const nlohmann::json &get_config() const { return quant_config_; }
+
+    virtual QuantScheme get_quant_scheme() const = 0;
+
+    // Return the list of parameters this quantization scheme needs
+    virtual std::vector<ParamDescriptor> get_param_layout(
+        size_t in_features, size_t out_features,
+        int split_dim, int tp_rank, int tp_size,
+        int tp_num_heads,
+        const infinicore::DataType &dtype,
+        bool bias) const = 0;
+
+    // Forward pass using the registered parameters
+    virtual infinicore::Tensor forward(
+        const ParamsMap &params,
+        const infinicore::Tensor &input,
+        bool has_bias,
+        float alpha = 1.0f) const = 0;
+
+    // Dimension for fused-split (gate/up, q/k/v) of a column-parallel weight.
+    // For NoneQuantization weight [out, in], split is on dim0.
+    // For AWQ qweight [in, out/pack], split is on dim1.
+    virtual int get_fused_split_dim() const { return 0; }
+
+    // Logical output size along fused_split_dim from a parameter's raw dimension size.
+    // For packed formats (AWQ, GPTQ), raw size needs to be multiplied by packing_num.
+    // Default: raw size is already logical size.
+    virtual size_t get_logical_dim_size(size_t raw_size) const { return raw_size; }
+
+    // Split fused linear parameters into named sub-parameters (for QKV/GateUp)
+    // params: the fused linear's registered parameters (by name)
+    // splits: description of each shard
+    // narrow_dim: 0=narrow dim0, 1=narrow dim1 (for weight-like params)
+    // Returns a list of (full_name, Parameter) pairs
+    virtual std::vector<SplitParam> split_params(
+        const std::unordered_map<std::string, infinicore::nn::Parameter> &params,
+        const std::vector<SplitInfo> &splits,
+        int narrow_dim,
+        int tp_rank, int tp_size, int tp_num_heads) const = 0;
+
+    // Post-loading weight processing (e.g., GPTQ->GPTQ_QY conversion).
+    // Returns a replacement quantization object if the scheme changed (e.g. GPTQ -> GPTQ_QY),
+    // or nullptr if no replacement is needed.
+    virtual std::shared_ptr<BaseQuantization> process_weights_after_loading(
+        ParamsMap &params,
+        const infinicore::Device &device) const {
+        (void)params;
+        (void)device;
+        return nullptr;
+    }
+
+    template <typename T>
+    T get(const std::string &key) const {
+        if (!quant_config_.contains(key)) {
+            throw std::out_of_range("Key '" + key + "' not found in config.");
+        }
+        try {
+            return quant_config_.at(key).get<T>();
+        } catch (const nlohmann::json::type_error &e) {
+            throw std::runtime_error("Type conversion failed for key '" + key + "': " + std::string(e.what()));
+        }
+    }
+
+    template <typename T>
+    T get_or(const std::string &key, const T &default_value) const {
+        if (!quant_config_.contains(key) || quant_config_.at(key).is_null()) {
+            return default_value;
+        }
+        try {
+            return quant_config_.at(key).get<T>();
+        } catch (const nlohmann::json::type_error &) {
+            return default_value;
+        }
+    }
+
+protected:
+    nlohmann::json quant_config_;
+};
+
+} // namespace infinilm::quantization

--- a/csrc/layers/quantization/compressed_tensors.cpp
+++ b/csrc/layers/quantization/compressed_tensors.cpp
@@ -1,0 +1,76 @@
+#include "compressed_tensors.hpp"
+#include "infinicore/ops/linear_w8a8i8.hpp"
+#include <optional>
+
+namespace infinilm::quantization {
+
+std::vector<ParamDescriptor> CompressedTensors::get_param_layout(
+    size_t in_features, size_t out_features,
+    int split_dim, int tp_rank, int tp_size,
+    int /*tp_num_heads*/,
+    const infinicore::DataType &dtype,
+    bool bias) const {
+
+    std::vector<ParamDescriptor> descs;
+    descs.push_back({"weight", {out_features, in_features}, infinicore::DataType::I8, split_dim, tp_rank, tp_size});
+    // weight_scale is per-output-channel [out_features, 1]; always split on
+    // dim0 (output dimension) for ColumnParallel, and don't split for RowParallel.
+    int scale_split_dim = (split_dim == 0) ? 0 : -1;
+    int scale_tp_size = (split_dim == 0) ? tp_size : 1;
+    int scale_tp_rank = (split_dim == 0) ? tp_rank : 0;
+    descs.push_back({"weight_scale", {out_features, 1}, infinicore::DataType::F32, scale_split_dim, scale_tp_rank, scale_tp_size});
+    if (bias) {
+        descs.push_back({"bias", {out_features}, dtype, -1, 0, 1});
+    }
+    return descs;
+}
+
+infinicore::Tensor CompressedTensors::forward(
+    const ParamsMap &params,
+    const infinicore::Tensor &input,
+    bool has_bias,
+    float /*alpha*/) const {
+
+    auto input_contiguous = input->is_contiguous() ? input : input->contiguous();
+    auto weight = params.at("weight");
+    auto weight_scale = params.at("weight_scale");
+
+    std::optional<infinicore::Tensor> bias_opt;
+    if (has_bias) {
+        bias_opt = params.at("bias");
+    }
+
+    return infinicore::op::linear_w8a8i8(input_contiguous->contiguous(), weight, weight_scale, bias_opt);
+}
+
+std::vector<SplitParam> CompressedTensors::split_params(
+    const std::unordered_map<std::string, infinicore::nn::Parameter> &params,
+    const std::vector<SplitInfo> &splits,
+    int narrow_dim,
+    int tp_rank, int tp_size, int /*tp_num_heads*/) const {
+
+    std::vector<SplitParam> result;
+    auto weight_it = params.find("weight");
+    auto scale_it = params.find("weight_scale");
+    auto bias_it = params.find("bias");
+
+    for (const auto &s : splits) {
+        result.push_back({s.prefix + ".weight",
+                          infinicore::nn::Parameter(
+                              weight_it->second->narrow({{static_cast<size_t>(narrow_dim), s.start, s.size}}),
+                              narrow_dim, tp_rank, tp_size, s.num_shards)});
+        result.push_back({s.prefix + ".weight_scale",
+                          infinicore::nn::Parameter(
+                              scale_it->second->narrow({{static_cast<size_t>(narrow_dim), s.start, s.size}}),
+                              narrow_dim, tp_rank, tp_size, s.num_shards)});
+        if (bias_it != params.end()) {
+            result.push_back({s.prefix + ".bias",
+                              infinicore::nn::Parameter(
+                                  bias_it->second->narrow({{0, s.start, s.size}}),
+                                  0, tp_rank, tp_size, s.num_shards)});
+        }
+    }
+    return result;
+}
+
+} // namespace infinilm::quantization

--- a/csrc/layers/quantization/compressed_tensors.hpp
+++ b/csrc/layers/quantization/compressed_tensors.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "base_quantization.hpp"
+namespace infinilm::quantization {
+
+class CompressedTensors : public BaseQuantization {
+public:
+    explicit CompressedTensors(const nlohmann::json &quant_config)
+        : BaseQuantization(quant_config) {};
+
+    QuantScheme get_quant_scheme() const override {
+        return QuantScheme::COMPRESSED_TENSOR_W8A8I8;
+    };
+
+    std::vector<ParamDescriptor> get_param_layout(
+        size_t in_features, size_t out_features,
+        int split_dim, int tp_rank, int tp_size,
+        int tp_num_heads,
+        const infinicore::DataType &dtype,
+        bool bias) const override;
+
+    infinicore::Tensor forward(
+        const ParamsMap &params,
+        const infinicore::Tensor &input,
+        bool has_bias,
+        float alpha = 1.0f) const override;
+
+    std::vector<SplitParam> split_params(
+        const std::unordered_map<std::string, infinicore::nn::Parameter> &params,
+        const std::vector<SplitInfo> &splits,
+        int narrow_dim,
+        int tp_rank, int tp_size, int tp_num_heads) const override;
+};
+
+} // namespace infinilm::quantization

--- a/csrc/layers/quantization/gptq.cpp
+++ b/csrc/layers/quantization/gptq.cpp
@@ -1,0 +1,91 @@
+#include "gptq.hpp"
+#include "gptq_qy.hpp"
+
+namespace infinilm::quantization {
+
+std::vector<ParamDescriptor> GPTQ::get_param_layout(
+    size_t in_features, size_t out_features,
+    int split_dim, int tp_rank, int tp_size,
+    int /*tp_num_heads*/,
+    const infinicore::DataType &dtype,
+    bool bias) const {
+
+    // GPTQ weight layout is transposed: qweight [in_features/8, out_features]
+    // ColumnParallel (split_dim=0, split output) → GPTQ tp_dim=1
+    // RowParallel    (split_dim=1, split input)  → GPTQ tp_dim=0
+    int gptq_tp_dim = (split_dim >= 0) ? (1 - split_dim) : -1;
+    int group_size = get_group_size();
+
+    std::vector<ParamDescriptor> descs;
+    descs.push_back({"qweight", {in_features / 8, out_features}, infinicore::DataType::I32, gptq_tp_dim, tp_rank, tp_size});
+    descs.push_back({"qzeros", {in_features / group_size, out_features / 8}, infinicore::DataType::I32, gptq_tp_dim, tp_rank, tp_size});
+    descs.push_back({"scales", {in_features / group_size, out_features}, dtype, gptq_tp_dim, tp_rank, tp_size});
+    descs.push_back({"g_idx", {in_features}, infinicore::DataType::I32, 0, tp_rank, tp_size});
+    if (bias) {
+        descs.push_back({"bias", {out_features}, dtype, -1, 0, 1});
+    }
+    return descs;
+}
+
+infinicore::Tensor GPTQ::forward(
+    const ParamsMap & /*params*/,
+    const infinicore::Tensor & /*input*/,
+    bool /*has_bias*/,
+    float /*alpha*/) const {
+    throw std::runtime_error("GPTQ_W4A16 must be converted to GPTQ_QY before forward pass. "
+                             "Call process_weights_after_loading() first.");
+}
+
+std::shared_ptr<BaseQuantization> GPTQ::process_weights_after_loading(
+    ParamsMap &params,
+    const infinicore::Device &device) const {
+
+    if (device.getType() == infinicore::Device::Type::QY) {
+        return GPTQ_QY::convert_from_gptq(params, device, get_config());
+    }
+    return std::const_pointer_cast<BaseQuantization>(shared_from_this());
+}
+
+std::vector<SplitParam> GPTQ::split_params(
+    const std::unordered_map<std::string, infinicore::nn::Parameter> &params,
+    const std::vector<SplitInfo> &splits,
+    int /*narrow_dim*/,
+    int tp_rank, int tp_size, int tp_num_heads) const {
+
+    // GPTQ parameters have output dimension on dim1.
+    int fused_dim = get_fused_split_dim();
+    std::vector<SplitParam> result;
+    auto qw_it = params.find("qweight");
+    auto qz_it = params.find("qzeros");
+    auto sc_it = params.find("scales");
+    auto gidx_it = params.find("g_idx");
+    auto bias_it = params.find("bias");
+
+    for (const auto &s : splits) {
+        result.push_back({s.prefix + ".qweight",
+                          infinicore::nn::Parameter(
+                              qw_it->second->narrow({{static_cast<size_t>(fused_dim), s.start, s.size}}),
+                              fused_dim, tp_rank, tp_size, s.num_shards)});
+        result.push_back({s.prefix + ".qzeros",
+                          infinicore::nn::Parameter(
+                              qz_it->second->narrow({{static_cast<size_t>(fused_dim), s.start / 8, s.size / 8}}),
+                              fused_dim, tp_rank, tp_size, s.num_shards)});
+        result.push_back({s.prefix + ".scales",
+                          infinicore::nn::Parameter(
+                              sc_it->second->narrow({{static_cast<size_t>(fused_dim), s.start, s.size}}),
+                              fused_dim, tp_rank, tp_size, s.num_shards)});
+        result.push_back({s.prefix + ".g_idx",
+                          infinicore::nn::Parameter(
+                              gidx_it->second->narrow({{0, 0, gidx_it->second->size(0)}}),
+                              0, 0, 1, 0)});
+        if (bias_it != params.end()) {
+            result.push_back({s.prefix + ".bias",
+                              infinicore::nn::Parameter(
+                                  bias_it->second->narrow({{0, s.start, s.size}}),
+                                  0, tp_rank, tp_size, s.num_shards)});
+        }
+    }
+    return result;
+}
+
+} // namespace infinilm::quantization

--- a/csrc/layers/quantization/gptq.hpp
+++ b/csrc/layers/quantization/gptq.hpp
@@ -1,0 +1,48 @@
+#pragma once
+#include "base_quantization.hpp"
+namespace infinilm::quantization {
+
+class GPTQ : public BaseQuantization {
+public:
+    explicit GPTQ(const nlohmann::json &quant_config)
+        : BaseQuantization(quant_config) {};
+
+    QuantScheme get_quant_scheme() const override {
+        return QuantScheme::GPTQ_W4A16;
+    };
+
+    int get_packing_num() const {
+        return 32 / get_or<int>("bits", 4);
+    }
+
+    int get_group_size() const {
+        return get_or<int>("group_size", 128);
+    }
+
+    std::vector<ParamDescriptor> get_param_layout(
+        size_t in_features, size_t out_features,
+        int split_dim, int tp_rank, int tp_size,
+        int tp_num_heads,
+        const infinicore::DataType &dtype,
+        bool bias) const override;
+
+    int get_fused_split_dim() const override { return 1; }
+
+    infinicore::Tensor forward(
+        const ParamsMap &params,
+        const infinicore::Tensor &input,
+        bool has_bias,
+        float alpha = 1.0f) const override;
+
+    std::vector<SplitParam> split_params(
+        const std::unordered_map<std::string, infinicore::nn::Parameter> &params,
+        const std::vector<SplitInfo> &splits,
+        int narrow_dim,
+        int tp_rank, int tp_size, int tp_num_heads) const override;
+
+    std::shared_ptr<BaseQuantization> process_weights_after_loading(
+        ParamsMap &params,
+        const infinicore::Device &device) const override;
+};
+
+} // namespace infinilm::quantization

--- a/csrc/layers/quantization/gptq_qy.cpp
+++ b/csrc/layers/quantization/gptq_qy.cpp
@@ -1,0 +1,259 @@
+#include "gptq_qy.hpp"
+#include "infinicore/ops.hpp"
+#include "infinicore/ops/linear_w4a16_gptq_qy.hpp"
+#include <optional>
+
+namespace infinilm::quantization {
+
+std::vector<ParamDescriptor> GPTQ_QY::get_param_layout(
+    size_t in_features, size_t out_features,
+    int split_dim, int tp_rank, int tp_size,
+    int /*tp_num_heads*/,
+    const infinicore::DataType &dtype,
+    bool bias) const {
+
+    // GPTQ_QY weight layout is transposed: qweight [in_features/2, out_features]
+    // ColumnParallel (split_dim=0, split output) → tp_dim=1
+    // RowParallel    (split_dim=1, split input)  → tp_dim=0
+    int gptq_tp_dim = (split_dim >= 0) ? (1 - split_dim) : -1;
+    int group_size = get_group_size();
+
+    std::vector<ParamDescriptor> descs;
+    descs.push_back({"qweight", {in_features / 2, out_features}, infinicore::DataType::U8, gptq_tp_dim, tp_rank, tp_size});
+    descs.push_back({"qzeros", {in_features / group_size, out_features}, dtype, gptq_tp_dim, tp_rank, tp_size});
+    descs.push_back({"scales", {in_features / group_size, out_features}, dtype, gptq_tp_dim, tp_rank, tp_size});
+    descs.push_back({"g_idx", {in_features}, infinicore::DataType::I32, -1, 0, 1});
+    if (bias) {
+        descs.push_back({"bias", {out_features}, dtype, -1, 0, 1});
+    }
+    return descs;
+}
+
+infinicore::Tensor GPTQ_QY::forward(
+    const ParamsMap &params,
+    const infinicore::Tensor &input,
+    bool has_bias,
+    float /*alpha*/) const {
+    auto input_contiguous = input->is_contiguous() ? input : input->contiguous();
+    auto qweight = params.at("qweight");
+    auto qzeros = params.at("qzeros");
+    auto scales = params.at("scales");
+
+    auto output = infinicore::op::linear_w4a16_gptq_qy(input_contiguous->contiguous(), qweight, qzeros, scales, 0, 4);
+
+    if (has_bias) {
+        auto bias = params.at("bias");
+        infinicore::op::add_(output, output, bias->as_strided(output->shape(), {0, 0, 1}));
+    }
+    return output;
+}
+
+std::vector<SplitParam> GPTQ_QY::split_params(
+    const std::unordered_map<std::string, infinicore::nn::Parameter> &params,
+    const std::vector<SplitInfo> &splits,
+    int /*narrow_dim*/,
+    int tp_rank, int tp_size, int tp_num_heads) const {
+
+    // GPTQ_QY parameters have output dimension on dim1.
+    int fused_dim = get_fused_split_dim();
+    std::vector<SplitParam> result;
+    auto qw_it = params.find("qweight");
+    auto qz_it = params.find("qzeros");
+    auto sc_it = params.find("scales");
+    auto gidx_it = params.find("g_idx");
+    auto bias_it = params.find("bias");
+
+    for (const auto &s : splits) {
+        result.push_back({s.prefix + ".qweight",
+                          infinicore::nn::Parameter(
+                              qw_it->second->narrow({{static_cast<size_t>(fused_dim), s.start, s.size}}),
+                              fused_dim, tp_rank, tp_size, s.num_shards)});
+        result.push_back({s.prefix + ".qzeros",
+                          infinicore::nn::Parameter(
+                              qz_it->second->narrow({{static_cast<size_t>(fused_dim), s.start, s.size}}),
+                              fused_dim, tp_rank, tp_size, s.num_shards)});
+        result.push_back({s.prefix + ".scales",
+                          infinicore::nn::Parameter(
+                              sc_it->second->narrow({{static_cast<size_t>(fused_dim), s.start, s.size}}),
+                              fused_dim, tp_rank, tp_size, s.num_shards)});
+        result.push_back({s.prefix + ".g_idx",
+                          infinicore::nn::Parameter(
+                              gidx_it->second->narrow({{0, 0, gidx_it->second->size(0)}}),
+                              0, 0, 1, 0)});
+        if (bias_it != params.end()) {
+            result.push_back({s.prefix + ".bias",
+                              infinicore::nn::Parameter(
+                                  bias_it->second->narrow({{0, s.start, s.size}}),
+                                  0, tp_rank, tp_size, s.num_shards)});
+        }
+    }
+    return result;
+}
+
+// ---- Conversion from GPTQ_W4A16 ----
+
+std::shared_ptr<BaseQuantization> GPTQ_QY::convert_from_gptq(
+    ParamsMap &params,
+    const infinicore::Device &device,
+    const nlohmann::json &quant_config) {
+
+    auto gptq_qy = std::make_shared<GPTQ_QY>(quant_config);
+    const int bits = gptq_qy->weight_bits();
+    const int values_per_int32 = 32 / bits;
+
+    const auto &original_qweight = params.at("qweight");
+    const auto &original_qzeros = params.at("qzeros");
+    const auto &original_scales = params.at("scales");
+    const auto &g_idx = params.at("g_idx");
+
+    {
+        const auto &shape = original_qweight->shape();
+        assert(shape.size() == 2);
+        size_t M = shape[0], N = shape[1];
+
+        auto weight_unpacked = unpack_int32_to_nibbles_3d_(original_qweight, bits);
+        auto weight_packed = combine_nibbles_last_dim_(weight_unpacked, M, values_per_int32, N);
+
+        size_t dimY = N;
+        size_t total_bytes = M * values_per_int32 * (N / 2);
+        size_t dimX = total_bytes / dimY;
+
+        assert(dimX * dimY == total_bytes && "Weight shape calculation mismatch");
+
+        params["qweight"] = make_tensor_from_host_(
+            weight_packed.data(), total_bytes * sizeof(uint8_t),
+            {dimX, dimY}, infinicore::DataType::U8, device);
+    }
+
+    {
+        const auto &shape = original_qzeros->shape();
+        assert(shape.size() == 2);
+        size_t P = shape[0], Q = shape[1];
+
+        auto zeros_fp32 = unpack_zeros_to_fp32_2d_(original_qzeros, bits);
+        auto zeros_fp16 = infinilm::detail::float_to_fp16_bits(zeros_fp32);
+
+        params["qzeros"] = make_tensor_from_host_(
+            zeros_fp16.data(), zeros_fp16.size() * sizeof(uint16_t),
+            {P, Q * static_cast<size_t>(values_per_int32)},
+            infinicore::DataType::F16, device);
+    }
+
+    {
+        auto scales_cpu = original_scales->to(infinicore::Device::Type::CPU);
+        size_t num_elements = scales_cpu->numel();
+        const void *raw_data = scales_cpu->data();
+
+        std::vector<uint16_t> scales_fp16(num_elements);
+        if (scales_cpu->dtype() == infinicore::DataType::F16) {
+            std::memcpy(scales_fp16.data(), raw_data, num_elements * sizeof(uint16_t));
+        } else if (scales_cpu->dtype() == infinicore::DataType::F32) {
+            std::vector<float> scales_fp32(num_elements);
+            std::memcpy(scales_fp32.data(), raw_data, num_elements * sizeof(float));
+            scales_fp16 = infinilm::detail::float_to_fp16_bits(scales_fp32);
+        } else {
+            spdlog::error("Unsupported scales dtype, expected F16 or F32");
+            assert(false && "Unsupported scales dtype");
+        }
+
+        params["scales"] = make_tensor_from_host_(
+            scales_fp16.data(), scales_fp16.size() * sizeof(uint16_t),
+            original_scales->shape(), infinicore::DataType::F16, device);
+    }
+
+    if (g_idx->numel() > 0) {
+        params["g_idx"] = g_idx->to(device);
+    }
+
+    return gptq_qy;
+}
+
+// ---- Private helpers ----
+
+std::vector<uint8_t> GPTQ_QY::unpack_int32_to_nibbles_3d_(const infinicore::Tensor &packed, int bits) {
+    assert(bits == 4 || bits == 8);
+    const int values_per_int32 = 32 / bits;
+
+    auto packed_cpu = packed->to(infinicore::Device::Type::CPU);
+    const int32_t *packed_host = reinterpret_cast<const int32_t *>(packed_cpu->data());
+
+    const auto &shape = packed->shape();
+    assert(shape.size() == 2);
+    size_t M = shape[0], N = shape[1];
+
+    std::vector<uint8_t> unpacked(M * values_per_int32 * N);
+
+    for (size_t i = 0; i < M; ++i) {
+        for (int k = 0; k < values_per_int32; ++k) {
+            for (size_t j = 0; j < N; ++j) {
+                int32_t val = packed_host[i * N + j];
+                uint8_t extracted = static_cast<uint8_t>((val >> (k * bits)) & ((1 << bits) - 1));
+                size_t idx = i * (values_per_int32 * N) + k * N + j;
+                unpacked[idx] = extracted;
+            }
+        }
+    }
+    return unpacked;
+}
+
+std::vector<uint8_t> GPTQ_QY::combine_nibbles_last_dim_(
+    const std::vector<uint8_t> &nibbles, size_t M, size_t K, size_t N) {
+    assert(N % 2 == 0 && "Last dimension must be even for nibble pairing");
+
+    std::vector<uint8_t> combined(M * K * (N / 2));
+    size_t out_idx = 0;
+
+    for (size_t i = 0; i < M; ++i) {
+        for (size_t k = 0; k < K; ++k) {
+            size_t row_base = i * (K * N) + k * N;
+            for (size_t j = 0; j < N; j += 2) {
+                uint8_t low = nibbles[row_base + j] & 0x0F;
+                uint8_t high = nibbles[row_base + j + 1] & 0x0F;
+                combined[out_idx++] = static_cast<uint8_t>((high << 4) | low);
+            }
+        }
+    }
+    return combined;
+}
+
+std::vector<float> GPTQ_QY::unpack_zeros_to_fp32_2d_(const infinicore::Tensor &packed_zeros, int bits) {
+    assert(bits == 4 || bits == 8);
+    const int values_per_int32 = 32 / bits;
+    const int mask = (1 << bits) - 1;
+
+    auto packed_cpu = packed_zeros->to(infinicore::Device::Type::CPU);
+    const int32_t *packed_host = reinterpret_cast<const int32_t *>(packed_cpu->data());
+
+    const auto &shape = packed_zeros->shape();
+    assert(shape.size() == 2);
+    size_t P = shape[0], Q = shape[1];
+
+    std::vector<float> result(P * Q * values_per_int32);
+    size_t out_idx = 0;
+
+    for (size_t p = 0; p < P; ++p) {
+        for (size_t q = 0; q < Q; ++q) {
+            int32_t val = packed_host[p * Q + q];
+            for (int k = 0; k < values_per_int32; ++k) {
+                uint8_t extracted = static_cast<uint8_t>((val >> (k * bits)) & mask);
+                int dequant_val = (static_cast<int>(extracted) + 1) & mask;
+                result[out_idx++] = static_cast<float>(dequant_val);
+            }
+        }
+    }
+    return result;
+}
+
+infinicore::Tensor GPTQ_QY::make_tensor_from_host_(const void *data, size_t bytes,
+                                                   const std::vector<size_t> &shape,
+                                                   infinicore::DataType dtype, const infinicore::Device &device) {
+    auto tensor = infinicore::Tensor::empty(shape, dtype, infinicore::Device::Type::CPU);
+    std::memcpy(reinterpret_cast<void *>(tensor->data()), data, bytes);
+
+    if (device != infinicore::Device::Type::CPU) {
+        return tensor->to(device);
+    }
+    return tensor;
+}
+
+} // namespace infinilm::quantization

--- a/csrc/layers/quantization/gptq_qy.hpp
+++ b/csrc/layers/quantization/gptq_qy.hpp
@@ -1,0 +1,139 @@
+#pragma once
+
+#include "base_quantization.hpp"
+#include "infinicore/tensor.hpp"
+#include <algorithm>
+#include <cassert>
+#include <cstring>
+#include <memory>
+#include <nlohmann/json.hpp>
+#include <spdlog/spdlog.h>
+#include <vector>
+
+namespace infinilm::detail {
+
+inline uint16_t fp32_to_fp16_bits(float value) {
+    union {
+        float f;
+        uint32_t u;
+    } f2u;
+    f2u.f = value;
+    uint32_t x = f2u.u;
+
+    uint32_t sign = (x >> 16) & 0x8000;
+    int32_t exp = ((x >> 23) & 0xFF) - 127;
+    uint32_t mantissa = x & 0x007FFFFF;
+
+    if (exp == 128) {
+        if (mantissa == 0) {
+            return static_cast<uint16_t>(sign | 0x7C00);
+        }
+        return static_cast<uint16_t>(sign | 0x7C00 | (mantissa >> 13));
+    }
+    if (exp > 15) {
+        return static_cast<uint16_t>(sign | 0x7C00);
+    }
+    if (exp < -14) {
+        if (exp < -24) {
+            return static_cast<uint16_t>(sign);
+        }
+        mantissa |= 0x00800000;
+        uint32_t shift = -exp - 14;
+        mantissa >>= shift;
+        if ((mantissa & 0x1000) && ((mantissa & 0x2FFF) != 0)) {
+            mantissa += 0x2000;
+        }
+        return static_cast<uint16_t>(sign | (mantissa >> 13));
+    }
+
+    uint32_t exp16 = static_cast<uint32_t>(exp + 15) << 10;
+    uint32_t mantissa16 = mantissa >> 13;
+    if ((mantissa & 0x1000) && ((mantissa & 0x2FFF) || (mantissa16 & 1))) {
+        mantissa16++;
+        if (mantissa16 == 0x400) {
+            exp16 += 0x400;
+            mantissa16 = 0;
+        }
+    }
+    return static_cast<uint16_t>(sign | exp16 | mantissa16);
+}
+
+inline std::vector<uint16_t> float_to_fp16_bits(const std::vector<float> &values) {
+    std::vector<uint16_t> result;
+    result.reserve(values.size());
+    for (float f : values) {
+        result.push_back(fp32_to_fp16_bits(f));
+    }
+    return result;
+}
+
+} // namespace infinilm::detail
+
+namespace infinilm::quantization {
+
+class GPTQ_QY : public BaseQuantization {
+public:
+    explicit GPTQ_QY(const nlohmann::json &quant_config)
+        : BaseQuantization(quant_config) {
+        int bits = weight_bits();
+        if (bits != 4) {
+            spdlog::warn("GPTQ_QY: bits={} not fully tested, expected 4", bits);
+        }
+    }
+
+    QuantScheme get_quant_scheme() const override {
+        return QuantScheme::GPTQ_W4A16_QY;
+    }
+
+    int get_packing_num() const {
+        return 32 / weight_bits();
+    }
+
+    int get_group_size() const {
+        return get_or<int>("group_size", 128);
+    }
+
+    int weight_bits() const { return get_or<int>("bits", 4); }
+    bool desc_act() const { return get_or<bool>("desc_act", false); }
+
+    // Parameter layout for GPTQ_QY (already converted format)
+    std::vector<ParamDescriptor> get_param_layout(
+        size_t in_features, size_t out_features,
+        int split_dim, int tp_rank, int tp_size,
+        int tp_num_heads,
+        const infinicore::DataType &dtype,
+        bool bias) const override;
+
+    int get_fused_split_dim() const override { return 1; }
+
+    infinicore::Tensor forward(
+        const ParamsMap &params,
+        const infinicore::Tensor &input,
+        bool has_bias,
+        float alpha = 1.0f) const override;
+
+    // Split fused linear parameters into named sub-parameters
+    std::vector<SplitParam> split_params(
+        const std::unordered_map<std::string, infinicore::nn::Parameter> &params,
+        const std::vector<SplitInfo> &splits,
+        int narrow_dim,
+        int tp_rank, int tp_size, int tp_num_heads) const override;
+
+    // Convert from GPTQ_W4A16 format and update params in-place.
+    // Returns a new GPTQ_QY quantization instance. Returns nullptr if
+    // the device is not QY.
+    static std::shared_ptr<BaseQuantization> convert_from_gptq(
+        ParamsMap &params,
+        const infinicore::Device &device,
+        const nlohmann::json &quant_config);
+
+private:
+    static std::vector<uint8_t> unpack_int32_to_nibbles_3d_(const infinicore::Tensor &packed, int bits);
+    static std::vector<uint8_t> combine_nibbles_last_dim_(const std::vector<uint8_t> &nibbles, size_t M, size_t K, size_t N);
+    static std::vector<float> unpack_zeros_to_fp32_2d_(const infinicore::Tensor &packed_zeros, int bits);
+    static infinicore::Tensor make_tensor_from_host_(const void *data, size_t bytes,
+                                                     const std::vector<size_t> &shape,
+                                                     infinicore::DataType dtype, const infinicore::Device &device);
+};
+
+} // namespace infinilm::quantization

--- a/csrc/layers/quantization/kv_quant.cpp
+++ b/csrc/layers/quantization/kv_quant.cpp
@@ -7,11 +7,11 @@ namespace infinilm {
 void KVQuantUtils::quantize(
     infinicore::Tensor &k,
     infinicore::Tensor &v,
-    infinicore::quantization::KVQuantAlgo algo,
+    infinilm::quantization::KVQuantAlgo algo,
     const infinicore::Tensor &k_scale,
     const infinicore::Tensor &v_scale) {
 
-    if (algo == infinicore::quantization::KVQuantAlgo::NONE) {
+    if (algo == infinilm::quantization::KVQuantAlgo::NONE) {
         return;
     }
 
@@ -26,12 +26,12 @@ void KVQuantUtils::quantize(
 void KVQuantUtils::dequantize(
     infinicore::Tensor &k,
     infinicore::Tensor &v,
-    infinicore::quantization::KVQuantAlgo algo,
+    infinilm::quantization::KVQuantAlgo algo,
     const infinicore::Tensor &k_scale,
     const infinicore::Tensor &v_scale,
     const infinicore::Tensor &reference) {
 
-    if (algo == infinicore::quantization::KVQuantAlgo::NONE) {
+    if (algo == infinilm::quantization::KVQuantAlgo::NONE) {
         return; // 无需反量化
     }
 

--- a/csrc/layers/quantization/kv_quant.hpp
+++ b/csrc/layers/quantization/kv_quant.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "infinicore/quantization.hpp"
+#include "quantization_scheme.hpp"
 #include "infinicore/tensor.hpp"
 #include <utility>
 
@@ -19,7 +19,7 @@ public:
     static void quantize(
         infinicore::Tensor &k,
         infinicore::Tensor &v,
-        infinicore::quantization::KVQuantAlgo algo,
+        infinilm::quantization::KVQuantAlgo algo,
         const infinicore::Tensor &k_scale,
         const infinicore::Tensor &v_scale);
 
@@ -35,7 +35,7 @@ public:
     static void dequantize(
         infinicore::Tensor &k,
         infinicore::Tensor &v,
-        infinicore::quantization::KVQuantAlgo algo,
+        infinilm::quantization::KVQuantAlgo algo,
         const infinicore::Tensor &k_scale,
         const infinicore::Tensor &v_scale,
         const infinicore::Tensor &reference);

--- a/csrc/layers/quantization/none_quantization.cpp
+++ b/csrc/layers/quantization/none_quantization.cpp
@@ -1,0 +1,65 @@
+#include "none_quantization.hpp"
+#include "infinicore/ops/linear.hpp"
+#include <optional>
+
+namespace infinilm::quantization {
+
+std::vector<ParamDescriptor> NoneQuantization::get_param_layout(
+    size_t in_features, size_t out_features,
+    int split_dim, int tp_rank, int tp_size,
+    int /*tp_num_heads*/,
+    const infinicore::DataType &dtype,
+    bool bias) const {
+
+    std::vector<ParamDescriptor> descs;
+    descs.push_back({"weight", {out_features, in_features}, dtype, split_dim, tp_rank, tp_size});
+    if (bias) {
+        descs.push_back({"bias", {out_features}, dtype, split_dim >= 0 ? 0 : -1,
+                         split_dim >= 0 ? tp_rank : 0, split_dim >= 0 ? tp_size : 1});
+    }
+    return descs;
+}
+
+infinicore::Tensor NoneQuantization::forward(
+    const ParamsMap &params,
+    const infinicore::Tensor &input,
+    bool has_bias,
+    float alpha) const {
+
+    auto input_contiguous = input->is_contiguous() ? input : input->contiguous();
+    auto weight = params.at("weight");
+
+    std::optional<infinicore::Tensor> bias_opt;
+    if (has_bias) {
+        bias_opt = params.at("bias");
+    }
+
+    return infinicore::op::linear(input_contiguous->contiguous(), weight->contiguous(), bias_opt, alpha);
+}
+
+std::vector<SplitParam> NoneQuantization::split_params(
+    const std::unordered_map<std::string, infinicore::nn::Parameter> &params,
+    const std::vector<SplitInfo> &splits,
+    int narrow_dim,
+    int tp_rank, int tp_size, int /*tp_num_heads*/) const {
+
+    std::vector<SplitParam> result;
+    auto weight_it = params.find("weight");
+    auto bias_it = params.find("bias");
+
+    for (const auto &s : splits) {
+        result.push_back({s.prefix + ".weight",
+                          infinicore::nn::Parameter(
+                              weight_it->second->narrow({{static_cast<size_t>(narrow_dim), s.start, s.size}}),
+                              narrow_dim, tp_rank, tp_size, s.num_shards)});
+        if (bias_it != params.end()) {
+            result.push_back({s.prefix + ".bias",
+                              infinicore::nn::Parameter(
+                                  bias_it->second->narrow({{0, s.start, s.size}}),
+                                  0, tp_rank, tp_size, s.num_shards)});
+        }
+    }
+    return result;
+}
+
+} // namespace infinilm::quantization

--- a/csrc/layers/quantization/none_quantization.hpp
+++ b/csrc/layers/quantization/none_quantization.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "base_quantization.hpp"
+namespace infinilm::quantization {
+
+class NoneQuantization : public BaseQuantization {
+public:
+    explicit NoneQuantization(const nlohmann::json &quant_config)
+        : BaseQuantization(quant_config) {};
+
+    QuantScheme get_quant_scheme() const override {
+        return QuantScheme::NONE;
+    };
+
+    std::vector<ParamDescriptor> get_param_layout(
+        size_t in_features, size_t out_features,
+        int split_dim, int tp_rank, int tp_size,
+        int tp_num_heads,
+        const infinicore::DataType &dtype,
+        bool bias) const override;
+
+    infinicore::Tensor forward(
+        const ParamsMap &params,
+        const infinicore::Tensor &input,
+        bool has_bias,
+        float alpha = 1.0f) const override;
+
+    std::vector<SplitParam> split_params(
+        const std::unordered_map<std::string, infinicore::nn::Parameter> &params,
+        const std::vector<SplitInfo> &splits,
+        int narrow_dim,
+        int tp_rank, int tp_size, int tp_num_heads) const override;
+};
+
+} // namespace infinilm::quantization

--- a/csrc/layers/quantization/quantization.hpp
+++ b/csrc/layers/quantization/quantization.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "awq.hpp"
+#include "base_quantization.hpp"
+#include "compressed_tensors.hpp"
+#include "gptq.hpp"
+#include "gptq_qy.hpp"
+#include "none_quantization.hpp"
+#include "quantization_scheme.hpp"

--- a/csrc/layers/quantization/quantization_scheme.hpp
+++ b/csrc/layers/quantization/quantization_scheme.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+namespace infinilm::quantization {
+
+enum class QuantScheme {
+    NONE,
+    COMPRESSED_TENSOR_W8A8I8,
+    AWQ_W4A16,
+    GPTQ_W4A16_QY,
+    GPTQ_W4A16,
+};
+
+enum class KVQuantAlgo {
+    NONE,
+    INT8,
+};
+
+} // namespace infinilm::quantization

--- a/csrc/models/glm4/glm4_attention.cpp
+++ b/csrc/models/glm4/glm4_attention.cpp
@@ -40,27 +40,15 @@ Glm4Attention::Glm4Attention(std::shared_ptr<infinilm::config::ModelConfig> mode
     scaling_ = 1.0f / std::sqrt(static_cast<float>(head_dim_));
 
     // Linear layer initialization
-    auto quant_scheme = this->model_config_->get_quant_scheme();
-    switch (quant_scheme) {
-    case infinicore::quantization::QuantScheme::COMPRESSED_TENSOR_W8A8I8:
-        INFINILM_QKV_LINEAR_W8A8_INIT(qkv_proj, "q_proj", "k_proj", "v_proj", hidden_size_, head_dim_, model_config_->get<size_t>("num_attention_heads"), model_config_->get<size_t>("num_key_value_heads"), this->model_config_->get_quantization_method(), use_bias_, dtype, device, g_rank_info);
-        INFINICORE_NN_MODULE_INIT(o_proj, model_config_->get<size_t>("num_attention_heads") * head_dim_, hidden_size_, this->model_config_->get_quantization_method(), use_output_bias_, dtype, device, tp_rank, tp_size, g_rank_info.comm);
-        break;
-    case infinicore::quantization::QuantScheme::AWQ_W4A16: {
-        INFINILM_QKV_LINEAR_W4A16AWQ_INIT(qkv_proj, "q_proj", "k_proj", "v_proj", hidden_size_, head_dim_, model_config_->get<size_t>("num_attention_heads"), model_config_->get<size_t>("num_key_value_heads"), this->model_config_->get_quantization_method(), use_bias_, dtype, device, g_rank_info);
-        INFINICORE_NN_MODULE_INIT(o_proj, model_config_->get<size_t>("num_attention_heads") * head_dim_, hidden_size_, this->model_config_->get_quantization_method(), use_output_bias_, dtype, device, tp_rank, tp_size, g_rank_info.comm);
-        break;
-    }
-    case infinicore::quantization::QuantScheme::GPTQ_W4A16_QY: {
-        INFINILM_QKV_LINEAR_W4A16GPTQ_INIT(qkv_proj, "q_proj", "k_proj", "v_proj", hidden_size_, head_dim_, model_config_->get<size_t>("num_attention_heads"), model_config_->get<size_t>("num_key_value_heads"), this->model_config_->get_quantization_method(), use_bias_, dtype, device, g_rank_info);
-        INFINICORE_NN_MODULE_INIT(o_proj, model_config_->get<size_t>("num_attention_heads") * head_dim_, hidden_size_, this->model_config_->get_quantization_method(), use_output_bias_, dtype, device, tp_rank, tp_size, g_rank_info.comm);
-        break;
-    }
-    default:
-        INFINILM_QKV_LINEAR_INIT(qkv_proj, "q_proj", "k_proj", "v_proj", hidden_size_, head_dim_, model_config_->get<size_t>("num_attention_heads"), model_config_->get<size_t>("num_key_value_heads"), this->model_config_->get_quantization_method(), use_bias_, dtype, device, g_rank_info);
-        INFINICORE_NN_MODULE_INIT(o_proj, model_config_->get<size_t>("num_attention_heads") * head_dim_, hidden_size_, this->model_config_->get_quantization_method(), use_output_bias_, dtype, device, tp_rank, tp_size, g_rank_info.comm);
-        break;
-    }
+    auto quantization_method = model_config->get_quantization_method();
+    auto register_fn = [this](const std::string &n, infinicore::nn::Parameter p) { this->register_parameter(n, std::move(p)); };
+    qkv_proj_ = std::make_shared<layers::linear::QKVParallelLinear>(
+        hidden_size_, head_dim_, model_config_->get<size_t>("num_attention_heads"), model_config_->get<size_t>("num_key_value_heads"),
+        "q_proj", "k_proj", "v_proj", register_fn,
+        quantization_method, use_bias_, dtype, device, g_rank_info);
+    o_proj_ = this->register_module<layers::linear::RowParallelLinear>(
+        "o_proj", model_config_->get<size_t>("num_attention_heads") * head_dim_, hidden_size_, quantization_method,
+        use_output_bias_, dtype, device, tp_rank, tp_size, g_rank_info.comm);
 
     // RoPE initialization
     attention_backend_ = infinilm::global_state::get_infinilm_config().attention_backend;
@@ -72,11 +60,7 @@ Glm4Attention::Glm4Attention(std::shared_ptr<infinilm::config::ModelConfig> mode
         kv_cache_k_scale_, kv_cache_v_scale_, attention_backend_);
 
     // KV Cache quantization scale initialization
-    auto kv_quant_scheme = infinilm::global_state::get_infinilm_config().model_config->get_kv_quant_scheme();
-    if (kv_quant_scheme == infinicore::quantization::KVQuantAlgo::INT8) {
-        INFINICORE_NN_PARAMETER_INIT(kv_cache_k_scale, ({1}, infinicore::DataType::F32, device, 0, 0, 1));
-        INFINICORE_NN_PARAMETER_INIT(kv_cache_v_scale, ({1}, infinicore::DataType::F32, device, 0, 0, 1));
-    }
+    infinilm::layers::attention::init_kv_cache_quant_params(register_fn, device, kv_cache_k_scale_, kv_cache_v_scale_);
 }
 
 infinicore::Tensor Glm4Attention::forward(const infinicore::Tensor &positions,

--- a/csrc/models/glm4/glm4_attention.hpp
+++ b/csrc/models/glm4/glm4_attention.hpp
@@ -20,8 +20,8 @@ public:
 
 protected:
     // Operator layers
-    INFINICORE_NN_MODULE(infinilm::layers::linear::QKVParallelLinear, qkv_proj);
-    INFINICORE_NN_MODULE(infinilm::layers::linear::RowParallelLinear, o_proj);
+    std::shared_ptr<infinilm::layers::linear::QKVParallelLinear> qkv_proj_;
+    std::shared_ptr<infinilm::layers::linear::RowParallelLinear> o_proj_;
     std::shared_ptr<infinilm::layers::attention::AttentionLayer> attn_;
     ::infinilm::backends::AttentionBackend attention_backend_;
     std::shared_ptr<infinicore::nn::RoPE> rotary_emb_;

--- a/csrc/models/infinilm_model.cpp
+++ b/csrc/models/infinilm_model.cpp
@@ -2,6 +2,8 @@
 #include "../backends/attention_backends.hpp"
 #include "../cache/kv_cache.hpp"
 #include "../global_state/global_state.hpp"
+#include "../layers/attention/attention.hpp"
+#include "../layers/mlp/mlp.hpp"
 #include <stdexcept>
 
 namespace infinilm {
@@ -91,12 +93,19 @@ void InfinilmModel::process_weights_after_loading() {
 }
 
 void InfinilmModel::process_weights_recursive_(infinicore::nn::Module *module) {
-    auto submodules = module->modules_dict();
-    for (auto &[name, sub] : submodules) {
-        process_weights_recursive_(sub);
+    for (const auto &[name, sub] : module->children()) {
+        process_weights_recursive_(sub.get());
     }
-    if (auto *linear = dynamic_cast<infinicore::nn::BaseLinear *>(module)) {
+    // Process BaseLinear (o_proj, down_proj, lm_head, etc.)
+    if (auto *linear = dynamic_cast<infinilm::nn::BaseLinear *>(module)) {
         linear->process_weights_after_loading();
+    }
+    // Process fused linear held by Attention/MLP as non-registered members
+    if (auto *attn = dynamic_cast<infinilm::layers::attention::Attention *>(module)) {
+        attn->process_fused_weights_after_loading();
+    }
+    if (auto *mlp = dynamic_cast<infinilm::layers::mlp::MLP *>(module)) {
+        mlp->process_fused_weights_after_loading();
     }
 }
 

--- a/csrc/models/infinilm_model.hpp
+++ b/csrc/models/infinilm_model.hpp
@@ -3,7 +3,7 @@
 #include "../backends/attention_backends.hpp"
 #include "../cache/cache.hpp"
 #include "../config/model_config.hpp"
-#include "infinicore/nn/linear.hpp"
+#include "../layers/linear/linear.hpp"
 #include "infinicore/nn/module.hpp"
 #include "infinicore/tensor.hpp"
 

--- a/csrc/models/llama_legacy/legacy_fused_linear.cpp
+++ b/csrc/models/llama_legacy/legacy_fused_linear.cpp
@@ -1,0 +1,396 @@
+/**
+ * @deprecated Legacy fused linear implementations based on InfiniCore.
+ * Removal target: v0.2.0 (Q2 2026)
+ */
+
+#include "legacy_fused_linear.hpp"
+
+#include <spdlog/spdlog.h>
+
+namespace infinilm::layers::linear {
+// DEPRECATED BEGIN
+// ---------------------------------------------------------
+// LegacyQKVParallelLinear
+// ---------------------------------------------------------
+LegacyQKVParallelLinear::LegacyQKVParallelLinear(size_t hidden_size,
+                                                 size_t head_dim,
+                                                 size_t num_q_head,
+                                                 size_t num_kv_head,
+                                                 bool bias,
+                                                 const infinicore::DataType &dtype,
+                                                 const infinicore::Device &device,
+                                                 engine::distributed::RankInfo rank_info)
+    : LegacyQKVParallelLinear(hidden_size,
+                              head_dim, head_dim, head_dim,
+                              num_q_head, num_kv_head, num_kv_head,
+                              bias, bias, bias,
+                              dtype, device, rank_info) {}
+
+LegacyQKVParallelLinear::LegacyQKVParallelLinear(size_t hidden_size,
+                                                 size_t q_dim, size_t k_dim, size_t v_dim,
+                                                 size_t num_q_head, size_t num_k_head, size_t num_v_head,
+                                                 bool q_bias, bool k_bias, bool v_bias,
+                                                 const infinicore::DataType &dtype,
+                                                 const infinicore::Device &device,
+                                                 engine::distributed::RankInfo rank_info)
+    : infinicore::nn::ColumnParallelLinear(
+          hidden_size,
+          num_q_head * q_dim + num_k_head * k_dim + num_v_head * v_dim,
+          (q_bias || k_bias || v_bias),
+          dtype,
+          device,
+          rank_info.tp_rank,
+          rank_info.tp_size),
+      q_dim_(q_dim),
+      k_dim_(k_dim),
+      v_dim_(v_dim),
+      num_q_head_(num_q_head),
+      num_k_head_(num_k_head),
+      num_v_head_(num_v_head),
+      q_bias_(q_bias),
+      k_bias_(k_bias),
+      v_bias_(v_bias) {
+    if (num_q_head % tp_size_ != 0 || num_k_head % tp_size_ != 0 || num_v_head % tp_size_ != 0) {
+        throw std::runtime_error("LegacyQKVParallelLinear: num_[q|k|v]_head must be divisible by tp_size");
+    }
+
+    if ((q_bias_ != k_bias_) || (k_bias_ != v_bias_)) {
+        throw std::runtime_error("q_bias, k_bias, v_bias must all match");
+    }
+
+    q_out_size_ = num_q_head_ * q_dim_ / tp_size_;
+    k_out_size_ = num_k_head_ * k_dim_ / tp_size_;
+    v_out_size_ = num_v_head_ * v_dim_ / tp_size_;
+}
+
+LegacyQKVParallelLinear::LegacyQKVParallelLinear(size_t hidden_size,
+                                                 size_t head_dim,
+                                                 size_t num_q_head,
+                                                 size_t num_kv_head,
+                                                 std::shared_ptr<infinicore::quantization::BaseQuantization> quantization,
+                                                 bool bias,
+                                                 const infinicore::DataType &dtype,
+                                                 const infinicore::Device &device,
+                                                 engine::distributed::RankInfo rank_info)
+    : LegacyQKVParallelLinear(hidden_size,
+                              head_dim, head_dim, head_dim,
+                              num_q_head, num_kv_head, num_kv_head,
+                              bias, bias, bias,
+                              quantization,
+                              dtype, device, rank_info) {}
+
+LegacyQKVParallelLinear::LegacyQKVParallelLinear(size_t hidden_size,
+                                                 size_t q_dim, size_t k_dim, size_t v_dim,
+                                                 size_t num_q_head, size_t num_k_head, size_t num_v_head,
+                                                 bool q_bias, bool k_bias, bool v_bias,
+                                                 std::shared_ptr<infinicore::quantization::BaseQuantization> quantization,
+                                                 const infinicore::DataType &dtype,
+                                                 const infinicore::Device &device,
+                                                 engine::distributed::RankInfo rank_info)
+    : infinicore::nn::ColumnParallelLinear(
+          hidden_size,
+          calculate_out_feature_size(num_q_head, q_dim, num_k_head, k_dim, num_v_head, v_dim, rank_info),
+          quantization,
+          (q_bias || k_bias || v_bias),
+          dtype,
+          device,
+          rank_info.tp_rank,
+          rank_info.tp_size),
+      q_dim_(q_dim),
+      k_dim_(k_dim),
+      v_dim_(v_dim),
+      num_q_head_(num_q_head),
+      num_k_head_(num_k_head),
+      num_v_head_(num_v_head),
+      q_bias_(q_bias),
+      k_bias_(k_bias),
+      v_bias_(v_bias),
+      num_kv_head_replicas_(calculate_kv_replicas(num_k_head, rank_info.tp_size)) {
+
+    if ((q_bias_ != k_bias_) || (k_bias_ != v_bias_)) {
+        throw std::runtime_error("q_bias, k_bias, v_bias must all match");
+    }
+
+    q_out_size_ = num_q_head_ * q_dim_ / tp_size_;
+    k_out_size_ = num_kv_head_replicas_ * num_k_head_ * k_dim_ / tp_size_;
+    v_out_size_ = num_kv_head_replicas_ * num_v_head_ * v_dim_ / tp_size_;
+}
+
+std::tuple<infinicore::Tensor, infinicore::Tensor, infinicore::Tensor>
+LegacyQKVParallelLinear::forward_split(infinicore::Tensor &input) {
+    auto output = this->forward(input);
+
+    auto q_out = output->narrow({{2, 0, q_out_size_}});
+    auto k_out = output->narrow({{2, q_out_size_, k_out_size_}});
+    auto v_out = output->narrow({{2, q_out_size_ + k_out_size_, v_out_size_}});
+
+    return std::make_tuple(q_out, k_out, v_out);
+}
+
+infinicore::nn::Parameter LegacyQKVParallelLinear::get_q_weight() const {
+    return infinicore::nn::Parameter(
+        weight_->narrow({{0, 0, q_out_size_}}),
+        0, tp_rank_, tp_size_);
+}
+
+infinicore::nn::Parameter LegacyQKVParallelLinear::get_k_weight() const {
+    return infinicore::nn::Parameter(
+        weight_->narrow({{0, q_out_size_, k_out_size_}}),
+        0, tp_rank_, tp_size_, num_k_head_);
+}
+
+infinicore::nn::Parameter LegacyQKVParallelLinear::get_v_weight() const {
+    return infinicore::nn::Parameter(
+        weight_->narrow({{0, q_out_size_ + k_out_size_, v_out_size_}}),
+        0, tp_rank_, tp_size_, num_v_head_);
+}
+
+infinicore::nn::Parameter LegacyQKVParallelLinear::get_q_weight_scale() const {
+    return infinicore::nn::Parameter(
+        weight_scale_->narrow({{0, 0, q_out_size_}}), 0, tp_rank_, tp_size_);
+}
+
+infinicore::nn::Parameter LegacyQKVParallelLinear::get_k_weight_scale() const {
+    return infinicore::nn::Parameter(
+        weight_scale_->narrow({{0, q_out_size_, k_out_size_}}),
+        0, tp_rank_, tp_size_, num_k_head_);
+}
+
+infinicore::nn::Parameter LegacyQKVParallelLinear::get_v_weight_scale() const {
+    return infinicore::nn::Parameter(
+        weight_scale_->narrow({{0, q_out_size_ + k_out_size_, v_out_size_}}),
+        0, tp_rank_, tp_size_, num_k_head_);
+}
+
+infinicore::nn::Parameter LegacyQKVParallelLinear::get_q_weight_awq(int scaling_factor) const {
+    return infinicore::nn::Parameter(
+        weight_->narrow({{1, 0, q_out_size_ / scaling_factor}}),
+        1, tp_rank_, tp_size_);
+}
+
+infinicore::nn::Parameter LegacyQKVParallelLinear::get_k_weight_awq(int scaling_factor) const {
+    return infinicore::nn::Parameter(
+        weight_->narrow({{1, q_out_size_ / scaling_factor, k_out_size_ / scaling_factor}}),
+        1, tp_rank_, tp_size_, num_k_head_);
+}
+
+infinicore::nn::Parameter LegacyQKVParallelLinear::get_v_weight_awq(int scaling_factor) const {
+    return infinicore::nn::Parameter(
+        weight_->narrow({{1, (q_out_size_ + k_out_size_) / scaling_factor, v_out_size_ / scaling_factor}}),
+        1, tp_rank_, tp_size_, num_k_head_);
+}
+
+infinicore::nn::Parameter LegacyQKVParallelLinear::get_q_weight_scale_awq(int scaling_factor) const {
+    return infinicore::nn::Parameter(
+        weight_scale_->narrow({{1, 0, q_out_size_ / scaling_factor}}), 1, tp_rank_, tp_size_);
+}
+
+infinicore::nn::Parameter LegacyQKVParallelLinear::get_k_weight_scale_awq(int scaling_factor) const {
+    return infinicore::nn::Parameter(
+        weight_scale_->narrow({{1, q_out_size_ / scaling_factor, k_out_size_ / scaling_factor}}),
+        1, tp_rank_, tp_size_, num_k_head_);
+}
+
+infinicore::nn::Parameter LegacyQKVParallelLinear::get_v_weight_scale_awq(int scaling_factor) const {
+    return infinicore::nn::Parameter(
+        weight_scale_->narrow({{1, (q_out_size_ + k_out_size_) / scaling_factor, v_out_size_ / scaling_factor}}),
+        1, tp_rank_, tp_size_, num_k_head_);
+}
+
+infinicore::nn::Parameter LegacyQKVParallelLinear::get_q_weight_zeros_awq(int scaling_factor) const {
+    return infinicore::nn::Parameter(
+        weight_zeros_->narrow({{1, 0, q_out_size_ / scaling_factor}}), 1, tp_rank_, tp_size_);
+}
+
+infinicore::nn::Parameter LegacyQKVParallelLinear::get_k_weight_zeros_awq(int scaling_factor) const {
+    return infinicore::nn::Parameter(
+        weight_zeros_->narrow({{1, q_out_size_ / scaling_factor, k_out_size_ / scaling_factor}}),
+        1, tp_rank_, tp_size_, num_k_head_);
+}
+
+infinicore::nn::Parameter LegacyQKVParallelLinear::get_v_weight_zeros_awq(int scaling_factor) const {
+    return infinicore::nn::Parameter(
+        weight_zeros_->narrow({{1, (q_out_size_ + k_out_size_) / scaling_factor, v_out_size_ / scaling_factor}}),
+        1, tp_rank_, tp_size_, num_k_head_);
+}
+
+infinicore::nn::Parameter LegacyQKVParallelLinear::get_q_weight_zeros() const {
+    return infinicore::nn::Parameter(
+        weight_zeros_->narrow({{0, 0, q_out_size_}}), 0, tp_rank_, tp_size_);
+}
+
+infinicore::nn::Parameter LegacyQKVParallelLinear::get_k_weight_zeros() const {
+    return infinicore::nn::Parameter(
+        weight_zeros_->narrow({{0, q_out_size_, k_out_size_}}),
+        0, tp_rank_, tp_size_, num_k_head_);
+}
+
+infinicore::nn::Parameter LegacyQKVParallelLinear::get_v_weight_zeros() const {
+    return infinicore::nn::Parameter(
+        weight_zeros_->narrow({{0, q_out_size_ + k_out_size_, v_out_size_}}),
+        0, tp_rank_, tp_size_, num_k_head_);
+}
+
+infinicore::nn::Parameter LegacyQKVParallelLinear::get_q_bias() const {
+    if (!q_bias_) {
+        return infinicore::nn::Parameter();
+    }
+    return infinicore::nn::Parameter(
+        bias_->narrow({{0, 0, q_out_size_}}),
+        0, tp_rank_, tp_size_);
+}
+
+infinicore::nn::Parameter LegacyQKVParallelLinear::get_k_bias() const {
+    if (!k_bias_) {
+        return infinicore::nn::Parameter();
+    }
+    return infinicore::nn::Parameter(
+        bias_->narrow({{0, q_out_size_, k_out_size_}}),
+        0, tp_rank_, tp_size_);
+}
+
+infinicore::nn::Parameter LegacyQKVParallelLinear::get_v_bias() const {
+    if (!v_bias_) {
+        return infinicore::nn::Parameter();
+    }
+    return infinicore::nn::Parameter(
+        bias_->narrow({{0, q_out_size_ + k_out_size_, v_out_size_}}),
+        0, tp_rank_, tp_size_);
+}
+
+infinicore::nn::Parameter LegacyQKVParallelLinear::get_q_g_idx_gptq() const {
+    return infinicore::nn::Parameter(gidx_->narrow({{0, 0, in_features_ / tp_size_}}), 0, tp_rank_, tp_size_);
+}
+
+infinicore::nn::Parameter LegacyQKVParallelLinear::get_k_g_idx_gptq() const {
+    return infinicore::nn::Parameter(gidx_->narrow({{0, 0, in_features_ / tp_size_}}), 0, tp_rank_, tp_size_, num_k_head_);
+}
+
+infinicore::nn::Parameter LegacyQKVParallelLinear::get_v_g_idx_gptq() const {
+    return infinicore::nn::Parameter(gidx_->narrow({{0, 0, in_features_ / tp_size_}}), 0, tp_rank_, tp_size_, num_k_head_);
+}
+
+bool LegacyQKVParallelLinear::has_q_bias() const { return q_bias_; }
+bool LegacyQKVParallelLinear::has_k_bias() const { return k_bias_; }
+bool LegacyQKVParallelLinear::has_v_bias() const { return v_bias_; }
+
+// ---------------------------------------------------------
+// LegacyGateUpParallelLinear
+// ---------------------------------------------------------
+LegacyGateUpParallelLinear::LegacyGateUpParallelLinear(size_t hidden_size, size_t intermediate_size, bool bias,
+                                                       const infinicore::DataType &dtype, const infinicore::Device &device,
+                                                       engine::distributed::RankInfo rank_info)
+    : LegacyGateUpParallelLinear(hidden_size, intermediate_size, bias, bias, dtype, device, rank_info) {
+}
+
+LegacyGateUpParallelLinear::LegacyGateUpParallelLinear(size_t hidden_size, size_t intermediate_size, bool gate_bias, bool up_bias,
+                                                       const infinicore::DataType &dtype, const infinicore::Device &device,
+                                                       engine::distributed::RankInfo rank_info)
+    : infinicore::nn::ColumnParallelLinear(hidden_size, intermediate_size * 2, gate_bias || up_bias, dtype, device, rank_info.tp_rank, rank_info.tp_size), gate_bias_(gate_bias), up_bias_(up_bias) {
+    if (gate_bias_ != up_bias_) {
+        throw std::runtime_error("Not supported yet: gate_bias and up_bias should be given at the same time");
+    }
+}
+
+LegacyGateUpParallelLinear::LegacyGateUpParallelLinear(size_t hidden_size, size_t intermediate_size, std::shared_ptr<infinicore::quantization::BaseQuantization> quantization, bool bias,
+                                                       const infinicore::DataType &dtype, const infinicore::Device &device,
+                                                       engine::distributed::RankInfo rank_info)
+    : LegacyGateUpParallelLinear(hidden_size, intermediate_size, bias, bias, quantization, dtype, device, rank_info) {
+}
+
+LegacyGateUpParallelLinear::LegacyGateUpParallelLinear(size_t hidden_size, size_t intermediate_size, bool gate_bias, bool up_bias,
+                                                       std::shared_ptr<infinicore::quantization::BaseQuantization> quantization,
+                                                       const infinicore::DataType &dtype, const infinicore::Device &device,
+                                                       engine::distributed::RankInfo rank_info)
+    : infinicore::nn::ColumnParallelLinear(hidden_size, intermediate_size * 2, quantization, gate_bias || up_bias, dtype, device, rank_info.tp_rank, rank_info.tp_size), gate_bias_(gate_bias), up_bias_(up_bias) {
+    if (gate_bias_ != up_bias_) {
+        throw std::runtime_error("Not supported yet: gate_bias and up_bias should be given at the same time");
+    }
+}
+
+std::tuple<infinicore::Tensor, infinicore::Tensor> LegacyGateUpParallelLinear::forward_split(infinicore::Tensor &input) {
+    auto output = this->forward(input);
+    auto cols = output->shape()[2];
+    auto gate_output = output->narrow({{2, 0, cols / 2}});
+    auto up_output = output->narrow({{2, cols / 2, cols / 2}});
+    return std::make_tuple(gate_output, up_output);
+}
+
+infinicore::nn::Parameter LegacyGateUpParallelLinear::get_gate_weight() const {
+    return infinicore::nn::Parameter(weight_->narrow({{0, 0, weight_->size(0) / 2}}), 0, tp_rank_, tp_size_);
+}
+
+infinicore::nn::Parameter LegacyGateUpParallelLinear::get_gate_bias() const {
+    if (!gate_bias_) {
+        return infinicore::nn::Parameter();
+    } else {
+        return infinicore::nn::Parameter(bias_->narrow({{0, 0, bias_->size(0) / 2}}), 0, tp_rank_, tp_size_);
+    }
+}
+
+infinicore::nn::Parameter LegacyGateUpParallelLinear::get_up_weight() const {
+    return infinicore::nn::Parameter(weight_->narrow({{0, weight_->size(0) / 2, weight_->size(0) / 2}}), 0, tp_rank_, tp_size_);
+}
+
+infinicore::nn::Parameter LegacyGateUpParallelLinear::get_up_bias() const {
+    if (!up_bias_) {
+        return infinicore::nn::Parameter();
+    } else {
+        return infinicore::nn::Parameter(bias_->narrow({{0, bias_->size(0) / 2, bias_->size(0) / 2}}),
+                                         0, tp_rank_, tp_size_);
+    }
+}
+
+infinicore::nn::Parameter LegacyGateUpParallelLinear::get_gate_weight_scale() const {
+    return infinicore::nn::Parameter(weight_scale_->narrow({{0, 0, weight_scale_->size(0) / 2}}), 0, tp_rank_, tp_size_);
+}
+
+infinicore::nn::Parameter LegacyGateUpParallelLinear::get_up_weight_scale() const {
+    return infinicore::nn::Parameter(weight_scale_->narrow({{0, weight_scale_->size(0) / 2, weight_scale_->size(0) / 2}}), 0, tp_rank_, tp_size_);
+}
+
+infinicore::nn::Parameter LegacyGateUpParallelLinear::get_gate_weight_zeros() const {
+    return infinicore::nn::Parameter(weight_zeros_->narrow({{0, 0, weight_zeros_->size(0) / 2}}), 0, tp_rank_, tp_size_);
+}
+
+infinicore::nn::Parameter LegacyGateUpParallelLinear::get_up_weight_zeros() const {
+    return infinicore::nn::Parameter(weight_zeros_->narrow({{0, weight_zeros_->size(0) / 2, weight_zeros_->size(0) / 2}}), 0, tp_rank_, tp_size_);
+}
+
+bool LegacyGateUpParallelLinear::has_gate_bias() const { return gate_bias_; }
+bool LegacyGateUpParallelLinear::has_up_bias() const { return up_bias_; }
+
+infinicore::nn::Parameter LegacyGateUpParallelLinear::get_gate_weight_awq() const {
+    return infinicore::nn::Parameter(weight_->narrow({{1, 0, weight_->size(1) / 2}}), 1, tp_rank_, tp_size_);
+}
+
+infinicore::nn::Parameter LegacyGateUpParallelLinear::get_up_weight_awq() const {
+    return infinicore::nn::Parameter(weight_->narrow({{1, weight_->size(1) / 2, weight_->size(1) / 2}}), 1, tp_rank_, tp_size_);
+}
+
+infinicore::nn::Parameter LegacyGateUpParallelLinear::get_gate_weight_scale_awq() const {
+    return infinicore::nn::Parameter(weight_scale_->narrow({{1, 0, weight_scale_->size(1) / 2}}), 1, tp_rank_, tp_size_);
+}
+
+infinicore::nn::Parameter LegacyGateUpParallelLinear::get_up_weight_scale_awq() const {
+    return infinicore::nn::Parameter(weight_scale_->narrow({{1, weight_scale_->size(1) / 2, weight_scale_->size(1) / 2}}), 1, tp_rank_, tp_size_);
+}
+
+infinicore::nn::Parameter LegacyGateUpParallelLinear::get_gate_weight_zeros_awq() const {
+    return infinicore::nn::Parameter(weight_zeros_->narrow({{1, 0, weight_zeros_->size(1) / 2}}), 1, tp_rank_, tp_size_);
+}
+
+infinicore::nn::Parameter LegacyGateUpParallelLinear::get_up_weight_zeros_awq() const {
+    return infinicore::nn::Parameter(weight_zeros_->narrow({{1, weight_zeros_->size(1) / 2, weight_zeros_->size(1) / 2}}), 1, tp_rank_, tp_size_);
+}
+
+infinicore::nn::Parameter LegacyGateUpParallelLinear::get_gate_g_idx_gptq() const {
+    return infinicore::nn::Parameter(gidx_->narrow({{0, 0, gidx_->size(0)}}), 0, tp_rank_, tp_size_);
+}
+
+infinicore::nn::Parameter LegacyGateUpParallelLinear::get_up_g_idx_gptq() const {
+    return infinicore::nn::Parameter(gidx_->narrow({{0, 0, gidx_->size(0)}}), 0, tp_rank_, tp_size_);
+}
+// DEPRECATED END
+
+} // namespace infinilm::layers::linear

--- a/csrc/models/llama_legacy/legacy_fused_linear.hpp
+++ b/csrc/models/llama_legacy/legacy_fused_linear.hpp
@@ -1,0 +1,328 @@
+#pragma once
+
+/**
+ * @deprecated Legacy fused linear classes based on InfiniCore.
+ *
+ * These classes inherit from infinicore::nn::ColumnParallelLinear and use the
+ * infinicore::quantization namespace. They exist solely for backward
+ * compatibility with the deprecated LlamaConfig-based constructors.
+ *
+ * Removal target: v0.2.0 (Q2 2026)
+ */
+
+#include "../../config/model_config.hpp"
+#include "../../engine/distributed/communication_group.hpp"
+#include "infinicore/nn/linear.hpp"
+#include "infinicore/quantization.hpp"
+#include <iostream>
+
+namespace infinilm::layers::linear {
+
+// DEPRECATED BEGIN
+
+/**
+ * Convert infinilm::quantization::BaseQuantization to infinicore::quantization::BaseQuantization.
+ * Needed because model_config now returns infinilm types but legacy classes use infinicore types.
+ */
+inline std::shared_ptr<infinicore::quantization::BaseQuantization>
+to_legacy_quant(const std::shared_ptr<infinilm::quantization::BaseQuantization> &quant) {
+    if (!quant) {
+        return std::make_shared<infinicore::quantization::NoneQuantization>(nlohmann::json{});
+    }
+    switch (quant->get_quant_scheme()) {
+    case infinilm::quantization::QuantScheme::COMPRESSED_TENSOR_W8A8I8:
+        return std::make_shared<infinicore::quantization::CompressedTensors>(quant->get_config());
+    case infinilm::quantization::QuantScheme::AWQ_W4A16:
+        return std::make_shared<infinicore::quantization::AWQ>(quant->get_config());
+    case infinilm::quantization::QuantScheme::GPTQ_W4A16_QY:
+        return std::make_shared<infinicore::quantization::GPTQ_QY>(quant->get_config());
+    case infinilm::quantization::QuantScheme::GPTQ_W4A16:
+        return std::make_shared<infinicore::quantization::GPTQ>(quant->get_config());
+    default:
+        return std::make_shared<infinicore::quantization::NoneQuantization>(quant->get_config());
+    }
+}
+
+inline infinicore::quantization::QuantScheme
+to_legacy_quant_scheme(infinilm::quantization::QuantScheme scheme) {
+    return static_cast<infinicore::quantization::QuantScheme>(static_cast<int>(scheme));
+}
+
+inline infinicore::quantization::KVQuantAlgo
+to_legacy_kv_quant_algo(infinilm::quantization::KVQuantAlgo algo) {
+    return static_cast<infinicore::quantization::KVQuantAlgo>(static_cast<int>(algo));
+}
+
+class LegacyQKVParallelLinear : public infinicore::nn::ColumnParallelLinear {
+public:
+    explicit LegacyQKVParallelLinear(size_t hidden_size,
+                                     size_t q_dim, size_t k_dim, size_t v_dim,
+                                     size_t num_q_head, size_t num_k_head, size_t num_v_head,
+                                     bool q_bias, bool k_bias, bool v_bias,
+                                     const infinicore::DataType &dtype = infinicore::DataType::F32,
+                                     const infinicore::Device &device = infinicore::Device(),
+                                     engine::distributed::RankInfo rank_info = engine::distributed::RankInfo());
+
+    explicit LegacyQKVParallelLinear(size_t hidden_size,
+                                     size_t head_dim,
+                                     size_t num_q_head, size_t num_kv_head,
+                                     bool bias = false,
+                                     const infinicore::DataType &dtype = infinicore::DataType::F32,
+                                     const infinicore::Device &device = infinicore::Device(),
+                                     engine::distributed::RankInfo rank_info = engine::distributed::RankInfo());
+
+    explicit LegacyQKVParallelLinear(size_t hidden_size,
+                                     size_t q_dim, size_t k_dim, size_t v_dim,
+                                     size_t num_q_head, size_t num_k_head, size_t num_v_head,
+                                     bool q_bias, bool k_bias, bool v_bias,
+                                     std::shared_ptr<infinicore::quantization::BaseQuantization> quantization,
+                                     const infinicore::DataType &dtype = infinicore::DataType::F32,
+                                     const infinicore::Device &device = infinicore::Device(),
+                                     engine::distributed::RankInfo rank_info = engine::distributed::RankInfo());
+
+    explicit LegacyQKVParallelLinear(size_t hidden_size,
+                                     size_t head_dim,
+                                     size_t num_q_head, size_t num_kv_head,
+                                     std::shared_ptr<infinicore::quantization::BaseQuantization> quantization,
+                                     bool bias = false,
+                                     const infinicore::DataType &dtype = infinicore::DataType::F32,
+                                     const infinicore::Device &device = infinicore::Device(),
+                                     engine::distributed::RankInfo rank_info = engine::distributed::RankInfo());
+
+    std::tuple<infinicore::Tensor, infinicore::Tensor, infinicore::Tensor>
+    forward_split(infinicore::Tensor &input);
+
+    infinicore::nn::Parameter get_q_weight() const;
+    infinicore::nn::Parameter get_k_weight() const;
+    infinicore::nn::Parameter get_v_weight() const;
+    infinicore::nn::Parameter get_q_weight_scale() const;
+    infinicore::nn::Parameter get_k_weight_scale() const;
+    infinicore::nn::Parameter get_v_weight_scale() const;
+    infinicore::nn::Parameter get_q_weight_zeros() const;
+    infinicore::nn::Parameter get_k_weight_zeros() const;
+    infinicore::nn::Parameter get_v_weight_zeros() const;
+
+    infinicore::nn::Parameter get_q_weight_awq(int scaling_factor) const;
+    infinicore::nn::Parameter get_k_weight_awq(int scaling_factor) const;
+    infinicore::nn::Parameter get_v_weight_awq(int scaling_factor) const;
+    infinicore::nn::Parameter get_q_weight_scale_awq(int scaling_factor) const;
+    infinicore::nn::Parameter get_k_weight_scale_awq(int scaling_factor) const;
+    infinicore::nn::Parameter get_v_weight_scale_awq(int scaling_factor) const;
+    infinicore::nn::Parameter get_q_weight_zeros_awq(int scaling_factor) const;
+    infinicore::nn::Parameter get_k_weight_zeros_awq(int scaling_factor) const;
+    infinicore::nn::Parameter get_v_weight_zeros_awq(int scaling_factor) const;
+
+    infinicore::nn::Parameter get_q_bias() const;
+    infinicore::nn::Parameter get_k_bias() const;
+    infinicore::nn::Parameter get_v_bias() const;
+
+    infinicore::nn::Parameter get_q_g_idx_gptq() const;
+    infinicore::nn::Parameter get_k_g_idx_gptq() const;
+    infinicore::nn::Parameter get_v_g_idx_gptq() const;
+
+    bool has_q_bias() const;
+    bool has_k_bias() const;
+    bool has_v_bias() const;
+
+private:
+    static size_t calculate_kv_replicas(size_t num_k_head, size_t tp_size) {
+        if (num_k_head % tp_size == 0) {
+            return 1;
+        }
+        if (tp_size % num_k_head == 0) {
+            return (tp_size + num_k_head - 1) / num_k_head;
+        }
+        throw std::runtime_error("Invalid KV head configuration");
+    }
+
+    static size_t
+    calculate_out_feature_size(size_t num_q_head, size_t q_dim, size_t num_k_head, size_t k_dim, size_t num_v_head, size_t v_dim, engine::distributed::RankInfo rank_info) {
+        return num_q_head * q_dim + num_k_head * k_dim * calculate_kv_replicas(num_k_head, rank_info.tp_size) + num_v_head * v_dim * calculate_kv_replicas(num_v_head, rank_info.tp_size);
+    }
+
+private:
+    size_t q_dim_;
+    size_t k_dim_;
+    size_t v_dim_;
+    size_t num_q_head_;
+    size_t num_k_head_;
+    size_t num_v_head_;
+    bool q_bias_;
+    bool k_bias_;
+    bool v_bias_;
+    size_t q_out_size_;
+    size_t k_out_size_;
+    size_t v_out_size_;
+    size_t num_kv_head_replicas_ = 1;
+};
+
+class LegacyGateUpParallelLinear : public infinicore::nn::ColumnParallelLinear {
+public:
+    LegacyGateUpParallelLinear(size_t hidden_size, size_t intermediate_size, bool bias = false,
+                               const infinicore::DataType &dtype = infinicore::DataType::F32, const infinicore::Device &device = infinicore::Device(),
+                               engine::distributed::RankInfo rank_info = engine::distributed::RankInfo());
+
+    LegacyGateUpParallelLinear(size_t hidden_size, size_t intermediate_size, bool gate_bias, bool up_bias,
+                               const infinicore::DataType &dtype = infinicore::DataType::F32, const infinicore::Device &device = infinicore::Device(),
+                               engine::distributed::RankInfo rank_info = engine::distributed::RankInfo());
+
+    LegacyGateUpParallelLinear(size_t hidden_size, size_t intermediate_size, std::shared_ptr<infinicore::quantization::BaseQuantization> quantization,
+                               bool bias = false,
+                               const infinicore::DataType &dtype = infinicore::DataType::F32,
+                               const infinicore::Device &device = infinicore::Device(),
+                               engine::distributed::RankInfo rank_info = engine::distributed::RankInfo());
+
+    LegacyGateUpParallelLinear(size_t hidden_size, size_t intermediate_size, bool gate_bias, bool up_bias,
+                               std::shared_ptr<infinicore::quantization::BaseQuantization> quantization,
+                               const infinicore::DataType &dtype = infinicore::DataType::F32, const infinicore::Device &device = infinicore::Device(),
+                               engine::distributed::RankInfo rank_info = engine::distributed::RankInfo());
+
+    std::tuple<infinicore::Tensor, infinicore::Tensor> forward_split(infinicore::Tensor &input);
+
+    infinicore::nn::Parameter get_gate_weight() const;
+    infinicore::nn::Parameter get_gate_bias() const;
+    infinicore::nn::Parameter get_up_weight() const;
+    infinicore::nn::Parameter get_up_bias() const;
+    infinicore::nn::Parameter get_gate_weight_scale() const;
+    infinicore::nn::Parameter get_up_weight_scale() const;
+    infinicore::nn::Parameter get_gate_weight_zeros() const;
+    infinicore::nn::Parameter get_up_weight_zeros() const;
+    infinicore::nn::Parameter get_gate_weight_awq() const;
+    infinicore::nn::Parameter get_up_weight_awq() const;
+    infinicore::nn::Parameter get_gate_weight_scale_awq() const;
+    infinicore::nn::Parameter get_up_weight_scale_awq() const;
+    infinicore::nn::Parameter get_gate_weight_zeros_awq() const;
+    infinicore::nn::Parameter get_up_weight_zeros_awq() const;
+    infinicore::nn::Parameter get_gate_g_idx_gptq() const;
+    infinicore::nn::Parameter get_up_g_idx_gptq() const;
+
+    bool has_gate_bias() const;
+    bool has_up_bias() const;
+
+private:
+    bool gate_bias_;
+    bool up_bias_;
+};
+// DEPRECATED END
+
+// DEPRECATED BEGIN — Legacy macros
+#define INFINILM_LEGACY_QKV_LINEAR_INIT(name, q_name, k_name, v_name, ...)                     \
+    name##_ = std::make_shared<layers::linear::LegacyQKVParallelLinear>(__VA_ARGS__);          \
+    this->register_parameter(std::string(q_name) + ".weight", name##_->get_q_weight());        \
+    this->register_parameter(std::string(k_name) + ".weight", name##_->get_k_weight());        \
+    this->register_parameter(std::string(v_name) + ".weight", name##_->get_v_weight());        \
+    if (name##_->has_q_bias())                                                                  \
+        this->register_parameter(std::string(q_name) + ".bias", name##_->get_q_bias());        \
+    if (name##_->has_k_bias())                                                                  \
+        this->register_parameter(std::string(k_name) + ".bias", name##_->get_k_bias());        \
+    if (name##_->has_v_bias())                                                                  \
+        this->register_parameter(std::string(v_name) + ".bias", name##_->get_v_bias());
+
+#define INFINILM_LEGACY_QKV_LINEAR_W8A8_INIT(name, q_name, k_name, v_name, ...)                            \
+    name##_ = std::make_shared<layers::linear::LegacyQKVParallelLinear>(__VA_ARGS__);                      \
+    this->register_parameter(std::string(q_name) + ".weight", name##_->get_q_weight());                    \
+    this->register_parameter(std::string(q_name) + ".weight_scale", name##_->get_q_weight_scale());        \
+    this->register_parameter(std::string(k_name) + ".weight", name##_->get_k_weight());                    \
+    this->register_parameter(std::string(k_name) + ".weight_scale", name##_->get_k_weight_scale());        \
+    this->register_parameter(std::string(v_name) + ".weight", name##_->get_v_weight());                    \
+    this->register_parameter(std::string(v_name) + ".weight_scale", name##_->get_v_weight_scale());        \
+    if (name##_->has_q_bias())                                                                             \
+        this->register_parameter(std::string(q_name) + ".bias", name##_->get_q_bias());                    \
+    if (name##_->has_k_bias())                                                                             \
+        this->register_parameter(std::string(k_name) + ".bias", name##_->get_k_bias());                    \
+    if (name##_->has_v_bias())                                                                             \
+        this->register_parameter(std::string(v_name) + ".bias", name##_->get_v_bias());
+
+#define INFINILM_LEGACY_QKV_LINEAR_W4A16AWQ_INIT(name, q_name, k_name, v_name, ...)                                \
+    name##_ = std::make_shared<layers::linear::LegacyQKVParallelLinear>(__VA_ARGS__);                               \
+    auto awq_ptr = std::static_pointer_cast<infinicore::quantization::AWQ>(name##_->get_quantization());            \
+    int packing_num = awq_ptr->get_packing_num();                                                                   \
+    this->register_parameter(std::string(q_name) + ".qweight", name##_->get_q_weight_awq(packing_num));             \
+    this->register_parameter(std::string(q_name) + ".qzeros", name##_->get_q_weight_zeros_awq(packing_num));        \
+    this->register_parameter(std::string(q_name) + ".scales", name##_->get_q_weight_scale_awq(1));                  \
+    this->register_parameter(std::string(k_name) + ".qweight", name##_->get_k_weight_awq(packing_num));             \
+    this->register_parameter(std::string(k_name) + ".qzeros", name##_->get_k_weight_zeros_awq(packing_num));        \
+    this->register_parameter(std::string(k_name) + ".scales", name##_->get_k_weight_scale_awq(1));                  \
+    this->register_parameter(std::string(v_name) + ".qweight", name##_->get_v_weight_awq(packing_num));             \
+    this->register_parameter(std::string(v_name) + ".qzeros", name##_->get_v_weight_zeros_awq(packing_num));        \
+    this->register_parameter(std::string(v_name) + ".scales", name##_->get_v_weight_scale_awq(1));                  \
+    if (name##_->has_q_bias())                                                                                      \
+        this->register_parameter(std::string(q_name) + ".bias", name##_->get_q_bias());                             \
+    if (name##_->has_k_bias())                                                                                      \
+        this->register_parameter(std::string(k_name) + ".bias", name##_->get_k_bias());                             \
+    if (name##_->has_v_bias())                                                                                      \
+        this->register_parameter(std::string(v_name) + ".bias", name##_->get_v_bias());
+
+#define INFINILM_LEGACY_QKV_LINEAR_W4A16GPTQ_INIT(name, q_name, k_name, v_name, ...)                                \
+    name##_ = std::make_shared<layers::linear::LegacyQKVParallelLinear>(__VA_ARGS__);                                \
+    auto gptq_ptr = std::static_pointer_cast<infinicore::quantization::GPTQ_QY>(name##_->get_quantization());        \
+    int packing_num = gptq_ptr->get_packing_num();                                                                   \
+    this->register_parameter(std::string(q_name) + ".qweight", name##_->get_q_weight_awq(1));                        \
+    this->register_parameter(std::string(q_name) + ".qzeros", name##_->get_q_weight_zeros_awq(8));                   \
+    this->register_parameter(std::string(q_name) + ".scales", name##_->get_q_weight_scale_awq(1));                   \
+    this->register_parameter(std::string(q_name) + ".g_idx", name##_->get_q_g_idx_gptq());                           \
+    this->register_parameter(std::string(k_name) + ".qweight", name##_->get_k_weight_awq(1));                        \
+    this->register_parameter(std::string(k_name) + ".qzeros", name##_->get_k_weight_zeros_awq(8));                   \
+    this->register_parameter(std::string(k_name) + ".scales", name##_->get_k_weight_scale_awq(1));                   \
+    this->register_parameter(std::string(k_name) + ".g_idx", name##_->get_k_g_idx_gptq());                           \
+    this->register_parameter(std::string(v_name) + ".qweight", name##_->get_v_weight_awq(1));                        \
+    this->register_parameter(std::string(v_name) + ".qzeros", name##_->get_v_weight_zeros_awq(8));                   \
+    this->register_parameter(std::string(v_name) + ".scales", name##_->get_v_weight_scale_awq(1));                   \
+    this->register_parameter(std::string(v_name) + ".g_idx", name##_->get_v_g_idx_gptq());                           \
+    if (name##_->has_q_bias())                                                                                       \
+        this->register_parameter(std::string(q_name) + ".bias", name##_->get_q_bias());                              \
+    if (name##_->has_k_bias())                                                                                       \
+        this->register_parameter(std::string(k_name) + ".bias", name##_->get_k_bias());                              \
+    if (name##_->has_v_bias())                                                                                       \
+        this->register_parameter(std::string(v_name) + ".bias", name##_->get_v_bias());
+
+#define INFINILM_LEGACY_GATE_UP_LINEAR_INIT(name, gate_name, up_name, ...)                          \
+    name##_ = std::make_shared<layers::linear::LegacyGateUpParallelLinear>(__VA_ARGS__);            \
+    this->register_parameter(std::string(gate_name) + ".weight", name##_->get_gate_weight());      \
+    this->register_parameter(std::string(up_name) + ".weight", name##_->get_up_weight());          \
+    if (name##_->has_gate_bias())                                                                   \
+        this->register_parameter(std::string(gate_name) + ".bias", name##_->get_gate_bias());      \
+    if (name##_->has_up_bias())                                                                     \
+        this->register_parameter(std::string(up_name) + ".bias", name##_->get_up_bias());
+
+#define INFINILM_LEGACY_GATE_UP_LINEAR_W8A8_INIT(name, gate_name, up_name, ...)                                  \
+    name##_ = std::make_shared<layers::linear::LegacyGateUpParallelLinear>(__VA_ARGS__);                          \
+    this->register_parameter(std::string(gate_name) + ".weight", name##_->get_gate_weight());                    \
+    this->register_parameter(std::string(gate_name) + ".weight_scale", name##_->get_gate_weight_scale());        \
+    this->register_parameter(std::string(up_name) + ".weight", name##_->get_up_weight());                        \
+    this->register_parameter(std::string(up_name) + ".weight_scale", name##_->get_up_weight_scale());            \
+    if (name##_->has_gate_bias())                                                                                 \
+        this->register_parameter(std::string(gate_name) + ".bias", name##_->get_gate_bias());                    \
+    if (name##_->has_up_bias())                                                                                   \
+        this->register_parameter(std::string(up_name) + ".bias", name##_->get_up_bias());
+
+#define INFINILM_LEGACY_GATE_UP_LINEAR_W4A16AWQ_INIT(name, gate_name, up_name, ...)                            \
+    name##_ = std::make_shared<layers::linear::LegacyGateUpParallelLinear>(__VA_ARGS__);                        \
+    this->register_parameter(std::string(gate_name) + ".qweight", name##_->get_gate_weight_awq());              \
+    this->register_parameter(std::string(gate_name) + ".qzeros", name##_->get_gate_weight_zeros_awq());        \
+    this->register_parameter(std::string(gate_name) + ".scales", name##_->get_gate_weight_scale_awq());        \
+    this->register_parameter(std::string(up_name) + ".qweight", name##_->get_up_weight_awq());                  \
+    this->register_parameter(std::string(up_name) + ".qzeros", name##_->get_up_weight_zeros_awq());            \
+    this->register_parameter(std::string(up_name) + ".scales", name##_->get_up_weight_scale_awq());            \
+    if (name##_->has_gate_bias())                                                                               \
+        this->register_parameter(std::string(gate_name) + ".bias", name##_->get_gate_bias());                   \
+    if (name##_->has_up_bias())                                                                                 \
+        this->register_parameter(std::string(up_name) + ".bias", name##_->get_up_bias());
+
+#define INFINILM_LEGACY_GATE_UP_LINEAR_W4A16GPTQ_INIT(name, gate_name, up_name, ...)                           \
+    name##_ = std::make_shared<layers::linear::LegacyGateUpParallelLinear>(__VA_ARGS__);                        \
+    this->register_parameter(std::string(gate_name) + ".qweight", name##_->get_gate_weight_awq());              \
+    this->register_parameter(std::string(gate_name) + ".qzeros", name##_->get_gate_weight_zeros_awq());        \
+    this->register_parameter(std::string(gate_name) + ".scales", name##_->get_gate_weight_scale_awq());        \
+    this->register_parameter(std::string(gate_name) + ".g_idx", name##_->get_gate_g_idx_gptq());               \
+    this->register_parameter(std::string(up_name) + ".qweight", name##_->get_up_weight_awq());                  \
+    this->register_parameter(std::string(up_name) + ".qzeros", name##_->get_up_weight_zeros_awq());            \
+    this->register_parameter(std::string(up_name) + ".scales", name##_->get_up_weight_scale_awq());            \
+    this->register_parameter(std::string(up_name) + ".g_idx", name##_->get_up_g_idx_gptq());                   \
+    if (name##_->has_gate_bias())                                                                               \
+        this->register_parameter(std::string(gate_name) + ".bias", name##_->get_gate_bias());                   \
+    if (name##_->has_up_bias())                                                                                 \
+        this->register_parameter(std::string(up_name) + ".bias", name##_->get_up_bias());
+// DEPRECATED END
+
+} // namespace infinilm::layers::linear

--- a/csrc/models/llama_legacy/llama_attention.cpp
+++ b/csrc/models/llama_legacy/llama_attention.cpp
@@ -20,6 +20,10 @@
 
 namespace infinilm::models::llama_legacy {
 
+using layers::linear::to_legacy_quant;
+using layers::linear::to_legacy_quant_scheme;
+using layers::linear::to_legacy_kv_quant_algo;
+
 /**
  * @deprecated This function is deprecated and will be REMOVED in the next major release (v0.2.0).
  *
@@ -66,7 +70,7 @@ LlamaAttention::LlamaAttention(const LlamaConfig &config,
     scaling_ = 1.0f / std::sqrt(static_cast<float>(head_dim_));
 
     // Initialize projection layers
-    INFINILM_QKV_LINEAR_INIT(qkv_proj, "q_proj", "k_proj", "v_proj", hidden_size_, head_dim_, config.num_attention_heads, config.num_key_value_heads, use_bias_,
+    INFINILM_LEGACY_QKV_LINEAR_INIT(qkv_proj, "q_proj", "k_proj", "v_proj", hidden_size_, head_dim_, config.num_attention_heads, config.num_key_value_heads, use_bias_,
                              dtype, device, rank_info);
     // Output projection uses attention_output_bias (can be different from qkv)
     INFINICORE_NN_MODULE_INIT(o_proj, num_attention_heads * head_dim_, hidden_size_, use_output_bias_,
@@ -112,36 +116,36 @@ LlamaAttention::LlamaAttention(std::shared_ptr<infinilm::config::ModelConfig> mo
     }
     scaling_ = 1.0f / std::sqrt(static_cast<float>(head_dim_));
 
-    auto quant_scheme = this->model_config_->get_quant_scheme();
+    auto quant_scheme = to_legacy_quant_scheme(this->model_config_->get_quant_scheme());
     switch (quant_scheme) {
     case infinicore::quantization::QuantScheme::COMPRESSED_TENSOR_W8A8I8:
-        INFINILM_QKV_LINEAR_W8A8_INIT(qkv_proj, "q_proj", "k_proj", "v_proj", hidden_size_, head_dim_, model_config_->get<size_t>("num_attention_heads"), model_config_->get<size_t>("num_key_value_heads"), this->model_config_->get_quantization_method(), use_bias_,
+        INFINILM_LEGACY_QKV_LINEAR_W8A8_INIT(qkv_proj, "q_proj", "k_proj", "v_proj", hidden_size_, head_dim_, model_config_->get<size_t>("num_attention_heads"), model_config_->get<size_t>("num_key_value_heads"), to_legacy_quant(this->model_config_->get_quantization_method()), use_bias_,
                                       dtype, device, rank_info);
-        INFINICORE_NN_MODULE_INIT(o_proj, model_config_->get<size_t>("num_attention_heads") * head_dim_, hidden_size_, this->model_config_->get_quantization_method(), use_output_bias_,
+        INFINICORE_NN_MODULE_INIT(o_proj, model_config_->get<size_t>("num_attention_heads") * head_dim_, hidden_size_, to_legacy_quant(this->model_config_->get_quantization_method()), use_output_bias_,
                                   dtype, device, tp_rank, tp_size, rank_info.comm);
         break;
 
     case infinicore::quantization::QuantScheme::AWQ_W4A16: {
-        INFINILM_QKV_LINEAR_W4A16AWQ_INIT(qkv_proj, "q_proj", "k_proj", "v_proj", hidden_size_, head_dim_, model_config_->get<size_t>("num_attention_heads"), model_config_->get<size_t>("num_key_value_heads"), this->model_config_->get_quantization_method(), use_bias_,
+        INFINILM_LEGACY_QKV_LINEAR_W4A16AWQ_INIT(qkv_proj, "q_proj", "k_proj", "v_proj", hidden_size_, head_dim_, model_config_->get<size_t>("num_attention_heads"), model_config_->get<size_t>("num_key_value_heads"), to_legacy_quant(this->model_config_->get_quantization_method()), use_bias_,
                                           dtype, device, rank_info);
-        INFINICORE_NN_MODULE_INIT(o_proj, model_config_->get<size_t>("num_attention_heads") * head_dim_, hidden_size_, this->model_config_->get_quantization_method(), use_output_bias_,
+        INFINICORE_NN_MODULE_INIT(o_proj, model_config_->get<size_t>("num_attention_heads") * head_dim_, hidden_size_, to_legacy_quant(this->model_config_->get_quantization_method()), use_output_bias_,
                                   dtype, device, tp_rank, tp_size, rank_info.comm);
         break;
     }
     case infinicore::quantization::QuantScheme::GPTQ_W4A16_QY: {
 
-        INFINILM_QKV_LINEAR_W4A16GPTQ_INIT(qkv_proj, "q_proj", "k_proj", "v_proj", hidden_size_, head_dim_, model_config_->get<size_t>("num_attention_heads"), model_config_->get<size_t>("num_key_value_heads"), this->model_config_->get_quantization_method(), use_bias_,
+        INFINILM_LEGACY_QKV_LINEAR_W4A16GPTQ_INIT(qkv_proj, "q_proj", "k_proj", "v_proj", hidden_size_, head_dim_, model_config_->get<size_t>("num_attention_heads"), model_config_->get<size_t>("num_key_value_heads"), to_legacy_quant(this->model_config_->get_quantization_method()), use_bias_,
                                            dtype, device, rank_info);
 
-        INFINICORE_NN_MODULE_INIT(o_proj, model_config_->get<size_t>("num_attention_heads") * head_dim_, hidden_size_, this->model_config_->get_quantization_method(), use_output_bias_,
+        INFINICORE_NN_MODULE_INIT(o_proj, model_config_->get<size_t>("num_attention_heads") * head_dim_, hidden_size_, to_legacy_quant(this->model_config_->get_quantization_method()), use_output_bias_,
                                   dtype, device, tp_rank, tp_size, rank_info.comm);
 
         break;
     }
     default:
-        INFINILM_QKV_LINEAR_INIT(qkv_proj, "q_proj", "k_proj", "v_proj", hidden_size_, head_dim_, model_config_->get<size_t>("num_attention_heads"), model_config_->get<size_t>("num_key_value_heads"), this->model_config_->get_quantization_method(), use_bias_,
+        INFINILM_LEGACY_QKV_LINEAR_INIT(qkv_proj, "q_proj", "k_proj", "v_proj", hidden_size_, head_dim_, model_config_->get<size_t>("num_attention_heads"), model_config_->get<size_t>("num_key_value_heads"), to_legacy_quant(this->model_config_->get_quantization_method()), use_bias_,
                                  dtype, device, rank_info);
-        INFINICORE_NN_MODULE_INIT(o_proj, model_config_->get<size_t>("num_attention_heads") * head_dim_, hidden_size_, this->model_config_->get_quantization_method(), use_output_bias_,
+        INFINICORE_NN_MODULE_INIT(o_proj, model_config_->get<size_t>("num_attention_heads") * head_dim_, hidden_size_, to_legacy_quant(this->model_config_->get_quantization_method()), use_output_bias_,
                                   dtype, device, tp_rank, tp_size, rank_info.comm);
         break;
     }
@@ -150,7 +154,7 @@ LlamaAttention::LlamaAttention(std::shared_ptr<infinilm::config::ModelConfig> mo
         INFINICORE_NN_MODULE_INIT(k_norm, head_dim_, model_config_->get<double>("rms_norm_eps"), dtype, device);
     }
 
-    switch (this->model_config_->get_kv_quant_scheme()) {
+    switch (to_legacy_kv_quant_algo(this->model_config_->get_kv_quant_scheme())) {
     case (infinicore::quantization::KVQuantAlgo::INT8): {
         INFINICORE_NN_PARAMETER_INIT(kv_cache_k_scale, ({1}, infinicore::DataType::F32, device, 0, 0, 1));
         INFINICORE_NN_PARAMETER_INIT(kv_cache_v_scale, ({1}, infinicore::DataType::F32, device, 0, 0, 1));

--- a/csrc/models/llama_legacy/llama_attention.hpp
+++ b/csrc/models/llama_legacy/llama_attention.hpp
@@ -6,6 +6,7 @@
 #include "../../engine/distributed/distributed.hpp"
 #include "../../layers/linear/fused_linear.hpp"
 #include "../../layers/quantization/kv_quant.hpp"
+#include "legacy_fused_linear.hpp"
 #include "llama_config.hpp"
 
 #include "infinicore/nn/linear.hpp"
@@ -20,15 +21,6 @@
 
 namespace infinilm::models::llama_legacy {
 
-/**
- * @brief Multi-head self-attention module for Llama
- *
- * Implements the attention mechanism with:
- * - Query, Key, Value projections
- * - Output projection
- * - Rotary Position Embeddings (RoPE) applied to Q and K
- * - Support for Grouped Query Attention (GQA)
- */
 class LlamaAttention : public infinicore::nn::Module {
 public:
     /**
@@ -115,10 +107,11 @@ private:
 
 protected:
     // Projection layers
-    INFINICORE_NN_MODULE(infinilm::layers::linear::QKVParallelLinear, qkv_proj);
+    INFINICORE_NN_MODULE(layers::linear::LegacyQKVParallelLinear, qkv_proj);
     INFINICORE_NN_MODULE(infinicore::nn::RowParallelLinear, o_proj);
     INFINICORE_NN_MODULE(infinicore::nn::RMSNorm, q_norm);
     INFINICORE_NN_MODULE(infinicore::nn::RMSNorm, k_norm);
+
     engine::distributed::RankInfo rank_info_;
 
     // Shared Rotary Position Embeddings (RoPE)

--- a/csrc/models/llama_legacy/llama_decoder_layer.cpp
+++ b/csrc/models/llama_legacy/llama_decoder_layer.cpp
@@ -4,35 +4,6 @@
 #include <optional>
 
 namespace infinilm::models::llama_legacy {
-/**
- * @deprecated This function is deprecated and will be REMOVED in the next major release (v0.2.0).
- *
- * ⚠️ DEVELOPMENT POLICY:
- *   - NO new development or feature additions permitted on this interface
- *   - Only critical bug fixes (security/stability) allowed until removal
- *   - All new code MUST migrate to the polymorphic overload below
- *
- * Replacement: Use the polymorphic overload of this same function name with updated signature
- * Reason: Legacy signature lacks support for dynamic quantization modes.
- * Removal target: v0.2.0 (Q2 2026)
- */
-LlamaDecoderLayer::LlamaDecoderLayer(const LlamaConfig &config,
-                                     const infinicore::Device &device,
-                                     size_t layer_idx,
-                                     engine::distributed::RankInfo rank_info,
-                                     backends::AttentionBackend attention_backend) : layer_idx_(layer_idx), rank_info_(rank_info) {
-    const auto &dtype{config.dtype};
-
-    // Initialize layer normalization layers
-    INFINICORE_NN_MODULE_INIT(input_layernorm, config.hidden_size, config.rms_norm_eps,
-                              dtype, device);
-    INFINICORE_NN_MODULE_INIT(post_attention_layernorm, config.hidden_size, config.rms_norm_eps,
-                              dtype, device);
-
-    // Initialize attention and MLP modules
-    INFINICORE_NN_MODULE_INIT(self_attn, config, device, layer_idx, rank_info_, attention_backend);
-    INFINICORE_NN_MODULE_INIT(mlp, config, device, rank_info_);
-}
 
 LlamaDecoderLayer::LlamaDecoderLayer(std::shared_ptr<infinilm::config::ModelConfig> model_config,
                                      const infinicore::Device &device,
@@ -40,15 +11,13 @@ LlamaDecoderLayer::LlamaDecoderLayer(std::shared_ptr<infinilm::config::ModelConf
                                      engine::distributed::RankInfo rank_info,
                                      backends::AttentionBackend attention_backend) : model_config_(model_config), layer_idx_(layer_idx), rank_info_(rank_info) {
     const auto &dtype{model_config_->get_dtype()};
-    // Initialize layer normalization layers
-    INFINICORE_NN_MODULE_INIT(input_layernorm, model_config_->get<size_t>("hidden_size"), model_config_->get<double>("rms_norm_eps"),
+    input_layernorm_ = this->register_module<infinicore::nn::RMSNorm>("input_layernorm", model_config_->get<size_t>("hidden_size"), model_config_->get<double>("rms_norm_eps"),
                               dtype, device);
-    INFINICORE_NN_MODULE_INIT(post_attention_layernorm, model_config_->get<size_t>("hidden_size"), model_config_->get<double>("rms_norm_eps"),
+    post_attention_layernorm_ = this->register_module<infinicore::nn::RMSNorm>("post_attention_layernorm", model_config_->get<size_t>("hidden_size"), model_config_->get<double>("rms_norm_eps"),
                               dtype, device);
 
-    // Initialize attention and MLP modules
-    INFINICORE_NN_MODULE_INIT(self_attn, model_config_, device, layer_idx, rank_info_, attention_backend);
-    INFINICORE_NN_MODULE_INIT(mlp, model_config_, device, rank_info_);
+    self_attn_ = this->register_module<LlamaAttention>("self_attn", model_config_, device, layer_idx, rank_info_, attention_backend);
+    mlp_ = this->register_module<LlamaMLP>("mlp", model_config_, device, rank_info_);
 }
 
 std::tuple<infinicore::Tensor, infinicore::Tensor>

--- a/csrc/models/llama_legacy/llama_decoder_layer.hpp
+++ b/csrc/models/llama_legacy/llama_decoder_layer.hpp
@@ -33,24 +33,6 @@ public:
      * @param layer_idx Layer index for cache management and debugging
      * @param dtype Optional data type for model parameters (defaults to F32)
      */
-    /**
-     * @deprecated This function is deprecated and will be REMOVED in the next major release (v0.2.0).
-     *
-     * ⚠️ DEVELOPMENT POLICY:
-     *   - NO new development or feature additions permitted on this interface
-     *   - Only critical bug fixes (security/stability) allowed until removal
-     *   - All new code MUST migrate to the polymorphic overload below
-     *
-     * Replacement: Use the polymorphic overload of this same function name with updated signature
-     * Reason: Legacy signature lacks support for dynamic quantization modes.
-     * Removal target: v0.2.0 (Q2 2026)
-     */
-    LlamaDecoderLayer(const LlamaConfig &config,
-                      const infinicore::Device &device,
-                      size_t layer_idx,
-                      engine::distributed::RankInfo rank_info = engine::distributed::RankInfo(),
-                      backends::AttentionBackend attention_backend = backends::AttentionBackend::Default);
-
     LlamaDecoderLayer(std::shared_ptr<infinilm::config::ModelConfig> model_config,
                       const infinicore::Device &device,
                       size_t layer_idx,
@@ -92,12 +74,11 @@ public:
 
 protected:
     // Layer normalization
-    INFINICORE_NN_MODULE(infinicore::nn::RMSNorm, input_layernorm);
-    INFINICORE_NN_MODULE(infinicore::nn::RMSNorm, post_attention_layernorm);
+    std::shared_ptr<infinicore::nn::RMSNorm> input_layernorm_;
+    std::shared_ptr<infinicore::nn::RMSNorm> post_attention_layernorm_;
 
-    // Attention and MLP
-    INFINICORE_NN_MODULE(LlamaAttention, self_attn);
-    INFINICORE_NN_MODULE(LlamaMLP, mlp);
+    std::shared_ptr<LlamaAttention> self_attn_;
+    std::shared_ptr<LlamaMLP> mlp_;
     engine::distributed::RankInfo rank_info_;
     std::shared_ptr<infinilm::config::ModelConfig> model_config_;
 

--- a/csrc/models/llama_legacy/llama_for_causal_lm.cpp
+++ b/csrc/models/llama_legacy/llama_for_causal_lm.cpp
@@ -3,36 +3,6 @@
 #include "infinicore/nn/linear.hpp"
 #include "infinicore/ops.hpp"
 namespace infinilm::models::llama_legacy {
-/**
- * @deprecated This function is deprecated and will be REMOVED in the next major release (v0.2.0).
- *
- * ⚠️ DEVELOPMENT POLICY:
- *   - NO new development or feature additions permitted on this interface
- *   - Only critical bug fixes (security/stability) allowed until removal
- *   - All new code MUST migrate to the polymorphic overload below
- *
- * Replacement: Use the polymorphic overload of this same function name with updated signature
- * Reason: Legacy signature lacks support for dynamic quantization modes.
- * Removal target: v0.2.0 (Q2 2026)
- */
-LlamaForCausalLM::LlamaForCausalLM(const LlamaConfig &config,
-                                   const infinicore::Device &device,
-                                   engine::distributed::RankInfo rank_info,
-                                   backends::AttentionBackend attention_backend) {
-    spdlog::warn("infinilm::models::llama_legacy: LlamaForCausalLM is no longer supported, please use the new model instead.");
-
-    // Initialize module's device_ member
-    device_ = device;
-    const auto &dtype{config.dtype};
-    // Initialize base model
-    INFINICORE_NN_MODULE_INIT(model, config, device, rank_info, attention_backend);
-
-    // Initialize language modeling head
-    // Note: If tie_word_embeddings is true, we would share weights with embed_tokens
-    // For now, we create a separate linear layer
-    INFINICORE_NN_MODULE_INIT(lm_head, config.hidden_size, config.vocab_size, false,
-                              dtype, device);
-}
 
 LlamaForCausalLM::LlamaForCausalLM(std::shared_ptr<infinilm::config::ModelConfig> model_config,
                                    const infinicore::Device &device,
@@ -40,17 +10,11 @@ LlamaForCausalLM::LlamaForCausalLM(std::shared_ptr<infinilm::config::ModelConfig
                                    backends::AttentionBackend attention_backend) {
     spdlog::warn("infinilm::models::llama_legacy: LlamaForCausalLM is no longer supported, please use the new model instead.");
 
-    // Initialize module's device_ member
     device_ = device;
     const auto &dtype{model_config->get_dtype()};
 
-    // Initialize base model
-    INFINICORE_NN_MODULE_INIT(model, model_config, device, rank_info, attention_backend);
-    // Initialize language modeling head
-    // Note: If tie_word_embeddings is true, we would share weights with embed_tokens
-    // For now, we create a separate linear layer
-
-    INFINICORE_NN_MODULE_INIT(lm_head, model_config->get<size_t>("hidden_size"), model_config->get<size_t>("vocab_size"), false,
+    model_ = this->register_module<LlamaModel>("model", model_config, device, rank_info, attention_backend);
+    lm_head_ = this->register_module<infinicore::nn::Linear>("lm_head", model_config->get<size_t>("hidden_size"), model_config->get<size_t>("vocab_size"), false,
                               dtype, device);
 }
 
@@ -64,11 +28,9 @@ LlamaForCausalLM::Output LlamaForCausalLM::forward(const Input &input) const {
     auto block_tables = input.block_tables;
     auto slot_mapping = input.slot_mapping;
 
-    // 1. Forward through base model to get hidden states
     auto hidden_states = model_->forward(
         input_ids, position_ids, past_sequence_lengths, total_sequence_length, input_offsets, cu_seqlens, block_tables, slot_mapping);
 
-    // 2. Apply language modeling head to get logits
     auto logits = lm_head_->forward(hidden_states);
     return {logits};
 }

--- a/csrc/models/llama_legacy/llama_for_causal_lm.hpp
+++ b/csrc/models/llama_legacy/llama_for_causal_lm.hpp
@@ -28,23 +28,6 @@ public:
      * @param config Model configuration
      * @param device Device to create tensors on
      */
-    /**
-     * @deprecated This function is deprecated and will be REMOVED in the next major release (v0.2.0).
-     *
-     * ⚠️ DEVELOPMENT POLICY:
-     *   - NO new development or feature additions permitted on this interface
-     *   - Only critical bug fixes (security/stability) allowed until removal
-     *   - All new code MUST migrate to the polymorphic overload below
-     *
-     * Replacement: Use the polymorphic overload of this same function name with updated signature
-     * Reason: Legacy signature lacks support for dynamic quantization modes.
-     * Removal target: v0.2.0 (Q2 2026)
-     */
-    LlamaForCausalLM(const LlamaConfig &config,
-                     const infinicore::Device &device,
-                     engine::distributed::RankInfo rank_info = engine::distributed::RankInfo(),
-                     backends::AttentionBackend attention_backend = backends::AttentionBackend::Default);
-
     LlamaForCausalLM(std::shared_ptr<infinilm::config::ModelConfig> model_config,
                      const infinicore::Device &device,
                      engine::distributed::RankInfo rank_info = engine::distributed::RankInfo(),
@@ -69,7 +52,6 @@ public:
     const LlamaModel &model() const { return *model_; }
 
 protected:
-    // Base model
     INFINICORE_NN_MODULE(LlamaModel, model);
 
     // Language modeling head

--- a/csrc/models/llama_legacy/llama_mlp.cpp
+++ b/csrc/models/llama_legacy/llama_mlp.cpp
@@ -3,6 +3,9 @@
 #include "infinicore/ops.hpp"
 
 namespace infinilm::models::llama_legacy {
+
+using layers::linear::to_legacy_quant;
+using layers::linear::to_legacy_quant_scheme;
 /**
  * @deprecated This function is deprecated and will be REMOVED in the next major release (v0.2.0).
  *
@@ -27,7 +30,7 @@ LlamaMLP::LlamaMLP(const LlamaConfig &config,
     int tp_size = rank_info.tp_size;
 
     // Initialize projection layers
-    INFINILM_GATE_UP_LINEAR_INIT(gate_up_proj, "gate_proj", "up_proj", hidden_size_, intermediate_size_, use_bias_,
+    INFINILM_LEGACY_GATE_UP_LINEAR_INIT(gate_up_proj, "gate_proj", "up_proj", hidden_size_, intermediate_size_, use_bias_,
                                  dtype, device, rank_info_);
     INFINICORE_NN_MODULE_INIT(down_proj, intermediate_size_, hidden_size_, use_bias_,
                               dtype, device, tp_rank, tp_size, rank_info.comm);
@@ -46,30 +49,30 @@ LlamaMLP::LlamaMLP(std::shared_ptr<infinilm::config::ModelConfig> model_config,
     int tp_size = rank_info.tp_size;
 
     // Initialize projection layers
-    auto quant_scheme = this->model_config_->get_quant_scheme();
+    auto quant_scheme = to_legacy_quant_scheme(this->model_config_->get_quant_scheme());
     switch (quant_scheme) {
     case infinicore::quantization::QuantScheme::COMPRESSED_TENSOR_W8A8I8:
-        INFINILM_GATE_UP_LINEAR_W8A8_INIT(gate_up_proj, "gate_proj", "up_proj", hidden_size_, intermediate_size_, this->model_config_->get_quantization_method(), use_bias_,
+        INFINILM_LEGACY_GATE_UP_LINEAR_W8A8_INIT(gate_up_proj, "gate_proj", "up_proj", hidden_size_, intermediate_size_, to_legacy_quant(this->model_config_->get_quantization_method()), use_bias_,
                                           dtype, device, rank_info_);
-        INFINICORE_NN_MODULE_INIT(down_proj, intermediate_size_, hidden_size_, this->model_config_->get_quantization_method(), use_bias_,
+        INFINICORE_NN_MODULE_INIT(down_proj, intermediate_size_, hidden_size_, to_legacy_quant(this->model_config_->get_quantization_method()), use_bias_,
                                   dtype, device, tp_rank, tp_size, rank_info.comm);
         break;
     case infinicore::quantization::QuantScheme::AWQ_W4A16:
-        INFINILM_GATE_UP_LINEAR_W4A16AWQ_INIT(gate_up_proj, "gate_proj", "up_proj", hidden_size_, intermediate_size_, this->model_config_->get_quantization_method(), use_bias_,
+        INFINILM_LEGACY_GATE_UP_LINEAR_W4A16AWQ_INIT(gate_up_proj, "gate_proj", "up_proj", hidden_size_, intermediate_size_, to_legacy_quant(this->model_config_->get_quantization_method()), use_bias_,
                                               dtype, device, rank_info_);
-        INFINICORE_NN_MODULE_INIT(down_proj, intermediate_size_, hidden_size_, this->model_config_->get_quantization_method(), use_bias_,
+        INFINICORE_NN_MODULE_INIT(down_proj, intermediate_size_, hidden_size_, to_legacy_quant(this->model_config_->get_quantization_method()), use_bias_,
                                   dtype, device, tp_rank, tp_size, rank_info.comm);
         break;
     case infinicore::quantization::QuantScheme::GPTQ_W4A16_QY:
-        INFINILM_GATE_UP_LINEAR_W4A16GPTQ_INIT(gate_up_proj, "gate_proj", "up_proj", hidden_size_, intermediate_size_, this->model_config_->get_quantization_method(), use_bias_,
+        INFINILM_LEGACY_GATE_UP_LINEAR_W4A16GPTQ_INIT(gate_up_proj, "gate_proj", "up_proj", hidden_size_, intermediate_size_, to_legacy_quant(this->model_config_->get_quantization_method()), use_bias_,
                                                dtype, device, rank_info_);
-        INFINICORE_NN_MODULE_INIT(down_proj, intermediate_size_, hidden_size_, this->model_config_->get_quantization_method(), use_bias_,
+        INFINICORE_NN_MODULE_INIT(down_proj, intermediate_size_, hidden_size_, to_legacy_quant(this->model_config_->get_quantization_method()), use_bias_,
                                   dtype, device, tp_rank, tp_size, rank_info.comm);
         break;
     default:
-        INFINILM_GATE_UP_LINEAR_INIT(gate_up_proj, "gate_proj", "up_proj", hidden_size_, intermediate_size_, this->model_config_->get_quantization_method(), use_bias_,
+        INFINILM_LEGACY_GATE_UP_LINEAR_INIT(gate_up_proj, "gate_proj", "up_proj", hidden_size_, intermediate_size_, to_legacy_quant(this->model_config_->get_quantization_method()), use_bias_,
                                      dtype, device, rank_info_);
-        INFINICORE_NN_MODULE_INIT(down_proj, intermediate_size_, hidden_size_, this->model_config_->get_quantization_method(), use_bias_,
+        INFINICORE_NN_MODULE_INIT(down_proj, intermediate_size_, hidden_size_, to_legacy_quant(this->model_config_->get_quantization_method()), use_bias_,
                                   dtype, device, tp_rank, tp_size, rank_info.comm);
         break;
     }

--- a/csrc/models/llama_legacy/llama_mlp.hpp
+++ b/csrc/models/llama_legacy/llama_mlp.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../../layers/linear/fused_linear.hpp"
+#include "./legacy_fused_linear.hpp"
 #include "llama_config.hpp"
 
 #include "../../config/model_config.hpp"
@@ -67,7 +67,7 @@ public:
     size_t intermediate_size() const { return intermediate_size_; }
 
 protected:
-    INFINICORE_NN_MODULE(layers::linear::GateUpParallelLinear, gate_up_proj);
+    INFINICORE_NN_MODULE(layers::linear::LegacyGateUpParallelLinear, gate_up_proj);
     INFINICORE_NN_MODULE(infinicore::nn::RowParallelLinear, down_proj);
 
     engine::distributed::RankInfo rank_info_;

--- a/csrc/models/llama_legacy/llama_model.cpp
+++ b/csrc/models/llama_legacy/llama_model.cpp
@@ -6,54 +6,6 @@
 #include <iostream>
 
 namespace infinilm::models::llama_legacy {
-/**
- * @deprecated This function is deprecated and will be REMOVED in the next major release (v0.2.0).
- *
- * ⚠️ DEVELOPMENT POLICY:
- *   - NO new development or feature additions permitted on this interface
- *   - Only critical bug fixes (security/stability) allowed until removal
- *   - All new code MUST migrate to the polymorphic overload below
- *
- * Replacement: Use the polymorphic overload of this same function name with updated signature
- * Reason: Legacy signature lacks support for dynamic quantization modes.
- * Removal target: v0.2.0 (Q2 2026)
- */
-LlamaModel::LlamaModel(const LlamaConfig &config,
-                       const infinicore::Device &device,
-                       engine::distributed::RankInfo rank_info,
-                       backends::AttentionBackend attention_backend)
-    : config_(config), rank_info_(rank_info) {
-    const auto &dtype{config.dtype};
-    // Initialize token embeddings
-    INFINICORE_NN_MODULE_INIT(embed_tokens, config.vocab_size, config.hidden_size,
-                              std::nullopt, dtype, device);
-
-    // Initialize decoder layers with layer indices
-    // TODO: Update INFINICORE_NN_MODULE_VEC_INIT macro to support per-layer constructor arguments
-    //       (e.g., via a factory function or lambda that receives the layer index)
-    //       Currently, we can't use the macro because each layer needs a different layer_idx
-    layers_.reserve(config.num_hidden_layers);
-    for (size_t i = 0; i < config.num_hidden_layers; ++i) {
-        layers_.push_back(this->register_module<LlamaDecoderLayer>(
-            "layers." + std::to_string(i), config, device, i, rank_info, attention_backend));
-    }
-
-    // Initialize final layer normalization
-    INFINICORE_NN_MODULE_INIT(norm, config.hidden_size, config.rms_norm_eps,
-                              dtype, device);
-
-    // Initialize Rotary Position Embeddings (shared across all layers)
-    // Use GPT-J-style inverse frequencies (default) and GPT_NEOX rotation pairing
-    INFINICORE_NN_MODULE_INIT(rotary_emb, config.head_dim, config.max_position_embeddings,
-                              config.rope_theta, infinicore::nn::RoPE::Algo::GPT_NEOX,
-                              dtype, device, config.rope_scaling);
-
-    for (auto &layer : layers_) {
-        if (layer) {
-            layer->set_rotary_emb(rotary_emb_);
-        }
-    }
-}
 
 LlamaModel::LlamaModel(std::shared_ptr<infinilm::config::ModelConfig> model_config,
                        const infinicore::Device &device,
@@ -61,23 +13,15 @@ LlamaModel::LlamaModel(std::shared_ptr<infinilm::config::ModelConfig> model_conf
                        backends::AttentionBackend attention_backend)
     : model_config_(model_config), rank_info_(rank_info) {
     const auto &dtype{model_config_->get_dtype()};
-    // Initialize token embeddings
     INFINICORE_NN_MODULE_INIT(embed_tokens, model_config_->get<size_t>("vocab_size"), model_config_->get<size_t>("hidden_size"),
                               std::nullopt, dtype, device);
-    // Initialize decoder layers with layer indices
-    // TODO: Update INFINICORE_NN_MODULE_VEC_INIT macro to support per-layer constructor arguments
-    //       (e.g., via a factory function or lambda that receives the layer index)
-    //       Currently, we can't use the macro because each layer needs a different layer_idx
     layers_.reserve(model_config_->get<size_t>("num_hidden_layers"));
     for (size_t i = 0; i < model_config_->get<size_t>("num_hidden_layers"); ++i) {
         layers_.push_back(this->register_module<LlamaDecoderLayer>(
             "layers." + std::to_string(i), model_config_, device, i, rank_info, attention_backend));
     }
-    // Initialize final layer normalization
     INFINICORE_NN_MODULE_INIT(norm, model_config_->get<size_t>("hidden_size"), model_config_->get<double>("rms_norm_eps"),
                               dtype, device);
-    // Initialize Rotary Position Embeddings (shared across all layers)
-    // Use GPT-J-style inverse frequencies (default) and GPT_NEOX rotation pairing
     INFINICORE_NN_MODULE_INIT(rotary_emb, model_config_->get_head_dim(), model_config_->get<size_t>("max_position_embeddings"),
                               model_config_->get<double>("rope_theta"), infinicore::nn::RoPE::Algo::GPT_NEOX,
                               dtype, device, model_config_->get_rope_scaling());
@@ -150,30 +94,7 @@ void LlamaModel::reset_cache(const cache::CacheConfig *cache_config) {
         kv_cache_ = nullptr;
         return;
     }
-    if (auto kv_cache_config = dynamic_cast<const cache::StaticKVCacheConfig *>(cache_config);
-        kv_cache_config && model_config_ == nullptr) {
-        kv_cache_ = std::make_shared<cache::StaticKVCache>(
-            config_.head_dim,
-            config_.head_dim,
-            config_.num_key_value_heads,
-            config_.num_key_value_heads,
-            config_.num_hidden_layers,
-            config_.max_position_embeddings,
-            model_config_->get_kv_cache_dtype(),
-            *kv_cache_config,
-            rank_info_);
-    } else if (auto paged_kv_cache_config = dynamic_cast<const cache::PagedKVCacheConfig *>(cache_config);
-               paged_kv_cache_config && model_config_ == nullptr) {
-        kv_cache_ = std::make_shared<cache::PagedKVCache>(
-            config_.head_dim,
-            config_.head_dim,
-            config_.num_key_value_heads,
-            config_.num_key_value_heads,
-            config_.num_hidden_layers,
-            model_config_->get_kv_cache_dtype(),
-            *paged_kv_cache_config,
-            rank_info_);
-    } else if (auto kv_cache_config = dynamic_cast<const cache::StaticKVCacheConfig *>(cache_config)) {
+    if (auto kv_cache_config = dynamic_cast<const cache::StaticKVCacheConfig *>(cache_config)) {
         kv_cache_ = std::make_shared<cache::StaticKVCache>(
             model_config_->get_head_dim(),
             model_config_->get_head_dim(),

--- a/csrc/models/llama_legacy/llama_model.hpp
+++ b/csrc/models/llama_legacy/llama_model.hpp
@@ -37,23 +37,6 @@ public:
      * @param device Device to create tensors on
      * @param dtype Optional data type for model parameters (defaults to F32)
      */
-    /**
-     * @deprecated This function is deprecated and will be REMOVED in the next major release (v0.2.0).
-     *
-     * ⚠️ DEVELOPMENT POLICY:
-     *   - NO new development or feature additions permitted on this interface
-     *   - Only critical bug fixes (security/stability) allowed until removal
-     *   - All new code MUST migrate to the polymorphic overload below
-     *
-     * Replacement: Use the polymorphic overload of this same function name with updated signature
-     * Reason: Legacy signature lacks support for dynamic quantization modes.
-     * Removal target: v0.2.0 (Q2 2026)
-     */
-    LlamaModel(const LlamaConfig &config,
-               const infinicore::Device &device,
-               engine::distributed::RankInfo rank_info = engine::distributed::RankInfo(),
-               backends::AttentionBackend attention_backend = backends::AttentionBackend::Default);
-
     LlamaModel(std::shared_ptr<infinilm::config::ModelConfig> model_config,
                const infinicore::Device &device,
                engine::distributed::RankInfo rank_info = engine::distributed::RankInfo(),
@@ -96,16 +79,12 @@ public:
     size_t num_layers() const { return model_config_->get<size_t>("num_hidden_layers"); }
 
 protected:
-    // Token embeddings
     INFINICORE_NN_MODULE(infinicore::nn::Embedding, embed_tokens);
 
-    // Decoder layers
     INFINICORE_NN_MODULE_VEC(LlamaDecoderLayer, layers);
 
-    // Final normalization
     INFINICORE_NN_MODULE(infinicore::nn::RMSNorm, norm);
 
-    // Rotary Position Embeddings (shared across all layers)
     INFINICORE_NN_MODULE(infinicore::nn::RoPE, rotary_emb);
 
     engine::distributed::RankInfo rank_info_;
@@ -113,8 +92,6 @@ protected:
     std::shared_ptr<cache::Cache> kv_cache_;
 
 private:
-    LlamaConfig config_;
-
     std::shared_ptr<infinilm::config::ModelConfig> model_config_;
 };
 

--- a/csrc/models/minicpm_sala/minicpm_sala_attention.cpp
+++ b/csrc/models/minicpm_sala/minicpm_sala_attention.cpp
@@ -1,5 +1,6 @@
 #include "minicpm_sala_attention.hpp"
 #include "../../global_state/global_state.hpp"
+#include "../../layers/attention/attention.hpp"
 #include <stdexcept>
 
 namespace infinilm::models::minicpm_sala {
@@ -32,23 +33,16 @@ AttentionBase::AttentionBase(std::shared_ptr<infinilm::config::ModelConfig> mode
     num_attention_heads_ = total_num_heads / static_cast<size_t>(tp_size);
     num_key_value_heads_ = total_num_kv_heads / static_cast<size_t>(tp_size);
 
-    auto quant_scheme = model_config->get_quant_scheme();
     auto quantization_method = model_config->get_quantization_method();
-    switch (quant_scheme) {
-    case infinicore::quantization::QuantScheme::NONE:
-        INFINICORE_NN_MODULE_INIT(q_proj, hidden_size_, total_num_heads * head_dim_, quantization_method,
+
+    q_proj_ = this->register_module<infinilm::layers::linear::ColumnParallelLinear>("q_proj", hidden_size_, total_num_heads * head_dim_, quantization_method,
                                   use_bias_, dtype, device, tp_rank, tp_size);
-        INFINICORE_NN_MODULE_INIT(k_proj, hidden_size_, total_num_kv_heads * head_dim_, quantization_method,
+    k_proj_ = this->register_module<infinilm::layers::linear::ColumnParallelLinear>("k_proj", hidden_size_, total_num_kv_heads * head_dim_, quantization_method,
                                   use_bias_, dtype, device, tp_rank, tp_size);
-        INFINICORE_NN_MODULE_INIT(v_proj, hidden_size_, total_num_kv_heads * head_dim_, quantization_method,
+    v_proj_ = this->register_module<infinilm::layers::linear::ColumnParallelLinear>("v_proj", hidden_size_, total_num_kv_heads * head_dim_, quantization_method,
                                   use_bias_, dtype, device, tp_rank, tp_size);
-        INFINICORE_NN_MODULE_INIT(o_proj, total_num_heads * head_dim_, hidden_size_, quantization_method,
+    o_proj_ = this->register_module<infinilm::layers::linear::RowParallelLinear>("o_proj", total_num_heads * head_dim_, hidden_size_, quantization_method,
                                   use_output_bias_, dtype, device, tp_rank, tp_size, rank_info.comm);
-        break;
-    default:
-        throw std::runtime_error("infinilm::models::minicpm_sala::AttentionBase: unsupported quantization scheme");
-        break;
-    }
 
     rotary_emb_ = infinilm::layers::rotary_embedding::get_rope(model_config, device);
 
@@ -57,21 +51,8 @@ AttentionBase::AttentionBase(std::shared_ptr<infinilm::config::ModelConfig> mode
                                                                           num_key_value_heads_, layer_idx_,
                                                                           kv_cache_k_scale_, kv_cache_v_scale_, attention_backend_);
 
-    auto kv_quant_scheme = infinilm::global_state::get_infinilm_config().model_config->get_kv_quant_scheme();
-    switch (kv_quant_scheme) {
-    case (infinicore::quantization::KVQuantAlgo::NONE): {
-        break;
-    }
-    case (infinicore::quantization::KVQuantAlgo::INT8): {
-        INFINICORE_NN_PARAMETER_INIT(kv_cache_k_scale, ({1}, infinicore::DataType::F32, device, 0, 0, 1));
-        INFINICORE_NN_PARAMETER_INIT(kv_cache_v_scale, ({1}, infinicore::DataType::F32, device, 0, 0, 1));
-        break;
-    }
-    default: {
-        throw std::runtime_error("infinilm::layers::attention: unsupported kv_quant_scheme");
-        break;
-    }
-    }
+    infinilm::layers::attention::init_kv_cache_quant_params([this](const std::string &n, infinicore::nn::Parameter p) { this->register_parameter(n, std::move(p)); },
+                              device, kv_cache_k_scale_, kv_cache_v_scale_);
 }
 
 InfLLMv2Attention::InfLLMv2Attention(std::shared_ptr<infinilm::config::ModelConfig> model_config,
@@ -85,7 +66,7 @@ InfLLMv2Attention::InfLLMv2Attention(std::shared_ptr<infinilm::config::ModelConf
     const auto &dtype{model_config->get_dtype()};
     size_t num_attention_heads = model_config->get<size_t>("num_attention_heads");
     if (use_output_gate_) {
-        INFINICORE_NN_MODULE_INIT(o_gate, hidden_size_, num_attention_heads * head_dim_,
+        o_gate_ = this->register_module<infinilm::layers::linear::ReplicatedLinear>("o_gate", hidden_size_, num_attention_heads * head_dim_,
                                   model_config->get_quantization_method(), use_bias_, dtype, device);
     }
 }
@@ -119,7 +100,7 @@ LightningAttention::LightningAttention(std::shared_ptr<infinilm::config::ModelCo
         INFINICORE_NN_MODULE_INIT(o_norm, num_attention_heads * head_dim_, rms_norm_eps, dtype, device);
     }
     if (use_output_gate_) {
-        INFINICORE_NN_MODULE_INIT(z_proj, hidden_size_, num_attention_heads * head_dim_,
+        z_proj_ = this->register_module<infinilm::layers::linear::ReplicatedLinear>("z_proj", hidden_size_, num_attention_heads * head_dim_,
                                   model_config->get_quantization_method(), use_bias_, dtype, device);
     }
 }

--- a/csrc/models/minicpm_sala/minicpm_sala_attention.hpp
+++ b/csrc/models/minicpm_sala/minicpm_sala_attention.hpp
@@ -24,10 +24,10 @@ public:
     size_t hidden_size() const { return hidden_size_; }
 
 protected:
-    INFINICORE_NN_MODULE(infinilm::layers::linear::ColumnParallelLinear, q_proj);
-    INFINICORE_NN_MODULE(infinilm::layers::linear::ColumnParallelLinear, k_proj);
-    INFINICORE_NN_MODULE(infinilm::layers::linear::ColumnParallelLinear, v_proj);
-    INFINICORE_NN_MODULE(infinilm::layers::linear::RowParallelLinear, o_proj);
+    std::shared_ptr<infinilm::layers::linear::ColumnParallelLinear> q_proj_;
+    std::shared_ptr<infinilm::layers::linear::ColumnParallelLinear> k_proj_;
+    std::shared_ptr<infinilm::layers::linear::ColumnParallelLinear> v_proj_;
+    std::shared_ptr<infinilm::layers::linear::RowParallelLinear> o_proj_;
 
     std::shared_ptr<infinilm::layers::attention::AttentionLayer> attn_;
     ::infinilm::backends::AttentionBackend attention_backend_;
@@ -60,7 +60,7 @@ public:
 
 protected:
     bool use_output_gate_;
-    INFINICORE_NN_MODULE(infinilm::layers::linear::ReplicatedLinear, o_gate);
+    std::shared_ptr<infinilm::layers::linear::ReplicatedLinear> o_gate_;
 };
 
 /**
@@ -82,7 +82,7 @@ protected:
     INFINICORE_NN_MODULE(infinicore::nn::RMSNorm, q_norm);
     INFINICORE_NN_MODULE(infinicore::nn::RMSNorm, k_norm);
     INFINICORE_NN_MODULE(infinicore::nn::RMSNorm, o_norm);
-    INFINICORE_NN_MODULE(infinilm::layers::linear::ReplicatedLinear, z_proj);
+    std::shared_ptr<infinilm::layers::linear::ReplicatedLinear> z_proj_;
 };
 
 } // namespace infinilm::models::minicpm_sala

--- a/csrc/models/model_factory.cpp
+++ b/csrc/models/model_factory.cpp
@@ -3,38 +3,6 @@
 #include "models_registry.hpp"
 
 namespace infinilm {
-/**
- * @deprecated This function is deprecated and will be REMOVED in the next major release (v0.2.0).
- *
- * ⚠️ DEVELOPMENT POLICY:
- *   - NO new development or feature additions permitted on this interface
- *   - Only critical bug fixes (security/stability) allowed until removal
- *   - All new code MUST migrate to the polymorphic overload below
- *
- * Replacement: Use the polymorphic overload of this same function name with updated signature
- * Reason: Legacy signature lacks support for dynamic quantization modes.
- * Removal target: v0.2.0 (Q2 2026)
- */
-std::shared_ptr<InfinilmModel> InfinilmModelFactory::createModel(
-    const InfinilmModel::Config &config,
-    engine::distributed::RankInfo rank_info,
-    const cache::CacheConfig *cache,
-    backends::AttentionBackend attention_backend) {
-    std::shared_ptr<InfinilmModel> model;
-    if (const auto llama_config_ptr = dynamic_cast<const models::llama_legacy::LlamaConfig *>(&config)) {
-        const auto &llama_config = *llama_config_ptr;
-        model = std::make_shared<models::llama_legacy::LlamaForCausalLM>(
-            llama_config, rank_info.device, rank_info, attention_backend);
-    } else {
-        throw std::invalid_argument("InfinilmModelFactory::createModel: Unsupported model config type");
-    }
-
-    if (cache) {
-        model->reset_cache(cache);
-    }
-
-    return model;
-}
 
 std::shared_ptr<InfinilmModel> InfinilmModelFactory::createModel(
     std::shared_ptr<infinilm::config::ModelConfig> model_config,

--- a/csrc/models/model_factory.hpp
+++ b/csrc/models/model_factory.hpp
@@ -5,29 +5,9 @@
 #include "infinilm_model.hpp"
 
 namespace infinilm {
+
 class InfinilmModelFactory {
 public:
-    /**
-     * @deprecated This function is deprecated and will be REMOVED in the next major release (v0.2.0).
-     *
-     * ⚠️ DEVELOPMENT POLICY:
-     *   - NO new development or feature additions permitted on this interface
-     *   - Only critical bug fixes (security/stability) allowed until removal
-     *   - All new code MUST migrate to the polymorphic overload below
-     *
-     * Replacement: Use the polymorphic overload of this same function name with updated signature
-     * Reason: Legacy signature lacks support for dynamic quantization modes.
-     * Removal target: v0.2.0 (Q2 2026)
-     */
-    static std::shared_ptr<InfinilmModel> createModel(
-        const InfinilmModel::Config &config,
-        engine::distributed::RankInfo rank_info = engine::distributed::RankInfo(),
-        const cache::CacheConfig *cache = nullptr,
-        backends::AttentionBackend attention_backend = backends::AttentionBackend::Default);
-
-    /**
-     * @deprecated This function is deprecated and will be REMOVED in the next major release.
-     */
     static std::shared_ptr<InfinilmModel> createModel(
         std::shared_ptr<infinilm::config::ModelConfig> model_config,
         engine::distributed::RankInfo rank_info = engine::distributed::RankInfo(),

--- a/csrc/models/qwen3/qwen3_attention.cpp
+++ b/csrc/models/qwen3/qwen3_attention.cpp
@@ -1,5 +1,6 @@
 #include "qwen3_attention.hpp"
 #include "../../global_state/global_state.hpp"
+#include "../../layers/attention/attention.hpp"
 #include "../../utils.hpp"
 
 namespace infinilm::models::qwen3 {
@@ -29,35 +30,15 @@ Qwen3Attention::Qwen3Attention(std::shared_ptr<infinilm::config::ModelConfig> mo
     num_attention_heads_ = total_num_heads / tp_size;
     num_key_value_heads_ = total_num_kv_heads / tp_size;
 
-    auto quant_scheme = model_config->get_quant_scheme();
     auto quantization_method = model_config->get_quantization_method();
-    switch (quant_scheme) {
-    case infinicore::quantization::QuantScheme::NONE: {
-        INFINILM_QKV_LINEAR_INIT(qkv_proj, "q_proj", "k_proj", "v_proj", hidden_size_, head_dim_, total_num_heads, total_num_kv_heads,
-                                 quantization_method, use_bias, dtype, device, rank_info);
-        INFINICORE_NN_MODULE_INIT(o_proj, total_num_heads * head_dim_, hidden_size_, quantization_method,
-                                  use_output_bias, dtype, device, tp_rank, tp_size, rank_info.comm);
-        break;
-    }
-    case infinicore::quantization::QuantScheme::COMPRESSED_TENSOR_W8A8I8: {
-        INFINILM_QKV_LINEAR_W8A8_INIT(qkv_proj, "q_proj", "k_proj", "v_proj", hidden_size_, head_dim_, total_num_heads, total_num_kv_heads,
-                                      quantization_method, use_bias, dtype, device, rank_info);
-        INFINICORE_NN_MODULE_INIT(o_proj, total_num_heads * head_dim_, hidden_size_, quantization_method,
-                                  use_output_bias, dtype, device, tp_rank, tp_size, rank_info.comm);
-        break;
-    }
-    case infinicore::quantization::QuantScheme::AWQ_W4A16: {
-        INFINILM_QKV_LINEAR_W4A16AWQ_INIT(qkv_proj, "q_proj", "k_proj", "v_proj", hidden_size_, head_dim_, total_num_heads, total_num_kv_heads,
-                                          quantization_method, use_bias, dtype, device, rank_info);
-        INFINICORE_NN_MODULE_INIT(o_proj, total_num_heads * head_dim_, hidden_size_, quantization_method,
-                                  use_output_bias, dtype, device, tp_rank, tp_size, rank_info.comm);
-        break;
-    }
-    default: {
-        throw std::runtime_error("infinilm::models::qwen3::Qwen3Attention: unsupported quantization scheme");
-        break;
-    }
-    }
+    auto register_fn = [this](const std::string &n, infinicore::nn::Parameter p) { this->register_parameter(n, std::move(p)); };
+    qkv_proj_ = std::make_shared<layers::linear::QKVParallelLinear>(
+        hidden_size_, head_dim_, total_num_heads, total_num_kv_heads,
+        "q_proj", "k_proj", "v_proj", register_fn,
+        quantization_method, use_bias, dtype, device, rank_info);
+    o_proj_ = this->register_module<layers::linear::RowParallelLinear>(
+        "o_proj", total_num_heads * head_dim_, hidden_size_, quantization_method,
+        use_output_bias, dtype, device, tp_rank, tp_size, rank_info.comm);
 
     rotary_emb_ = infinilm::layers::rotary_embedding::get_rope(model_config, device);
 
@@ -68,21 +49,7 @@ Qwen3Attention::Qwen3Attention(std::shared_ptr<infinilm::config::ModelConfig> mo
     INFINICORE_NN_MODULE_INIT(q_norm, head_dim_, rms_norm_eps, dtype, device);
     INFINICORE_NN_MODULE_INIT(k_norm, head_dim_, rms_norm_eps, dtype, device);
 
-    auto kv_quant_scheme = infinilm::global_state::get_infinilm_config().model_config->get_kv_quant_scheme();
-    switch (kv_quant_scheme) {
-    case (infinicore::quantization::KVQuantAlgo::NONE): {
-        break;
-    }
-    case (infinicore::quantization::KVQuantAlgo::INT8): {
-        INFINICORE_NN_PARAMETER_INIT(kv_cache_k_scale, ({1}, infinicore::DataType::F32, device, 0, 0, 1));
-        INFINICORE_NN_PARAMETER_INIT(kv_cache_v_scale, ({1}, infinicore::DataType::F32, device, 0, 0, 1));
-        break;
-    }
-    default: {
-        throw std::runtime_error("infinilm::layers::attention: unsupported kv_quant_scheme");
-        break;
-    }
-    }
+    infinilm::layers::attention::init_kv_cache_quant_params(register_fn, device, kv_cache_k_scale_, kv_cache_v_scale_);
 }
 
 infinicore::Tensor Qwen3Attention::forward(const infinicore::Tensor &positions,

--- a/csrc/models/qwen3/qwen3_attention.hpp
+++ b/csrc/models/qwen3/qwen3_attention.hpp
@@ -26,8 +26,8 @@ private:
                                       const infinicore::Tensor &hidden_states) const;
 
 protected:
-    INFINICORE_NN_MODULE(infinilm::layers::linear::QKVParallelLinear, qkv_proj);
-    INFINICORE_NN_MODULE(infinilm::layers::linear::RowParallelLinear, o_proj);
+    std::shared_ptr<infinilm::layers::linear::QKVParallelLinear> qkv_proj_;
+    std::shared_ptr<infinilm::layers::linear::RowParallelLinear> o_proj_;
     INFINICORE_NN_MODULE(infinicore::nn::RMSNorm, q_norm);
     INFINICORE_NN_MODULE(infinicore::nn::RMSNorm, k_norm);
     std::shared_ptr<infinicore::nn::RoPE> rotary_emb_;

--- a/csrc/models/qwen3_next/qwen3_next_attention.cpp
+++ b/csrc/models/qwen3_next/qwen3_next_attention.cpp
@@ -35,34 +35,15 @@ Qwen3NextAttention::Qwen3NextAttention(std::shared_ptr<infinilm::config::ModelCo
     num_attention_heads_ = total_num_heads / tp_size;
     num_key_value_heads_ = total_num_kv_heads / tp_size;
 
-    auto quant_scheme = model_config->get_quant_scheme();
     auto quantization_method = model_config->get_quantization_method();
-    switch (quant_scheme) {
-    case infinicore::quantization::QuantScheme::NONE: {
-        INFINILM_QKV_LINEAR_INIT(qkv_proj, "q_proj", "k_proj", "v_proj", hidden_size_, head_dim_, total_num_heads * (1 + attn_output_gate), total_num_kv_heads, quantization_method,
-                                 use_bias, dtype, device, rank_info);
-        INFINICORE_NN_MODULE_INIT(o_proj, total_num_heads * head_dim_, hidden_size_, quantization_method,
-                                  use_output_bias, dtype, device, tp_rank, tp_size, rank_info.comm);
-        break;
-    }
-    case infinicore::quantization::QuantScheme::COMPRESSED_TENSOR_W8A8I8: {
-        INFINILM_QKV_LINEAR_W8A8_INIT(qkv_proj, "q_proj", "k_proj", "v_proj", hidden_size_, head_dim_, total_num_heads * (1 + attn_output_gate), total_num_kv_heads, quantization_method,
-                                      use_bias, dtype, device, rank_info);
-        INFINICORE_NN_MODULE_INIT(o_proj, total_num_heads * head_dim_, hidden_size_, quantization_method,
-                                  use_output_bias, dtype, device, tp_rank, tp_size, rank_info.comm);
-        break;
-    }
-    case infinicore::quantization::QuantScheme::AWQ_W4A16: {
-        INFINILM_QKV_LINEAR_W4A16AWQ_INIT(qkv_proj, "q_proj", "k_proj", "v_proj", hidden_size_, head_dim_, total_num_heads * (1 + attn_output_gate), total_num_kv_heads, quantization_method,
-                                          use_bias, dtype, device, rank_info);
-        INFINICORE_NN_MODULE_INIT(o_proj, total_num_heads * head_dim_, hidden_size_, quantization_method,
-                                  use_output_bias, dtype, device, tp_rank, tp_size, rank_info.comm);
-        break;
-    }
-    default: {
-        throw std::runtime_error("infinilm::models::qwen3_next::Qwen3NextAttention: unsupported quantization scheme");
-    }
-    }
+    auto register_fn = [this](const std::string &n, infinicore::nn::Parameter p) { this->register_parameter(n, std::move(p)); };
+    qkv_proj_ = std::make_shared<layers::linear::QKVParallelLinear>(
+        hidden_size_, head_dim_, total_num_heads * (1 + attn_output_gate), total_num_kv_heads,
+        "q_proj", "k_proj", "v_proj", register_fn,
+        quantization_method, use_bias, dtype, device, rank_info);
+    o_proj_ = this->register_module<layers::linear::RowParallelLinear>(
+        "o_proj", total_num_heads * head_dim_, hidden_size_, quantization_method,
+        use_output_bias, dtype, device, tp_rank, tp_size, rank_info.comm);
 
     rotary_emb_ = infinilm::layers::rotary_embedding::get_rope(model_config, device);
 

--- a/csrc/models/qwen3_next/qwen3_next_attention.hpp
+++ b/csrc/models/qwen3_next/qwen3_next_attention.hpp
@@ -20,8 +20,8 @@ public:
     size_t hidden_size() const { return hidden_size_; }
 
 protected:
-    INFINICORE_NN_MODULE(infinilm::layers::linear::QKVParallelLinear, qkv_proj);
-    INFINICORE_NN_MODULE(infinilm::layers::linear::RowParallelLinear, o_proj);
+    std::shared_ptr<infinilm::layers::linear::QKVParallelLinear> qkv_proj_;
+    std::shared_ptr<infinilm::layers::linear::RowParallelLinear> o_proj_;
     INFINICORE_NN_MODULE(infinicore::nn::RMSNorm, q_norm);
     INFINICORE_NN_MODULE(infinicore::nn::RMSNorm, k_norm);
     std::shared_ptr<infinicore::nn::RoPE> rotary_emb_;

--- a/csrc/models/qwen3_next/qwen3_next_gated_deltanet.cpp
+++ b/csrc/models/qwen3_next/qwen3_next_gated_deltanet.cpp
@@ -41,14 +41,14 @@ Qwen3NextGatedDeltaNet::Qwen3NextGatedDeltaNet(std::shared_ptr<infinilm::config:
     size_t projection_size_qkvz = key_dim * 2 + value_dim * 2;
     size_t projection_size_ba = linear_num_value_heads * 2;
 
-    INFINICORE_NN_MODULE_INIT(in_proj_qkvz, hidden_size, projection_size_qkvz, false, dtype, device);
-    INFINICORE_NN_MODULE_INIT(in_proj_ba, hidden_size, projection_size_ba, false, dtype, device);
+    in_proj_qkvz_ = this->register_module<infinilm::layers::linear::ReplicatedLinear>("in_proj_qkvz", hidden_size, projection_size_qkvz, false, dtype, device);
+    in_proj_ba_ = this->register_module<infinilm::layers::linear::ReplicatedLinear>("in_proj_ba", hidden_size, projection_size_ba, false, dtype, device);
 
     INFINICORE_NN_PARAMETER_INIT(dt_bias, ({linear_num_value_heads}, dtype, device));
     INFINICORE_NN_PARAMETER_INIT(A_log, ({linear_num_value_heads}, dtype, device));
 
     INFINICORE_NN_MODULE_INIT(norm, linear_value_head_dim, rms_norm_eps, dtype, device);
-    INFINICORE_NN_MODULE_INIT(out_proj, value_dim, hidden_size, false, dtype, device);
+    out_proj_ = this->register_module<infinilm::layers::linear::ReplicatedLinear>("out_proj", value_dim, hidden_size, false, dtype, device);
 }
 
 infinicore::Tensor Qwen3NextGatedDeltaNet::forward(const infinicore::Tensor &positions,

--- a/csrc/models/qwen3_next/qwen3_next_gated_deltanet.hpp
+++ b/csrc/models/qwen3_next/qwen3_next_gated_deltanet.hpp
@@ -33,13 +33,13 @@ public:
                                const infinicore::Tensor &hidden_states) const;
 
 private:
-    INFINICORE_NN_MODULE(infinilm::layers::linear::ReplicatedLinear, in_proj_qkvz);
-    INFINICORE_NN_MODULE(infinilm::layers::linear::ReplicatedLinear, in_proj_ba);
+    std::shared_ptr<infinilm::layers::linear::ReplicatedLinear> in_proj_qkvz_;
+    std::shared_ptr<infinilm::layers::linear::ReplicatedLinear> in_proj_ba_;
     INFINICORE_NN_MODULE(FakeConv1d, conv1d);
     INFINICORE_NN_PARAMETER(dt_bias);
     INFINICORE_NN_PARAMETER(A_log);
     INFINICORE_NN_MODULE(Qwen3Next_Fake_RMSNormGated, norm);
-    INFINICORE_NN_MODULE(infinilm::layers::linear::ReplicatedLinear, out_proj);
+    std::shared_ptr<infinilm::layers::linear::ReplicatedLinear> out_proj_;
 
     size_t layer_idx_;
 };

--- a/csrc/pybind11/engine/engine.hpp
+++ b/csrc/pybind11/engine/engine.hpp
@@ -32,50 +32,6 @@ inline void bind_infer_engine(py::module &m) {
     py::class_<InferEngine, std::shared_ptr<InferEngine>> infer_engine(m, "InferEngine");
     infer_engine
         .def(py::init([](
-                          const InfinilmModel::Config &cfg,
-                          const distributed::DistConfig &dist,
-                          infinicore::Device::Type dev,
-                          std::shared_ptr<const infinilm::cache::CacheConfig> cache_cfg,
-                          bool enable_graph_compiling,
-                          const std::string &attention_backend) {
-                 return std::make_shared<InferEngine>(
-                     cfg,
-                     dist,
-                     dev,
-                     cache_cfg ? cache_cfg.get() : nullptr,
-                     enable_graph_compiling,
-                     infinilm::backends::parse_attention_backend(attention_backend));
-             }),
-             py::arg("config"),
-             py::arg("distributed_config") = distributed::DistConfig(),
-             py::arg("device_type") = infinicore::context::getDevice().getType(),
-             py::arg("cache_config") = py::none(),
-             py::arg("enable_graph_compiling") = false,
-             py::arg("attention_backend") = "default")
-        .def("load_param", &InferEngine::load_param,
-             py::arg("name"), py::arg("param"),
-             "Load a parameter tensor into all workers (each worker picks its shard)")
-        .def("state_dict", [](InferEngine &self) {
-            py::list state_dict_tp_all;
-            for (const auto &state_dict_tp : self.state_dict()) {
-                py::dict result;
-                for (const auto &[name, param] : state_dict_tp) {
-                    result[py::cast(name)] = infinicore::Tensor(param);
-                }
-                state_dict_tp_all.append(result);
-            }
-            return state_dict_tp_all;
-        })
-        .def("process_weights_after_loading", &InferEngine::process_weights_after_loading, "Process the weights after loading on all workers (e.g., for quantization)")
-        .def("forward", [](InferEngine &self, const InferEngine::Input &input) -> InferEngine::Output { return self.forward(input); }, "Run inference on all ranks with arbitrary arguments")
-        .def("reset_cache", [](InferEngine &self, std::shared_ptr<cache::CacheConfig> cfg) { self.reset_cache(cfg ? cfg.get() : nullptr); }, py::arg("cache_config") = py::none())
-        .def("get_cache_config", [](const InferEngine &self) -> std::shared_ptr<cache::CacheConfig> {
-            auto cfg = self.get_cache_config();
-            return cfg ? std::shared_ptr<cache::CacheConfig>(cfg->unique_copy()) : nullptr; })
-        .def("__repr__", [](const InferEngine &self) { return "<InferEngine: " + std::string(self.get_dist_config()) + ">"; });
-
-    infer_engine
-        .def(py::init([](
                           const std::string &model_path,
                           const distributed::DistConfig &dist,
                           infinicore::Device::Type dev,
@@ -116,9 +72,9 @@ inline void bind_infer_engine(py::module &m) {
         .def("process_weights_after_loading", &InferEngine::process_weights_after_loading, "Process the weights after loading on all workers (e.g., for quantization)")
         .def("forward", [](InferEngine &self, const InferEngine::Input &input) -> InferEngine::Output { return self.forward(input); }, "Run inference on all ranks with arbitrary arguments")
         .def("reset_cache", [](InferEngine &self, std::shared_ptr<cache::CacheConfig> cfg) { self.reset_cache(cfg ? cfg.get() : nullptr); }, py::arg("cache_config") = py::none())
-        .def("get_cache_config", [](const InferEngine &self) {
+        .def("get_cache_config", [](const InferEngine &self) -> std::shared_ptr<cache::CacheConfig> {
             auto cfg = self.get_cache_config();
-            return std::shared_ptr<cache::CacheConfig>(std::move(cfg->unique_copy())); })
+            return cfg ? std::shared_ptr<cache::CacheConfig>(cfg->unique_copy()) : nullptr; })
         .def("__repr__", [](const InferEngine &self) { return "<InferEngine: " + std::string(self.get_dist_config()) + ">"; });
 
     py::class_<InferEngine::Input>(infer_engine, "Input")

--- a/csrc/utils.hpp
+++ b/csrc/utils.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <infinicore/dtype.hpp>
+#include <infinicore/context/context.hpp>
 #include <infinirt.h>
 
 #include <cstring>
@@ -7,6 +8,7 @@
 #include <spdlog/spdlog.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <vector>
 
 inline void assertTrue(int expr, const char *msg, const char *function, const char *file, int line) {
     if (!expr) {
@@ -118,6 +120,16 @@ inline uint16_t f32_to_bf16(float val) {
     uint16_t bf16_bits = static_cast<uint16_t>((bits32 + rounding_bias) >> 16);
 
     return bf16_bits;
+}
+
+inline void set_zeros(infinicore::Tensor &tensor) {
+    std::vector<uint8_t> zeros(tensor->nbytes(), 0);
+    infinicore::context::memcpyH2D(tensor->data(), zeros.data(), tensor->nbytes(), false);
+}
+
+inline void set_minus_one(infinicore::Tensor &tensor) {
+    std::vector<uint8_t> minus_one(tensor->nbytes(), 0xFF);
+    infinicore::context::memcpyH2D(tensor->data(), minus_one.data(), tensor->nbytes(), false);
 }
 
 // Hash combine utility (similar to boost::hash_combine)


### PR DESCRIPTION
<!--
Thanks for contributing to InfiniLM! Please read `CONTRIBUTING.md` before
opening a pull request and fill out every section below. Delete any section
that is genuinely not applicable (and note why), but do not delete the
"Checklist" section — it must be filled in for every PR.

The PR title MUST follow Conventional Commits, e.g.
  feat: support Llama 3 models
  fix: correct linear attention calculations
See: https://www.conventionalcommits.org/
-->

## Summary

<!--
A concise description of **what** this PR changes. Prefer bullet points over
prose. Reference files with backtick-fenced paths (e.g. `csrc/models/llama/*`).
-->

-
-

## Motivation

<!--
Explain **why** this change is needed. Link to any related issue, bug, or
discussion. If this is a performance change, include before/after numbers
(hardware, shape, dtype, and the measurement methodology).
-->

Closes #

## Type of Change

<!-- Tick one or more. -->

- [ ] `feat` — new feature / new model
- [ ] `fix` — bug fix
- [ ] `perf` — performance improvement (no behavioral change)
- [ ] `refactor` — code restructuring without behavior change
- [ ] `test` — adding or fixing tests only
- [ ] `docs` — documentation only
- [ ] `build` / `ci` — build system or CI configuration
- [ ] `chore` — tooling, formatting, or other non-code changes
- [ ] Breaking change

## Test Results of Involved Models on Supported Platforms (Please attach screenshots)

<!--
For now, provide the screenshots for involved tests performed on platforms supposed to support the changes.

Tests that might be involved:
Single request test: examples/test_infer.py
Offline performance: examples/bench.py
Sanity test: test/bench/test_benchmark.py
Service: python/infinilm/server/inference_server.py + scripts/test_perf.py

Model adaptations may involve all four tests, unless specifying partial support for vastly new structures and confirmed with admin.

Python-level changes may involve less tests depending on which files/features are modified. 

Framework-level and Python-level changes may affect different models. Test a few models that might be affected.
-->

## Benchmark / Performance Impact

<!--
Required for `perf` PRs; optional otherwise. Describe the benchmark harness,
shapes, dtypes, hardware, and include baseline vs. new numbers. If the PR is
not performance-sensitive, write "N/A".
-->

## Notes for Reviewers

<!--
Anything reviewers should focus on: subtle invariants, known trade-offs,
follow-up work intentionally left out of scope, etc.
-->

---

## Checklist

> Every contributor **must** verify every item below before requesting
> review. Tick each box only after the check has actually been performed —
> do not tick speculatively. If an item truly does not apply, replace the
> checkbox with `N/A` and briefly explain why in an inline comment.

### Title, Branch, and Commits

- [ ] PR **title** follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(nvidia): …`, `fix(cuda/gemm): …`).
- [ ] Branch name follows `<type>/xxx-yyyy-zzzz` where `<type>` matches the PR title's Conventional Commits type and words are joined with hyphens (see `CONTRIBUTING.md` §Branches).
- [ ] Each **commit** message follows Conventional Commits.
- [ ] Small PR is a **single squashable commit**; or, for a large PR, every commit is meaningful, well-formed, and independently reviewable (see `CONTRIBUTING.md` §Pull Requests).
- [ ] No stray merge commits from `main` — the branch is rebased cleanly on top of the current `main`.
- [ ] No `fixup!` / `squash!` / `wip` commits remain.
- [ ] Existing PR/branch/commit that followed the legacy issue format.

### Scope and Design

- [ ] Changes are **minimal** — nothing unrelated to the stated motivation was added (`CONTRIBUTING.md` §Code/General).
- [ ] No dead code, commented-out blocks, debug prints, `printf`/`std::cout`/`print(...)` left behind, or `TODO` without an owner and issue link.
- [ ] No unrelated formatting churn that would obscure the diff.
- [ ] Public API changes (if any) are intentional, documented, and reflected in affected callers/tests.

### General Code Hygiene (applies to all languages)

- [ ] The code is self-explanatory; comments were added **only** where the *why* is non-obvious (`CONTRIBUTING.md` §Code/General).
- [ ] Every modified or added file **ends with a single trailing newline** (`CONTRIBUTING.md` §Code/General).
- [ ] No trailing whitespace, tab/space mixing, or stray BOMs.
- [ ] Identifiers in comments and error messages are wrapped in backticks (e.g. ``the `seqlens_k` tensor``) (`CONTRIBUTING.md` §Code/General).
- [ ] All comments and error messages are in **English** (`CONTRIBUTING.md` §Code/General).
- [ ] Comments and error messages are complete sentences — capitalized first letter, terminal punctuation — **unless** the language/framework convention says otherwise (`CONTRIBUTING.md` §Code/General; §Python).

### C++ Specific (if C++ files changed)

- [ ] Code follows the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) strictly.
- [ ] Error and warning message wording follows the [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html#error-and-warning-messages) (`CONTRIBUTING.md` §C++).
- [ ] Constructor **initializer list order matches member declaration order** (`CONTRIBUTING.md` §C++).
- [ ] No raw `new`/`delete`; RAII / smart pointers / existing allocators are used.
- [ ] Changed files are formatted by `scripts/format.py`.
- [ ] No changes/reference to `csrc/models/llama_legacy/`.

### Python Specific (if Python files changed)

- [ ] Code is [PEP 8](https://peps.python.org/pep-0008/) compliant.
- [ ] Comments are complete English sentences, starting with a capital letter and ending with punctuation; Markdown backticks are used for code references (`CONTRIBUTING.md` §Python).
- [ ] Docstrings (if any) follow [PEP 257](https://peps.python.org/pep-0257/) (`CONTRIBUTING.md` §Python).
- [ ] Changed files are formatted by `scripts/format.py`.
- [ ] No changes/reference to `python/infinilm/auto_config.py`.

### Testing

- [ ] For any platform that could not be tested, an explicit reason is given in the table and a reviewer with access has been tagged.
- [ ] Passed single request test (`examples/test_infer.py`), or specify the reason for skipping.
- [ ] Passed offline performance test (`examples/bench.py`), or specify the reason for skipping.
- [ ] Passed sanity test (`test/bench/test_benchmark.py`), or specify the reason for skipping.
- [ ] Passed service test (`python/infinilm/server/inference_server.py` + `scripts/test_perf.py`), or specify the reason for skipping.

### Build, CI, and Tooling

- [ ] The project builds cleanly from a fresh directory on at least one affected platform.

### Documentation

- [ ] `README.md`, `CONTRIBUTING.md`, or inline docs updated when behavior, build flags, or developer workflow changed.
- [ ] Any user-visible breaking change is called out explicitly under "Motivation" **and** in the commit/PR title with a `!` or `BREAKING CHANGE:` footer.

### Security and Safety

- [ ] No secrets, access tokens, internal URLs, customer data, or personal hardware identifiers have been committed.
- [ ] Third-party code is license-compatible and attributed.
- [ ] No unsafe pointer arithmetic, uninitialized reads, or missing bounds checks were introduced.
