### PR TITLE
issue/378 fix(static_scheduler): ensure at least one token for prefill on full cache hit

### DIFF
--- a/python/infinilm/llm/static_scheduler.py
+++ b/python/infinilm/llm/static_scheduler.py
@@ -177,6 +177,32 @@ class StaticScheduler:
                 del self.cached_block_hashes[matched:]
 
             prefix_hit_len = matched * _BLOCK_SIZE
+
+            # Prevent 100% prefix cache hits to avoid an empty prefill input.
+            # When prefix_hit_len equals the total token length, the remaining tokens
+            # for prefill would be zero (input_ids becomes empty), leading to crashes
+            # or incorrect state transitions in the downstream processor.
+            #
+            # This fix is directly inspired by SGLang's approach in their core scheduler
+            # logic (specifically the `adjust_max_prefix_ids` method). SGLang explicitly
+            # trims the prefix matching length to ensure at least one token is left:
+            #
+            #   # To work around some bugs in logprob computation, we need to
+            #   # ensure each request has at least one token. Later, we can relax
+            #   # this requirement and use `input_len`.
+            #   max_prefix_len = input_len - 1
+            #
+            # By forcing the last token to be "missed" from the cache hit, we guarantee
+            # that every request has at least one token to go through the prefill forward
+            # pass. This elegantly avoids the complexity of hijacking the request into
+            # the decode phase and handles edge cases in logprob computation gracefully.
+            #
+            # Mathematically and architecturally, this 2-line adjustment is exactly
+            # equivalent to SGLang's robust production strategy.
+            #
+            if prefix_hit_len >= len(tokens):
+                prefix_hit_len = len(tokens) - 1
+
             logger.info(
                 f"Prefill cache match: {matched}/{num_full_blocks} blocks "
                 f"({prefix_hit_len} tokens reused, {len(self.pending_block_hashes)} pending)"


### PR DESCRIPTION
A 100% prefix cache hit causes an empty `input_ids` tensor, crashing the downstream processor. Force leaving the last token for prefill to prevent this. This is directly equivalent to SGLang's robust production strategy in `adjust_max_prefix_ids`, which limits prefix matching to `input_len - 1` to handle logprob edge cases gracefully.

这里参考了sglang中sglang/srt/managers/scheduler_batch.py中的adjust_max_prefix_ids实现。
当cache全部命中的时候，从逻辑上来讲，直接就能跳过prefill流程，而直接进入decode，取prompt最后一个token送入decode。

但这样就会存在一些特殊的状态需要处理，影响状态机代码复杂度，影响状态机的效率，我猜测是这样。

sglang的实现就是简单粗暴，你全命中，那不行，我得给你保留一个token，你得干一个token的prefill的活。

大概就是这样，这个PR就同个思路修改。

修改前构造crash场景：
python examples/test_infer.py --device nvidia --model=/data/rubik/models/DeepSeek-R1-Distill-Qwen-7B/ --batch-size=4 --prompt="请问你能认真地介绍下你自己到底是谁吗"
<img width="1701" height="915" alt="image" src="https://github.com/user-attachments/assets/d605c9f1-304d-4ce4-8309-653ef0b6d793" />


修改后正常：
<img width="1699" height="937" alt="image" src="https://github.com/user-attachments/assets/da21647e-038a-4f83-ac1a-c03b374c0971" />
