### PR TITLE
issue/348 - Support Baichuan model

### DIFF
--- a/csrc/models/baichuan/baichuan_for_causal_lm.cpp
+++ b/csrc/models/baichuan/baichuan_for_causal_lm.cpp
@@ -1,0 +1,44 @@
+#include "baichuan_for_causal_lm.hpp"
+#include "../models_registry.hpp"
+
+namespace infinilm::models::baichuan {
+
+std::shared_ptr<infinilm::config::ModelConfig> create_baichuan_model_config(
+    std::shared_ptr<infinilm::config::ModelConfig> model_config) {
+    const std::string &model_type = model_config->get<std::string>("model_type");
+    if ("baichuan" != model_type) {
+        throw std::runtime_error(
+            "infinilm::models::baichuan::create_baichuan_model_config: model_type is not baichuan");
+    }
+
+    nlohmann::json &config_json = model_config->get_config_json();
+
+    if (!config_json.contains("num_key_value_heads")) {
+        config_json["num_key_value_heads"] = model_config->get<size_t>("num_attention_heads");
+    }
+
+    if (!config_json.contains("head_dim")) {
+        config_json["head_dim"] = model_config->get<size_t>("hidden_size")
+            / model_config->get<size_t>("num_attention_heads");
+    }
+
+    if (!config_json.contains("rope_theta")) {
+        config_json["rope_theta"] = 10000.0;
+    }
+
+    if (!config_json.contains("attention_bias")) {
+        config_json["attention_bias"] = false;
+    }
+
+    return model_config;
+}
+
+} // namespace infinilm::models::baichuan
+
+namespace {
+
+INFINILM_REGISTER_CAUSAL_LM_MODEL(
+    baichuan,
+    infinilm::models::baichuan::BaichuanForCausalLM,
+    infinilm::models::baichuan::create_baichuan_model_config);
+} // namespace

--- a/csrc/models/baichuan/baichuan_for_causal_lm.hpp
+++ b/csrc/models/baichuan/baichuan_for_causal_lm.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "../../layers/common_modules.hpp"
+#include "../llama/llama_for_causal_lm.hpp"
+#include <memory>
+
+namespace infinilm::models::baichuan {
+using BaichuanForCausalLM = infinilm::models::llama::LlamaForCausalLM;
+
+std::shared_ptr<infinilm::config::ModelConfig> create_baichuan_model_config(
+    std::shared_ptr<infinilm::config::ModelConfig> model_config);
+
+} // namespace infinilm::models::baichuan

--- a/examples/bench.py
+++ b/examples/bench.py
@@ -24,22 +24,55 @@ DATA_TYPE_BYTES = {
 
 _PAGED_KV_BLOCK_SIZE = 256
 
+# Maps model_type to its specific config key normalization rules.
+# Each rule maps a standard key (e.g., "head_dim") to either:
+#   - A string: representing the model-specific key name for direct mapping.
+#   - A callable: a function that takes the config dict and computes the derived value.
 _CONFIG_KEY_MAP = {
     "chatglm": {
         "num_key_value_heads": "multi_query_group_num",
         "num_hidden_layers": "num_layers",
         "head_dim": "kv_channels",
     },
+    "baichuan": {
+        "num_key_value_heads": "num_attention_heads",
+        "head_dim": lambda cfg: cfg["hidden_size"] // cfg["num_attention_heads"],
+    },
 }
 
 def _normalize_config(config, model_type):
-    key_map = _CONFIG_KEY_MAP.get(model_type)
-    if not key_map:
-        return config
+    """
+    Normalize model config to standard keys.
+
+    Applies model-specific key mappings and derived computations defined in
+    _CONFIG_KEY_MAP. Standard keys already present in the original config
+    will not be overwritten.
+    """
     normalized = dict(config)
-    for std_key, model_key in key_map.items():
-        if model_key in normalized:
-            normalized.setdefault(std_key, normalized[model_key])
+
+    key_map = _CONFIG_KEY_MAP.get(model_type)
+
+    if not key_map:
+        return normalized
+
+    for std_key, rule in key_map.items():
+        # Skip if the standard key already exists in the original config
+        if std_key in normalized:
+            continue
+
+        # Rule is a string: perform a direct key remapping
+        if isinstance(rule, str):
+            if rule in normalized:
+                normalized[std_key] = normalized[rule]
+
+        # Rule is a callable: compute the derived value dynamically
+        elif callable(rule):
+            try:
+                normalized[std_key] = rule(normalized)
+            except (KeyError, ZeroDivisionError, TypeError):
+                # Silently skip if dependencies are missing or computation fails
+                pass
+
     return normalized
 
 # BATCH_SIZES = [1, 4, 8, 16, 32, 64, 128]

--- a/python/infinilm/modeling_utils.py
+++ b/python/infinilm/modeling_utils.py
@@ -523,9 +523,53 @@ def _remap_chatglm(state_dict, config=None):
 
     return state_dict
 
+def _is_baichuan2(config):
+    """
+    Baichuan1 and Baichuan2 share the same model_type "baichuan" in official HuggingFace configs,
+    making them indistinguishable by model_type alone. However, their inference logic differs
+    critically: Baichuan2 requires normalized lm_head while Baichuan1 does not.
+
+    The most reliable automatic way to distinguish them is by vocab_size:
+      - Baichuan1: vocab_size = 64000
+      - Baichuan2: vocab_size = 125696
+    """
+    return config.get("vocab_size") == 125696
+
+def _remap_baichuan(state_dict, config=None):
+    """Split Baichuan fused W_pack into q_proj, k_proj, v_proj
+    and apply Baichuan2-specific fixes."""
+    import torch.nn.functional as F
+
+    hf_config = config or {}
+    hidden_size = hf_config.get("hidden_size", 4096)
+    num_heads = hf_config.get("num_attention_heads", 32)
+    vocab_size = hf_config.get("vocab_size", 125696)
+    per_head_dim = num_heads * (hidden_size // num_heads)
+
+    # 1. Split W_pack → q_proj, k_proj, v_proj
+    state_dict = split_fused_weight(
+        state_dict,
+        fused_key="W_pack",
+        output_names=["q_proj", "k_proj", "v_proj"],
+        split_sizes=[per_head_dim, per_head_dim, -1],
+    )
+
+    # 2. Baichuan2: normalize lm_head.weight
+    #    Baichuan2 trains with normalized lm_head. Inference must match this,
+    #    otherwise the logits distribution will be distorted, causing severe
+    #    repetitive output especially under greedy decoding.
+    #    (See _is_baichuan2 for how we distinguish Baichuan1 vs Baichuan2)
+    if _is_baichuan2(hf_config) and "lm_head.weight" in state_dict:
+        state_dict["lm_head.weight"] = F.normalize(
+            state_dict["lm_head.weight"], p=2, dim=-1
+        )
+
+    return state_dict
+
 
 # Model type → remap function mapping
 _WEIGHT_REMAPPER = {
     "glm4": _remap_glm4,
     "chatglm": _remap_chatglm,
+    "baichuan": _remap_baichuan,
 }

--- a/python/infinilm/processors/__init__.py
+++ b/python/infinilm/processors/__init__.py
@@ -2,6 +2,7 @@ from .processor import InfinilmProcessor
 from .basic_llm_processor import BasicLLMProcessor
 from .llama_processor import LlamaProcessor
 from .chatglm_processor import ChatGLMProcessor
+from .baichuan_processor import BaichuanProcessor
 
 from transformers import AutoConfig
 
@@ -17,5 +18,7 @@ class AutoInfinilmProcessor:
             return LlamaProcessor(model_dir_path)
         elif model_type in ["chatglm"]:
             return ChatGLMProcessor(model_dir_path)
+        elif model_type in ["baichuan"]:
+            return BaichuanProcessor(model_dir_path)
         else:
             return BasicLLMProcessor(model_dir_path)

--- a/python/infinilm/processors/baichuan_processor.py
+++ b/python/infinilm/processors/baichuan_processor.py
@@ -1,0 +1,88 @@
+# python/infinilm/processors/baichuan_processor.py
+
+import json
+import os
+from .basic_llm_processor import BasicLLMProcessor
+
+
+class BaichuanProcessor(BasicLLMProcessor):
+    def __init__(self, model_dir_path: str):
+        self.model_dir_path = model_dir_path
+        super().__init__(model_dir_path)
+        self._fix_missing_chat_template()
+
+    def _fix_missing_chat_template(self):
+        """
+        Baichuan models do not ship with tokenizer.chat_template in HuggingFace format.
+        They use user_token_id and assistant_token_id (from generation_config.json)
+        via custom build_chat_input code.
+
+        We dynamically inject a Jinja template that reproduces the official logic.
+        The key insight: the token IDs (e.g., 195, 196) must be converted to their
+        actual vocabulary text via tokenizer.convert_ids_to_tokens() before being
+        embedded in the template string. This is because the tokenizer's encode()
+        function maps text → IDs, and the mapping is:
+
+            generation_config.json           tokenizer vocab
+            ─────────────────────          ──────────────────
+            user_token_id: 195      →     "<reserved_106>"    (convert_ids_to_tokens(195))
+            assistant_token_id: 196  →     "<reserved_107>"    (convert_ids_to_tokens(196))
+
+        The string "<reserved_195>" is NOT a valid token in the vocabulary — it gets
+        split into multiple garbage tokens by the tokenizer. Only the actual vocab
+        text (e.g., "<reserved_106>") will correctly encode back to ID 195.
+
+        Since different Baichuan model versions may have different token IDs and
+        different vocab text, we read generation_config.json and resolve the text
+        dynamically rather than hardcoding.
+
+        You can verify the ID-to-text mapping with the following experiment:
+
+            from transformers import AutoTokenizer
+            tok = AutoTokenizer.from_pretrained("/data/rubik/models/Baichuan2-7B-Chat", trust_remote_code=True)
+            print("195 →", tok.convert_ids_to_tokens(195), "→ encode:", tok.encode(tok.convert_ids_to_tokens(195)))
+            print("196 →", tok.convert_ids_to_tokens(196), "→ encode:", tok.encode(tok.convert_ids_to_tokens(196)))
+
+        Output:
+
+            195 → <reserved_106> → encode: [195]
+            196 → <reserved_107> → encode: [196]
+
+        This confirms that "<reserved_106>" encodes to [195] and "<reserved_107>" encodes
+        to [196], while the naive "<reserved_195>" would be split into garbage tokens.
+        """
+        if getattr(self.tokenizer, 'chat_template', None):
+            return
+
+        # Step 1: Read role token IDs from generation_config.json
+        gen_config_path = os.path.join(self.model_dir_path, "generation_config.json")
+        if not os.path.exists(gen_config_path):
+            return
+
+        with open(gen_config_path) as f:
+            gen_config = json.load(f)
+
+        user_token_id = gen_config.get("user_token_id")
+        assistant_token_id = gen_config.get("assistant_token_id")
+
+        if user_token_id is None or assistant_token_id is None:
+            return
+
+        # Step 2: Resolve token IDs to their actual vocabulary text
+        # e.g., 195 → "<reserved_106>", 196 → "<reserved_107>"
+        # These are the strings the tokenizer recognizes as single tokens.
+        user_token_text = self.tokenizer.convert_ids_to_tokens(user_token_id)
+        assistant_token_text = self.tokenizer.convert_ids_to_tokens(assistant_token_id)
+
+        # Step 3: Build Jinja template using the resolved text
+        baichuan_template = (
+            "{%- for message in messages -%}"
+            "{%- if message['role'] == 'user' -%}"
+            f"{user_token_text}{{{{ message['content'] }}}}{assistant_token_text}"
+            "{%- elif message['role'] == 'assistant' -%}"
+            "{{ message['content'] }}"
+            "{%- endif -%}"
+            "{%- endfor -%}"
+        )
+        self.tokenizer.chat_template = baichuan_template
+


### PR DESCRIPTION
Baichuan shares the same underlying architecture as LLaMA, but requires specific handling for fused weight decomposition, config normalization, and chat template injection due to HuggingFace implementation quirks.

This commit introduces full Baichuan/Baichuan2 compatibility across the C++ backend and Python frontend. Key changes include:

1. C++ Backend: Config Defaulting
   - Add fallback values for missing config keys (`num_key_value_heads`, `head_dim`, `rope_theta`, `attention_bias`).
   - Rationale: Older or non-standard Baichuan config files often omit these parameters. Since the architecture is LLaMA-like, we can safely compute or default them to ensure the C++ backend initializes correctly.

2. Weight Remapping: W_pack Split & lm_head Normalization
   - Split the fused `W_pack` attention weight into separate `q_proj`, `k_proj`, and `v_proj` tensors.
   - Apply L2 normalization to `lm_head.weight` specifically for Baichuan2 models.
   - Rationale: HuggingFace Baichuan stores attention weights as a single fused tensor, which our standard LLaMA loader does not expect. Baichuan2 trains with a normalized lm_head; failing to normalize during inference severely distorts the logit distribution, causing highly repetitive outputs under greedy decoding.

3. Config Normalization: Dynamic Key Derivation
   - Extend `_CONFIG_KEY_MAP` to support both string mappings and callable dynamic derivations (lambdas). Add the `baichuan` mapping.
   - Rationale: Baichuan's config lacks `num_key_value_heads` (it uses MHA, so it equals `num_attention_heads`) and `head_dim` (must be derived as `hidden_size // num_attention_heads`). The callable pattern cleanly handles derived values without polluting the config.

4. Processor: Dynamic Chat Template Injection
   - Implement `_fix_missing_chat_template` to dynamically generate and inject a Jinja template using `user_token_id` and `assistant_token_id` from `generation_config.json`.
   - Rationale: Baichuan models lack a standard `chat_template`. Simply embedding the token ID string (e.g., "<reserved_195>") into the template causes the tokenizer to split it into garbage tokens. We must resolve the ID to its actual vocabulary text (e.g., "<reserved_106>") via `convert_ids_to_tokens` to ensure it encodes back to the correct single token.




以下为验证截图：
static attn ：python examples/test_infer.py --device nvidia --model=/data/rubik/models/Baichuan2-7B-Chat/  --prompt="山东最高的山是？"
<img width="1699" height="363" alt="image" src="https://github.com/user-attachments/assets/88a65a2a-2008-43b2-8aeb-95a1a02e6bbd" />
英文输出：python examples/test_infer.py --device nvidia --model=/data/rubik/models/Baichuan2-7B-Chat/  --prompt="introduce youself"
<img width="1693" height="424" alt="image" src="https://github.com/user-attachments/assets/d407aa82-d638-4cc4-bcbe-463802b70d26" />

paged-attn,需要结合--tp=2, baichuan2是MHA模型，相比GQA/MQA kv-cache大好几倍 L40的卡显存为48G，单卡放不下
CUDA_VISIBLE_DEVICES=0,1 python examples/test_infer.py --device nvidia --model=/data/rubik/models/Baichuan2-7B-Chat/ --enable-paged-attn --tp=2 --prompt="山东最高的山是？"
<img width="1697" height="382" alt="image" src="https://github.com/user-attachments/assets/cc61db62-228e-4e62-9d37-0af7ce851d06" />

batch处理验证
python examples/test_infer.py --device nvidia --model=/data/rubik/models/Baichuan2-7B-Chat/ --enable-paged-attn --tp=2 --batch-size=3 --prompt="山东最高的山是？"
<img width="1699" height="639" alt="image" src="https://github.com/user-attachments/assets/35cc6036-751c-4807-ba90-b9350dec3a46" />

examples/bench.py验证：
<img width="1736" height="508" alt="image" src="https://github.com/user-attachments/assets/4686ff31-85b7-4274-b5b0-5b87a2a66ea3" />


推理服务验证：CUDA_VISIBLE_DEVICES=0,1 python python/infinilm/server/inference_server.py --device nvidia --model=/data/rubik/models/Baichuan2-7B-Chat/ --enable-paged-attn --tp=2
<img width="1694" height="925" alt="image" src="https://github.com/user-attachments/assets/a88822c9-2d2a-4103-a929-9fdcf10efacb" />
<img width="1700" height="824" alt="image" src="https://github.com/user-attachments/assets/13d254ef-7f86-4b7e-b1fe-415d4ca76107" />

<img width="1710" height="854" alt="image" src="https://github.com/user-attachments/assets/3b204eb8-b315-451c-abde-230123bac86e" />

test_benchmark.py验证：
python test/bench/test_benchmark.py --device nvidia --model=/data/rubik/models/Baichuan2-7B-Chat/ --enable-paged-attn --tp=2 --bench=mmlu  --split=val

<img width="1704" height="929" alt="image" src="https://github.com/user-attachments/assets/d7aba73a-159c-40ca-938e-5c2748ea67d5" />


<img width="1268" height="852" alt="image" src="https://github.com/user-attachments/assets/e741d023-847c-49be-bf4b-2b4ab9fbe40b" />



