### PR TITLE
issue/#383 refactor: replace if-elif processor dispatch with auto-discovery registry

### DIFF
--- a/python/infinilm/processors/__init__.py
+++ b/python/infinilm/processors/__init__.py
@@ -1,24 +1,37 @@
-from .processor import InfinilmProcessor
-from .basic_llm_processor import BasicLLMProcessor
-from .llama_processor import LlamaProcessor
-from .chatglm_processor import ChatGLMProcessor
-from .baichuan_processor import BaichuanProcessor
-
+import importlib
+import pkgutil
+from pathlib import Path
 from transformers import AutoConfig
+from .processor import get_processor_class, InfinilmProcessor
+
+# ---------------------------------------------------------------------------
+# Auto-discovery mechanism
+# ---------------------------------------------------------------------------
+# Automatically discover and import all modules matching *_processor.py in
+# this directory. This ensures that any @register_processor decorators are
+# executed at load time, populating the processor registry dynamically
+# without requiring manual imports for each new model.
+# ---------------------------------------------------------------------------
+_current_dir = Path(__file__).resolve().parent
+
+for _module_info in pkgutil.iter_modules([str(_current_dir)]):
+    if _module_info.name.endswith("_processor"):
+        importlib.import_module(f".{_module_info.name}", __package__)
 
 
 class AutoInfinilmProcessor:
+    """Factory class to instantiate the appropriate model processor."""
+
     @classmethod
     def from_pretrained(cls, model_dir_path: str, **kwargs) -> InfinilmProcessor:
-        """Factory method to get the appropriate processor based on model config."""
+        """Instantiate a processor based on the model's configuration.
+
+        Reads the model_type from the config and looks up the corresponding
+        registered Processor. Falls back to the registered default processor
+        for unregistered or standard architectures.
+        """
         config = AutoConfig.from_pretrained(model_dir_path, trust_remote_code=True)
         model_type = config.model_type.lower()
 
-        if model_type in ["llama"]:
-            return LlamaProcessor(model_dir_path)
-        elif model_type in ["chatglm"]:
-            return ChatGLMProcessor(model_dir_path)
-        elif model_type in ["baichuan"]:
-            return BaichuanProcessor(model_dir_path)
-        else:
-            return BasicLLMProcessor(model_dir_path)
+        processor_cls = get_processor_class(model_type)
+        return processor_cls(model_dir_path)

--- a/python/infinilm/processors/baichuan_processor.py
+++ b/python/infinilm/processors/baichuan_processor.py
@@ -3,8 +3,10 @@
 import json
 import os
 from .basic_llm_processor import BasicLLMProcessor
+from .processor import register_processor
 
 
+@register_processor("baichuan")
 class BaichuanProcessor(BasicLLMProcessor):
     def __init__(self, model_dir_path: str):
         self.model_dir_path = model_dir_path

--- a/python/infinilm/processors/basic_llm_processor.py
+++ b/python/infinilm/processors/basic_llm_processor.py
@@ -1,9 +1,10 @@
-from .processor import InfinilmProcessor
+from .processor import InfinilmProcessor, register_processor
 from transformers import AutoTokenizer
 from ..llm.static_scheduler import StaticSchedulerOutput
 from ..llm.scheduler import SchedulerOutput
 
 
+@register_processor("default")
 class BasicLLMProcessor(InfinilmProcessor):
     def __init__(self, model_dir_path: str):
         self.tokenizer = AutoTokenizer.from_pretrained(

--- a/python/infinilm/processors/chatglm_processor.py
+++ b/python/infinilm/processors/chatglm_processor.py
@@ -3,8 +3,10 @@
 import re
 import types
 from .basic_llm_processor import BasicLLMProcessor
+from .processor import register_processor
 
 
+@register_processor("chatglm")
 class ChatGLMProcessor(BasicLLMProcessor):
     def __init__(self, model_dir_path: str):
         super().__init__(model_dir_path)

--- a/python/infinilm/processors/llama_processor.py
+++ b/python/infinilm/processors/llama_processor.py
@@ -1,7 +1,9 @@
 from .basic_llm_processor import BasicLLMProcessor
+from .processor import register_processor
 from tokenizers import decoders as _dec
 
 
+@register_processor("llama")
 class LlamaProcessor(BasicLLMProcessor):
     def __init__(self, model_dir_path: str):
         super().__init__(model_dir_path)

--- a/python/infinilm/processors/processor.py
+++ b/python/infinilm/processors/processor.py
@@ -32,3 +32,28 @@ class InfinilmProcessor:
     def get_tokenizer(self):
         """Return the text tokenizer associated with this processor."""
         raise NotImplementedError("InfinilmProcessor is not implemented yet")
+
+# Global registry mapping model_type strings to their Processor classes
+_PROCESSOR_REGISTRY = {}
+
+
+def register_processor(model_type: str):
+    """Decorator to register a Processor class for a specific model type."""
+    def decorator(cls):
+        if model_type in _PROCESSOR_REGISTRY:
+            raise ValueError(
+                f"Duplicate processor registration: model_type '{model_type}' "
+                f"is already registered by {_PROCESSOR_REGISTRY[model_type].__name__}"
+            )
+        _PROCESSOR_REGISTRY[model_type] = cls
+        return cls
+    return decorator
+
+
+def get_processor_class(model_type: str):
+    """Retrieve the processor class for a given model type.
+
+    Falls back to the "default" registered processor if the model type
+    is not explicitly recognized.
+    """
+    return _PROCESSOR_REGISTRY.get(model_type, _PROCESSOR_REGISTRY["default"])


### PR DESCRIPTION
The previous AutoInfinilmProcessor.from_pretrained() used a chain of if-elif-else branches to dispatch model types to their corresponding Processor classes. This approach has two practical problems as the number of supported models grows:

1. Adding a new model requires modifying the factory method itself to insert a new elif branch, violating the Open-Closed Principle.
2. More critically, the developer must also remember to add the new Processor class to the imports in __init__.py. Forgetting either step results in the model silently falling back to BasicLLMProcessor, which is hard to debug at runtime.

Solve this by introducing a decorator-based registry with auto-discovery:

- processor.py: Defines @register_processor decorator and a registry lookup function (get_processor_class) with BasicLLMProcessor fallback.
- __init__.py: Auto-discovers and imports all *_processor.py modules in the package directory at load time, triggering decorator execution and populating the registry. No manual imports needed.
- Each concrete processor (e.g., baichuan_processor.py) registers itself via @register_processor("model_type").
- AutoInfinilmProcessor.from_pretrained() is reduced to a single registry lookup, requiring zero changes when new models are added.

Now, supporting a new model only requires creating a new xxx_processor.py file with the @register_processor decorator. No other files need to be touched, eliminating the risk of forgotten imports or missing branches.


避免出现类似下面的笔误，引入一个新模型的processor，不再需要修改__init__.py文件
<img width="1233" height="642" alt="image" src="https://github.com/user-attachments/assets/7e01ced9-8b8c-4e34-a8b6-a0960c4452f1" />


验证，只要现有的模型能跑通python examples/test_infer.py，就已覆盖到了processor处理流程了。
python examples/test_infer.py --device nvidia --model=/data/rubik/models/Baichuan2-7B-Chat/ --enable-paged-attn --tp=2 --batch-size=3 --prompt="山东最高的山是？"
<img width="1717" height="586" alt="image" src="https://github.com/user-attachments/assets/5d965de7-3b38-4c1a-99bc-ebdb260b5536" />

python examples/test_infer.py --device nvidia --model=/data/rubik/models/GLM-4-9B-0414/ --enable-paged-attn --tp=2 --batch-size=3 --prompt="山东最高的山是？"
<img width="1700" height="940" alt="image" src="https://github.com/user-attachments/assets/25af45de-09d7-47c7-88ee-635affdb8a48" />


python examples/test_infer.py --device nvidia --model=/data/rubik/models/DeepSeek-R1-Distill-Qwen-7B/ --enable-paged-attn --tp=2 --batch-size=3 --prompt="山东最高的山是？"
<img width="1685" height="893" alt="image" src="https://github.com/user-attachments/assets/b8190e89-55ef-4a2f-8314-c013987fc201" />


python examples/test_infer.py --device nvidia --model=/data/rubik/models/chatglm3-6b/ --enable-paged-attn --tp=2 --batch-size=3 --prompt="山东最高的山是？"
<img width="1700" height="893" alt="image" src="https://github.com/user-attachments/assets/b3658815-94f0-4214-90b5-d2f39f55bf18" />


python examples/test_infer.py --device nvidia --model=/data/rubik/models/internlm3-8b-instruct/ --enable-paged-attn --tp=2 --batch-size=3 --prompt="山东最高的山是？"
<img width="1696" height="660" alt="image" src="https://github.com/user-attachments/assets/55e09011-6622-43b2-9e11-c55bdf986c3f" />


python examples/test_infer.py --device nvidia --model=/data/rubik/models/Meta-Llama-3-8B-Instruct/ --enable-paged-attn --tp=2 --batch-size=3 --prompt="山东最高的山是？"
<img width="1699" height="855" alt="image" src="https://github.com/user-attachments/assets/47fa2770-1456-4015-afe0-6d2db06aaf02" />



