### PR TITLE
issue/#386 [Bug]eos_token_id not correctly loaded when config.json and generation_config.json are inconsistent

### DIFF
--- a/python/infinilm/infer_engine.py
+++ b/python/infinilm/infer_engine.py
@@ -24,6 +24,18 @@ def read_hf_config(model_path):
         )
     return config_dict
 
+# config.json (required) defines model architecture, while generation_config.json
+# (optional) defines generation behavior. They are kept as separate readers
+# because: 1) config.json must exist and requires model_type validation,
+# whereas generation_config.json may not exist; 2) keeping them separate
+# preserves clear semantics and avoids a one-size-fits-all function with
+# multiple conditional parameters.
+def read_hf_generation_config(model_path):
+    gen_config_path = os.path.join(model_path, "generation_config.json")
+    if os.path.exists(gen_config_path):
+        with open(gen_config_path, "r") as f:
+            return json.load(f)
+    return {}
 
 @dataclass
 class GenerationConfig:
@@ -49,6 +61,7 @@ class InferEngine(_infinilm.InferEngine):
         kv_cache_dtype=None,
     ):
         self.hf_config = read_hf_config(model_path)
+        self.hf_generation_config = read_hf_generation_config(model_path)
 
         if device is None:
             device = infinicore.device()
@@ -84,7 +97,23 @@ class InferEngine(_infinilm.InferEngine):
 
     @property
     def eos_token_id(self):
-        eos_token_id = self.hf_config["eos_token_id"]
+        # HuggingFace priority: generation_config.json > config.json
+        # HuggingFace's documented loading priority for generation parameters
+        # (see transformers/generation/utils.py, GenerationMixin.generate docstring):
+        #   1) from the `generation_config.json` model file, if it exists
+        #   2) from the model configuration (config.json)
+        #
+        # config.json may contain incomplete or outdated generation parameters
+        # because HuggingFace treats config.json as model architecture config
+        # and generation_config.json as generation behavior config. For example,
+        # InternLM3's config.json has eos_token_id=2, while
+        # generation_config.json has eos_token_id=[2, 128131].
+        # Following this priority ensures we always get the authoritative value.
+        eos_token_id = (
+            self.hf_generation_config.get("eos_token_id")
+            or self.hf_config.get("eos_token_id")
+            or []
+        )
         if isinstance(eos_token_id, int):
             eos_token_id = [eos_token_id]
         return eos_token_id
@@ -174,10 +203,7 @@ class InferEngine(_infinilm.InferEngine):
         tgt_sizes=None,
         _measure_and_log_time=False,
     ):
-        if generation_config.eos_token_id is None:
-            eos_token_id = self.eos_token_id
-        else:
-            eos_token_id = generation_config.eos_token_id
+        eos_token_id = self.eos_token_id
 
         past_seq_len = 0
         output_ids = []


### PR DESCRIPTION
When config.json and generation_config.json define inconsistent eos_token_id values (e.g., InternLM3: config.json has 2, generation_config.json has [2, 128131]), only config.json was read, causing incomplete EOS detection and runaway generation.

Add read_hf_generation_config() to load generation_config.json separately, and update eos_token_id property to follow HuggingFace's documented priority: generation_config.json > config.json.


验证：python examples/test_infer.py --device nvidia --model=/data/rubik/models/internlm3-8b-instruct/ --enable-paged-attn --tp=2 --batch-size=3 --prompt="山东最高的山是？"
未修改前，模型遇到结束符而没有结束，一直输出到最大长度。
<img width="1706" height="946" alt="1779188594079_3514c6e69d9b42ddbc91ee7c5ab57593" src="https://github.com/user-attachments/assets/d16050e7-f6dc-4e99-b9e0-4298b3da7136" />


该问题修复后，就能正常结束：
<img width="1702" height="937" alt="image" src="https://github.com/user-attachments/assets/5624c4ac-03aa-4ba4-a4b8-7d459167babf" />

