### PR TITLE
issue/388 [BugFix](basic_llm_processor): prevent duplicate BOS token in Llama-3/3.1 chat

### DIFF
--- a/python/infinilm/processors/basic_llm_processor.py
+++ b/python/infinilm/processors/basic_llm_processor.py
@@ -12,18 +12,25 @@ class BasicLLMProcessor(InfinilmProcessor):
         )
 
     def __call__(self, prompt: str, return_tensors: str = None, **kwargs) -> dict:
+        # add_special_tokens=False Prevent duplicate BOS token for Llama-3/3.1 models.
+        # The `prompt` string here is already rendered by `apply_chat_template(tokenize=False)`,
+        # which explicitly includes the `<|begin_of_text|>` (BOS) token at the start.
+        # Since `LlamaTokenizerFast` defaults to `add_bos_token=True`, calling the tokenizer
+        # with the default `add_special_tokens=True` would prepend a second BOS token.
+        # This shifts the RoPE positional encodings by 1 and causes greedy decoding outputs
+        # to diverge significantly from HuggingFace. We must explicitly disable it.
         if return_tensors is None:
-            return self.tokenizer(prompt)
+            return self.tokenizer(prompt, add_special_tokens=False)
         elif return_tensors == "infini":
             import infinicore
 
             result = {}
-            for key, tensor in self.tokenizer(prompt, return_tensors="pt").items():
+            for key, tensor in self.tokenizer(prompt, return_tensors="pt", add_special_tokens=False).items():
                 result[key] = tensor.from_torch(tensor)
             return result
 
         # "pt" or "np" or "tf".
-        return self.tokenizer(prompt, return_tensors="pt")
+        return self.tokenizer(prompt, return_tensors="pt", add_special_tokens=False)
 
     def apply_chat_template(
         self,


### PR DESCRIPTION
When using `model.chat()` with Llama-3/3.1 models, the framework inadvertently prepends two `<|begin_of_text|>` (BOS, token ID 128000) tokens to the prompt_token_ids. This shifts the RoPE positional encodings by 1, causing the greedy decoding output to diverge significantly from HuggingFace.

Root cause:
The Llama-3/3.1 chat template explicitly includes `<|begin_of_text|>` at the start of the rendered string. Later, `BasicLLMProcessor.__call__` passes this string to `self.tokenizer(prompt)`, which defaults to `add_special_tokens=True`. Since `LlamaTokenizerFast` initializes with `add_bos_token=True` by default, the tokenizer automatically prepends a second BOS token via its Rust backend PostProcessor.

Fix:
Explicitly pass `add_special_tokens=False` to the tokenizer calls in `BasicLLMProcessor.__call__`. Since the chat template is already responsible for adding necessary special tokens, the tokenizer should only perform pure text-to-ID mapping.


修复前，input_ids有两个BOS符，实际推理时看起来也没有什么影响。当想使用贪心解码来验证RotaryEmbedding的时候就会有问题，此时一般会去跟HF原生的输出对比输出token以及logprobs，双重BOS导致输出天然不一致，于是就想把这个隐藏的bug修复掉。
<img width="1448" height="470" alt="image" src="https://github.com/user-attachments/assets/9bcd2dc1-8f5f-4d14-91b0-b0667b6f4700" />

修复后，double bos消失
<img width="1481" height="532" alt="image" src="https://github.com/user-attachments/assets/1bafedfe-78f5-4c51-84f6-22c5f8193763" />


重新跑一遍已有的模型推理就能验证对原有推理逻辑没影响。

<img width="1447" height="646" alt="image" src="https://github.com/user-attachments/assets/33da4014-9b56-4488-9a83-f924c1b9812e" />

<img width="1464" height="877" alt="image" src="https://github.com/user-attachments/assets/79de9852-a3fc-48cf-b417-71af940d32c9" />

<img width="1457" height="893" alt="image" src="https://github.com/user-attachments/assets/797b472d-ef8c-408b-97f6-d9c67c5906ae" />

<img width="1459" height="848" alt="image" src="https://github.com/user-attachments/assets/7deacc5f-00ec-4d46-b712-331270f0e430" />

<img width="1479" height="916" alt="image" src="https://github.com/user-attachments/assets/63148100-cc39-4acf-913b-d1b293cab45f" />

<img width="1466" height="875" alt="image" src="https://github.com/user-attachments/assets/ef5e328a-78b1-48c3-ac45-3f8e1f65c56a" />

<img width="1467" height="835" alt="image" src="https://github.com/user-attachments/assets/bed2d484-3e4b-4e3a-a8c7-4d4171582cdd" />

<img width="1457" height="831" alt="image" src="https://github.com/user-attachments/assets/5a43598e-9ffc-40e6-b2b2-e8368fb42430" />

