### PR TITLE
build: add an cmake build option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ __pycache__/
 
 # txt
 *.txt
+!CMakeLists.txt
 
 *.http
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,90 @@
+cmake_minimum_required(VERSION 3.18)
+project(infinilm LANGUAGES CXX)
+
+# ==================== Basic Configuration ====================
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# INFINI_ROOT environment variable
+if(DEFINED ENV{INFINI_ROOT})
+    set(INFINI_ROOT "$ENV{INFINI_ROOT}")
+elseif(WIN32)
+    set(INFINI_ROOT "$ENV{HOMEPATH}/.infini")
+else()
+    set(INFINI_ROOT "$ENV{HOME}/.infini")
+endif()
+
+# ==================== Compilation Options ====================
+option(USE_KV_CACHING "Whether to compile the path using the kv caching operator" OFF)
+if(USE_KV_CACHING)
+    add_definitions(-DENABLE_KV_CACHING)
+endif()
+
+option(USE_CLASSIC_LLAMA "Whether to use the classic LlamaForCausalLM" OFF)
+if(USE_CLASSIC_LLAMA)
+    add_definitions(-DUSE_CLASSIC_LLAMA)
+endif()
+
+# ==================== Third-party Headers ====================
+# spdlog (third_party)
+include_directories("${CMAKE_SOURCE_DIR}/third_party/spdlog/include")
+
+# json (third_party)
+include_directories("${CMAKE_SOURCE_DIR}/third_party/json/single_include/")
+
+# Infini headers
+include_directories("${INFINI_ROOT}/include")
+
+# Local includes
+include_directories("${CMAKE_SOURCE_DIR}/include")
+
+# ==================== Find pybind11 ====================
+# Method 1: Use find_package
+find_package(pybind11 REQUIRED)
+
+# Method 2: If pybind11 exists as a subdirectory
+# add_subdirectory(third_party/pybind11)
+# Note: If using Method 1, ensure pybind11 is installed or CMAKE_PREFIX_PATH is set
+
+# ==================== Library Link Directories ====================
+link_directories("${INFINI_ROOT}/lib")
+
+# ==================== Build Target ====================
+pybind11_add_module(_infinilm MODULE
+    # Source files - recursively add all files under csrc
+    # Alternatively, use file(GLOB) to collect files
+)
+
+# Collect source files
+file(GLOB_RECURSE INFINILM_SOURCES
+    "${CMAKE_SOURCE_DIR}/csrc/*.cpp"
+    "${CMAKE_SOURCE_DIR}/csrc/*.cc"
+)
+
+# Add source files to target
+target_sources(_infinilm PRIVATE ${INFINILM_SOURCES})
+
+# ==================== Link Libraries ====================
+target_link_libraries(_infinilm PRIVATE
+    infinicore_cpp_api
+    infiniop
+    infinirt
+    infiniccl
+)
+
+# ==================== Target Properties ====================
+# Set output directory (corresponds to xmake's set_installdir)
+set_target_properties(_infinilm PROPERTIES
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/python/infinilm/lib"
+    PREFIX ""  # Remove lib prefix
+)
+
+# If pybind11 requires specific compile definitions
+target_compile_definitions(_infinilm PRIVATE
+    $<$<CONFIG:Debug>:DEBUG>
+)
+
+# ==================== Python Module Installation (Optional) ====================
+# install(TARGETS _infinilm
+#     LIBRARY DESTINATION python/infinilm/lib
+# )

--- a/README.md
+++ b/README.md
@@ -37,6 +37,30 @@
     ```
 
 
+  - 安装 InfiniLM c++ 引擎
+    
+    使用xmake编译和安装
+    ```bash
+      xmake build _infinilm && xmake install _infinilm
+    ```
+    或
+    
+    使用cmake编译和安装
+    ```bash
+    mkdir build && cd build
+    
+    # 可能需要手动确保pybind11版本与InfiniCore的xmake一致
+    # 可能需要手动指定python版本
+    cmake .. \
+      -Dpybind11_DIR=/<path-to>/pybind11/share/cmake/pybind11 \ 
+      -DPYTHON_EXECUTABLE=$(which python) 
+
+    cmake --build . -j$(nproc)
+
+    cd ..
+    ```
+
+
   - 安装 InfiniLM Python 包
     ```bash
       pip install -e .

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,10 @@ from setuptools.command.egg_info import egg_info
 
 def build_cpp_module():
     """Build and install the C++ extension module"""
-    subprocess.run(["xmake", "build", "_infinilm"], check=True)
-    subprocess.run(["xmake", "install", "_infinilm"], check=True)
+    return
+    # xmake build is now optional
+    # subprocess.run(["xmake", "build", "_infinilm"], check=True)
+    # subprocess.run(["xmake", "install", "_infinilm"], check=True)
 
 
 class Build(build):


### PR DESCRIPTION
<!--
Thanks for contributing to InfiniLM! Please read `CONTRIBUTING.md` before
opening a pull request and fill out every section below. Delete any section
that is genuinely not applicable (and note why), but do not delete the
"Checklist" section — it must be filled in for every PR.

The PR title MUST follow Conventional Commits, e.g.
  feat: support Llama 3 models
  fix: correct linear attention calculations
See: https://www.conventionalcommits.org/
-->

## Summary

<!--
A concise description of **what** this PR changes. Prefer bullet points over
prose. Reference files with backtick-fenced paths (e.g. `csrc/models/llama/*`).
-->

- 增加一个使用cmake编译的选择
- NV天数摩尔寒武纪MACA海光已测，HPCC不可用，阿里没配网，其他平台待测

## Motivation

<!--
Explain **why** this change is needed. Link to any related issue, bug, or
discussion. If this is a performance change, include before/after numbers
(hardware, shape, dtype, and the measurement methodology).
-->
部分环境中xmake所需库配置过于繁琐

Closes #390 

## Type of Change

<!-- Tick one or more. -->

- [ ] `feat` — new feature / new model
- [ ] `fix` — bug fix
- [ ] `perf` — performance improvement (no behavioral change)
- [ ] `refactor` — code restructuring without behavior change
- [ ] `test` — adding or fixing tests only
- [ ] `docs` — documentation only
- [x] `build` / `ci` — build system or CI configuration
- [ ] `chore` — tooling, formatting, or other non-code changes
- [ ] Breaking change

## Test Results of Involved Models on Supported Platforms (Please attach screenshots)

<!--
For now, provide the screenshots for involved tests performed on platforms supposed to support the changes.

Tests that might be involved:
Single request test: examples/test_infer.py
Offline performance: examples/bench.py
Sanity test: test/bench/test_benchmark.py
Service: python/infinilm/server/inference_server.py + scripts/test_perf.py

Model adaptations may involve all four tests, unless specifying partial support for vastly new structures and confirmed with admin.

Python-level changes may involve less tests depending on which files/features are modified. 

Framework-level and Python-level changes may affect different models. Test a few models that might be affected.
-->

## Benchmark / Performance Impact

<!--
Required for `perf` PRs; optional otherwise. Describe the benchmark harness,
shapes, dtypes, hardware, and include baseline vs. new numbers. If the PR is
not performance-sensitive, write "N/A".
-->

## Notes for Reviewers

<!--
Anything reviewers should focus on: subtle invariants, known trade-offs,
follow-up work intentionally left out of scope, etc.
-->

---

## Checklist

> Every contributor **must** verify every item below before requesting
> review. Tick each box only after the check has actually been performed —
> do not tick speculatively. If an item truly does not apply, replace the
> checkbox with `N/A` and briefly explain why in an inline comment.

### Title, Branch, and Commits

- [x] PR **title** follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(nvidia): …`, `fix(cuda/gemm): …`).
- [x] Branch name follows `<type>/xxx-yyyy-zzzz` where `<type>` matches the PR title's Conventional Commits type and words are joined with hyphens (see `CONTRIBUTING.md` §Branches).
- [x] Each **commit** message follows Conventional Commits.
- [x] Small PR is a **single squashable commit**; or, for a large PR, every commit is meaningful, well-formed, and independently reviewable (see `CONTRIBUTING.md` §Pull Requests).
- [x] No stray merge commits from `main` — the branch is rebased cleanly on top of the current `main`.
- [x] No `fixup!` / `squash!` / `wip` commits remain.
- [ ] Existing PR/branch/commit that followed the legacy issue format.

### Scope and Design

- [x] Changes are **minimal** — nothing unrelated to the stated motivation was added (`CONTRIBUTING.md` §Code/General).
- [ ] No dead code, commented-out blocks, debug prints, `printf`/`std::cout`/`print(...)` left behind, or `TODO` without an owner and issue link.
- [x] No unrelated formatting churn that would obscure the diff.
- [x] Public API changes (if any) are intentional, documented, and reflected in affected callers/tests.

### General Code Hygiene (applies to all languages)

- [x] The code is self-explanatory; comments were added **only** where the *why* is non-obvious (`CONTRIBUTING.md` §Code/General).
- [x] Every modified or added file **ends with a single trailing newline** (`CONTRIBUTING.md` §Code/General).
- [x] No trailing whitespace, tab/space mixing, or stray BOMs.
- [x] Identifiers in comments and error messages are wrapped in backticks (e.g. ``the `seqlens_k` tensor``) (`CONTRIBUTING.md` §Code/General).
- [x] All comments and error messages are in **English** (`CONTRIBUTING.md` §Code/General).
- [x] Comments and error messages are complete sentences — capitalized first letter, terminal punctuation — **unless** the language/framework convention says otherwise (`CONTRIBUTING.md` §Code/General; §Python).

### C++ Specific (if C++ files changed)

- [ ] Code follows the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) strictly.
- [ ] Error and warning message wording follows the [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html#error-and-warning-messages) (`CONTRIBUTING.md` §C++).
- [ ] Constructor **initializer list order matches member declaration order** (`CONTRIBUTING.md` §C++).
- [ ] No raw `new`/`delete`; RAII / smart pointers / existing allocators are used.
- [ ] Changed files are formatted by `scripts/format.py`.
- [ ] No changes/reference to `csrc/models/llama_legacy/`.

### Python Specific (if Python files changed)

- [x] Code is [PEP 8](https://peps.python.org/pep-0008/) compliant.
- [x] Comments are complete English sentences, starting with a capital letter and ending with punctuation; Markdown backticks are used for code references (`CONTRIBUTING.md` §Python).
- [x] Docstrings (if any) follow [PEP 257](https://peps.python.org/pep-0257/) (`CONTRIBUTING.md` §Python).
- [x] Changed files are formatted by `scripts/format.py`.
- [x] No changes/reference to `python/infinilm/auto_config.py`.

### Testing

- [ ] For any platform that could not be tested, an explicit reason is given in the table and a reviewer with access has been tagged.
- [x] Passed single request test (`examples/test_infer.py`), or specify the reason for skipping.
- [x] Passed offline performance test (`examples/bench.py`), or specify the reason for skipping.
- [x] Passed sanity test (`test/bench/test_benchmark.py`), or specify the reason for skipping.
- [x] Passed service test (`python/infinilm/server/inference_server.py` + `scripts/test_perf.py`), or specify the reason for skipping.

### Build, CI, and Tooling

- [x] The project builds cleanly from a fresh directory on at least one affected platform.

### Documentation

- [x] `README.md`, `CONTRIBUTING.md`, or inline docs updated when behavior, build flags, or developer workflow changed.
- [x] Any user-visible breaking change is called out explicitly under "Motivation" **and** in the commit/PR title with a `!` or `BREAKING CHANGE:` footer.

### Security and Safety

- [x] No secrets, access tokens, internal URLs, customer data, or personal hardware identifiers have been committed.
- [x] Third-party code is license-compatible and attributed.
- [x] No unsafe pointer arithmetic, uninitialized reads, or missing bounds checks were introduced.
