### PR TITLE
issue/392 [Feature](rope): implement Llama 3.1 frequency-aware RoPE scaling

### DIFF
--- a/csrc/config/model_config.cpp
+++ b/csrc/config/model_config.cpp
@@ -45,34 +45,138 @@ ModelConfig::get_rope_scaling() const {
         throw std::runtime_error("rope_scaling must contain 'type' or 'rope_type' field");
     }
 
-    if (type_str == "longrope") {
-        // Required fields for LongRopeConfig
-        if (!rope_scaling.contains("short_factor") || !rope_scaling.contains("long_factor") || !rope_scaling.contains("original_max_position_embeddings")) {
-            throw std::runtime_error(
-                "LongRopeConfig requires 'short_factor', 'long_factor', and 'original_max_position_embeddings'");
-        }
-
-        auto short_factor = rope_scaling["short_factor"].get<std::vector<float>>();
-        auto long_factor = rope_scaling["long_factor"].get<std::vector<float>>();
-        size_t original_max_position_embeddings = rope_scaling["original_max_position_embeddings"].get<size_t>();
-
-        float factor = 1.0f;
-        if (rope_scaling.contains("factor")) {
-            factor = rope_scaling["factor"].get<float>();
-        }
-
-        return std::make_shared<infinicore::nn::RoPE::LongRopeConfig>(
-            std::move(short_factor),
-            std::move(long_factor),
-            original_max_position_embeddings,
-            factor);
-    } else if (type_str == "default" || type_str == "none" || type_str == "dynamic") {
-        // Default scaling, no scaling applied
-        // Currently not handling extended sequence lengths for dynamic scaling. Add specific branches when needed.
-        return nullptr;
-    } else {
-        throw std::runtime_error("Unsupported rope_scaling type: " + type_str);
+    // SGLang's style if-else routing in python/srt/layers/rotary_embedding.py:get_rope
+    if (type_str == "llama3") {
+        return createLlama3Scaling(rope_scaling);
+    } else if (type_str == "longrope") {
+        return createLongRopeScaling(rope_scaling);
+    } else if (type_str == "default") {
+        return createDefaultScaling(rope_scaling);
+    } else if (type_str == "none") {
+        return createNoneScaling(rope_scaling);
+    } else if (type_str == "dynamic") {
+        return createDynamicScaling(rope_scaling);
     }
+
+    throw std::runtime_error("Unsupported rope_scaling type: " + type_str);
+}
+
+std::shared_ptr<infinicore::nn::RoPE::ScalingConfig>
+ModelConfig::createDefaultScaling(const nlohmann::json &rope_scaling) const {
+    return nullptr;
+}
+
+std::shared_ptr<infinicore::nn::RoPE::ScalingConfig>
+ModelConfig::createNoneScaling(const nlohmann::json &rope_scaling) const {
+    return nullptr;
+}
+
+std::shared_ptr<infinicore::nn::RoPE::ScalingConfig>
+ModelConfig::createDynamicScaling(const nlohmann::json &rope_scaling) const {
+    // [TODO]Dynamic scaling: currently not handling extended sequence lengths
+    return nullptr;
+}
+
+std::shared_ptr<infinicore::nn::RoPE::ScalingConfig>
+ModelConfig::createLlama3Scaling(const nlohmann::json &rope_scaling) const {
+    // Native support for Llama 3.1 frequency-aware RoPE scaling
+    // equivalent to SGLang/HuggingFace implementations
+
+    // 1. Validate and extract Llama3 specific parameters
+    const std::vector<std::string> required_keys = {
+        "factor", "low_freq_factor", "high_freq_factor", "original_max_position_embeddings"};
+    for (const auto &key : required_keys) {
+        if (!rope_scaling.contains(key)) {
+            throw std::runtime_error("Llama3RoPE requires '" + key + "' in rope_scaling");
+        }
+    }
+
+    const double factor = rope_scaling["factor"].get<double>();
+    const double low_freq_factor = rope_scaling["low_freq_factor"].get<double>();
+    const double high_freq_factor = rope_scaling["high_freq_factor"].get<double>();
+    const size_t orig_max_pos = rope_scaling["original_max_position_embeddings"].get<size_t>();
+
+    // 2. Validate and extract model base parameters
+    if (!config_json.contains("hidden_size") || !config_json.contains("num_attention_heads")) {
+        throw std::runtime_error("Llama3RoPE requires 'hidden_size' and 'num_attention_heads' in config");
+    }
+    const size_t hidden_size = config_json["hidden_size"].get<size_t>();
+    const size_t num_heads = config_json["num_attention_heads"].get<size_t>();
+    const size_t head_dim = hidden_size / num_heads;
+    const double theta = config_json.value("rope_theta", 10000.0);
+
+    // 3. Pre-compute smooth factors based on wavelength
+    constexpr double kPi = 3.14159265358979323846;
+    const size_t cache_dim = head_dim / 2;
+    const double low_freq_wavelen = static_cast<double>(orig_max_pos) / low_freq_factor;
+    const double high_freq_wavelen = static_cast<double>(orig_max_pos) / high_freq_factor;
+
+    const bool has_smooth_range = (high_freq_factor != low_freq_factor);
+    const double smooth_denom = has_smooth_range ? (high_freq_factor - low_freq_factor) : 1.0;
+
+    std::vector<float> smooth_factors(cache_dim);
+    for (size_t j = 0; j < cache_dim; ++j) {
+        const double exponent = 2.0 * static_cast<double>(j) / static_cast<double>(head_dim);
+        const double inv_freq = 1.0 / std::pow(theta, exponent);
+        const double wavelen = 2.0 * kPi / inv_freq;
+
+        if (wavelen < high_freq_wavelen) {
+            // High frequency: no scaling (freq_scale = 1.0)
+            smooth_factors[j] = 1.0f;
+        } else if (wavelen > low_freq_wavelen) {
+            // Low frequency: full scaling (freq_scale = 1.0 / factor)
+            smooth_factors[j] = static_cast<float>(factor);
+        } else {
+            // Mid frequency: smooth frequency interpolation
+            //
+            // Equivalent to SGLang's implementation:
+            //   smooth = (orig_max_pos / wavelen - low_freq_factor) / (high_freq_factor - low_freq_factor)
+            //   new_freq = (1 - smooth) * inv_freq / factor + smooth * inv_freq
+            //   => freq_scale = (1 - smooth) / factor + smooth
+            //
+            // Since LongRopeConfig applies factors as wavelength multipliers
+            // (i.e., new_freq = inv_freq / scale), the required smooth_factor
+            // is the inverse of the frequency scale.
+            //
+            double smooth = 0.0;
+            if (has_smooth_range) {
+                smooth = (static_cast<double>(orig_max_pos) / wavelen - low_freq_factor) / smooth_denom;
+            }
+            const double freq_scale = (1.0 - smooth) / factor + smooth;
+            smooth_factors[j] = static_cast<float>(1.0 / freq_scale);
+        }
+    }
+
+    // 4. Adapt to LongRopeConfig
+    // - short_factor and long_factor use the same smooth_factors
+    // - Pass factor=1.0f to bypass the amplitude scaling sqrt(log(...)) in LongRopeConfig constructor
+    return std::make_shared<infinicore::nn::RoPE::LongRopeConfig>(
+        smooth_factors, // short_factor
+        smooth_factors, // long_factor
+        orig_max_pos,
+        1.0f // Force 1.0f to disable amplitude scaling
+    );
+}
+
+std::shared_ptr<infinicore::nn::RoPE::ScalingConfig>
+ModelConfig::createLongRopeScaling(const nlohmann::json &rope_scaling) const {
+    const std::vector<std::string> required_keys = {"short_factor", "long_factor", "original_max_position_embeddings"};
+    for (const auto &key : required_keys) {
+        if (!rope_scaling.contains(key)) {
+            throw std::runtime_error("LongRopeConfig requires '" + key + "' in rope_scaling");
+        }
+    }
+
+    auto short_factor = rope_scaling["short_factor"].get<std::vector<float>>();
+    auto long_factor = rope_scaling["long_factor"].get<std::vector<float>>();
+    const size_t orig_max_pos = rope_scaling["original_max_position_embeddings"].get<size_t>();
+    const float factor = rope_scaling.value("factor", 1.0f);
+
+    return std::make_shared<infinicore::nn::RoPE::LongRopeConfig>(
+        std::move(short_factor),
+        std::move(long_factor),
+        orig_max_pos,
+        factor);
 }
 
 infinicore::DataType ModelConfig::get_dtype() const {

--- a/csrc/config/model_config.hpp
+++ b/csrc/config/model_config.hpp
@@ -105,5 +105,11 @@ public:
 private:
     nlohmann::json config_json;
     QuantConfig quant_config;
+
+    std::shared_ptr<infinicore::nn::RoPE::ScalingConfig> createLlama3Scaling(const nlohmann::json &rope_scaling) const;
+    std::shared_ptr<infinicore::nn::RoPE::ScalingConfig> createLongRopeScaling(const nlohmann::json &rope_scaling) const;
+    std::shared_ptr<infinicore::nn::RoPE::ScalingConfig> createDefaultScaling(const nlohmann::json &rope_scaling) const;
+    std::shared_ptr<infinicore::nn::RoPE::ScalingConfig> createNoneScaling(const nlohmann::json &rope_scaling) const;
+    std::shared_ptr<infinicore::nn::RoPE::ScalingConfig> createDynamicScaling(const nlohmann::json &rope_scaling) const;
 };
 } // namespace infinilm::config


### PR DESCRIPTION
Add native support for `rope_type: "llama3"` to enable proper inference for Llama 3.1 models with extended 128k context lengths.

Implement `ModelConfig::createLlama3Scaling` method, introducing the piece-wise smooth interpolation mechanism based on frequency wavelengths, strictly referencing the implementations from SGLang and HuggingFace.

To seamlessly integrate this logic without modifying the underlying RoPE kernels, the Llama 3 frequency scaling is elegantly mapped to the existing `LongRopeConfig` structure. Key technical adaptations include:

- Deriving `smooth_factor = 1.0 / freq_scale` to align with `LongRopeConfig`'s wavelength multiplier semantics.
- Enforcing full double-precision (`double`) for intermediate math to prevent precision truncation with Llama 3's large `rope_theta` (e.g., 500000.0), ensuring bit-wise alignment with PyTorch behavior.
- Overriding the outer factor to `1.0f` in the `LongRopeConfig` constructor to bypass the unused amplitude scaling penalty.


增加该rope实现后，就自然能跑Meta-Llama-3.1-8B-Instruct模型了。
其它现有模型无影响，rope_type不是llama3
验证：
 python examples/test_infer.py --device nvidia --model=/data/rubik/models/Meta-Llama-3.1-8B-Instruct/ --enable-paged-attn --tp=2 --batch-size=1 --prompt="山东最高的山是？"
<img width="1460" height="650" alt="image" src="https://github.com/user-attachments/assets/41a04c97-f133-4164-9cfd-14f84e71f70e" />

python examples/test_infer.py --device nvidia --model=/data/rubik/models/Meta-Llama-3.1-8B-Instruct/ --enable-paged-attn --tp=2 --batch-size=1 --prompt="introduce yourself"
<img width="1461" height="656" alt="image" src="https://github.com/user-attachments/assets/106eaf38-6629-4398-9c29-c131bd23f03d" />

另外rope还做了一个验证，在贪心解码方式下，同样的输入对比输出需要完全一致。其实再进一步，最好再对比下top-n个的logprobs 分布，infinilm api目前不支持输出，暂不验证。


### HuggingFace Verification
**Code:**
```python
import torch
from transformers import AutoModelForCausalLM, AutoTokenizer
model_path = "/data/rubik/models/Meta-Llama-3.1-8B-Instruct"
print("Loading HF model and tokenizer...")
tokenizer = AutoTokenizer.from_pretrained(model_path)
# Align precision with the inference framework using bfloat16
model = AutoModelForCausalLM.from_pretrained(
    model_path, 
    torch_dtype=torch.bfloat16, 
    device_map="auto"
)
model.eval()
# 1. Use the identical chat format as InfiniLM
prompt = "The key to life is"
messages = [
    {"role": "user", "content": prompt}
]
# 2. Apply Llama 3 chat template; add_generation_prompt=True appends the assistant header
input_ids = tokenizer.apply_chat_template(
    messages, 
    add_generation_prompt=True, 
    return_tensors="pt"
).to(model.device)
print(f"Input Tokens: {input_ids.tolist()[0]}")
# 3. Greedily generate 30 tokens
with torch.no_grad():
    outputs = model.generate(
        input_ids, 
        max_new_tokens=30, 
        do_sample=False,      # Enforce strict greedy decoding
        temperature=0.0,
        top_p=1.0
    )
# 4. Strip the input tokens to isolate the generated portion
generated_ids = outputs[0][input_ids.shape[1]:]
generated_text = tokenizer.decode(generated_ids, skip_special_tokens=True)
print("\n=================== HF Result ====================")
print(generated_text)
print("==================================================")
```
**Output:**
```text
=================== HF Result ====================
The key to life is often subjective and can vary from person to person. However, some common themes that are often cited as being essential to a fulfilling
==================================================
```
---
### InfiniLM Verification
**Code:**
```python
import time
import os
from infinilm.base_config import BaseConfig
from infinilm.llm.llm import LLM
def test_greedy(model_path, prompt, device="cpu", tp=1):
    model_path = os.path.expanduser(model_path)
    
    # ---------------------------------------------------------------------------- #
    #                 Enforce Greedy Decoding Parameters (Temperature=0, TopK=1)
    # ---------------------------------------------------------------------------- #
    model = LLM(
        model_path=model_path,
        device=device,
        tensor_parallel_size=tp,
        cache_type="static",     # Static cache is sufficient for simple testing
        max_batch_size=1,
        max_tokens=30,           # Generate 30 tokens to prevent cumulative divergence
        temperature=0.0,         # Strict 0.0 for deterministic output
        top_k=1,                 # TopK=1 enforces pure greedy sampling
        top_p=1.0,
        enable_graph=False,
    )
    conversations = [
        [{"role": "user", "content": [{"type": "text", "text": prompt}]}]
    ]
    t1 = time.time()
    outputs = model.chat(messages=conversations)
    t2 = time.time()
    req_output = outputs[0]
    comp_output = req_output.outputs[0]
    print("=================== InfiniLM Verification ====================")
    # 1. Verify the double BOS fix (expecting a single 128000)
    print(f"Input Token IDs: {req_output.prompt_token_ids[:20]}... (first 20 tokens)")
    
    # 2. Verify output text alignment with HuggingFace
    print(f"\nGenerated Text: {comp_output.text}")
    
    # 3. Print inference latency
    print(f"\nLatency: {round((t2 - t1) * 1000, 2)} ms")
    print("=============================================================")
if __name__ == "__main__":
    cfg = BaseConfig()
    device_str = cfg.get_device_str(cfg.device)
    
    test_greedy(
        model_path=cfg.model,
        prompt="The key to life is",
        device=device_str,
        tp=cfg.tp
    )
```
**Output:**
```text
Generating: 100%| 1/1 [00:00<00:00,  1.04it/s]
=================== InfiniLM Verification ====================
Input Token IDs: [128000, 128006, 9125, 128007, 271, 38766, 1303, 33025, 2696, 25, 6790, 220, 2366, 18, 198, 15724, 2696, 25, 220, 1627]... (first 20 tokens)
Generated Text: The key to life is often subjective and can vary from person to person. However, some common themes that are often cited as being essential to a fulfilling
Latency: 994.12 ms
=============================================================
```

可以看出来贪心解码下，InfiniLM 与HF的输出完全一致，能证明rope实现基本没问题

