### PR TITLE
issue/401 refactor(rope): add scaling factory and TP-safe RoPE cache

### DIFF
--- a/csrc/config/model_config.cpp
+++ b/csrc/config/model_config.cpp
@@ -25,56 +25,6 @@ ModelConfig::get_quant_scheme() const {
     }
 }
 
-std::shared_ptr<infinicore::nn::RoPE::ScalingConfig>
-ModelConfig::get_rope_scaling() const {
-    if (!config_json.contains("rope_scaling") || config_json["rope_scaling"].is_null()) {
-        return nullptr;
-    }
-
-    const auto &rope_scaling = config_json["rope_scaling"];
-    if (!rope_scaling.is_object()) {
-        throw std::runtime_error("rope_scaling must be an object");
-    }
-
-    std::string type_str;
-    if (rope_scaling.contains("type")) {
-        type_str = rope_scaling["type"].get<std::string>();
-    } else if (rope_scaling.contains("rope_type")) {
-        type_str = rope_scaling["rope_type"].get<std::string>();
-    } else {
-        throw std::runtime_error("rope_scaling must contain 'type' or 'rope_type' field");
-    }
-
-    if (type_str == "longrope") {
-        // Required fields for LongRopeConfig
-        if (!rope_scaling.contains("short_factor") || !rope_scaling.contains("long_factor") || !rope_scaling.contains("original_max_position_embeddings")) {
-            throw std::runtime_error(
-                "LongRopeConfig requires 'short_factor', 'long_factor', and 'original_max_position_embeddings'");
-        }
-
-        auto short_factor = rope_scaling["short_factor"].get<std::vector<float>>();
-        auto long_factor = rope_scaling["long_factor"].get<std::vector<float>>();
-        size_t original_max_position_embeddings = rope_scaling["original_max_position_embeddings"].get<size_t>();
-
-        float factor = 1.0f;
-        if (rope_scaling.contains("factor")) {
-            factor = rope_scaling["factor"].get<float>();
-        }
-
-        return std::make_shared<infinicore::nn::RoPE::LongRopeConfig>(
-            std::move(short_factor),
-            std::move(long_factor),
-            original_max_position_embeddings,
-            factor);
-    } else if (type_str == "default" || type_str == "none" || type_str == "dynamic") {
-        // Default scaling, no scaling applied
-        // Currently not handling extended sequence lengths for dynamic scaling. Add specific branches when needed.
-        return nullptr;
-    } else {
-        throw std::runtime_error("Unsupported rope_scaling type: " + type_str);
-    }
-}
-
 infinicore::DataType ModelConfig::get_dtype() const {
     std::string dtype_str;
     if (config_json.contains("dtype")) {
@@ -86,6 +36,24 @@ infinicore::DataType ModelConfig::get_dtype() const {
     }
 
     return parse_dtype(dtype_str);
+}
+
+size_t ModelConfig::get_rotary_dim() const {
+    size_t head_dim = get_head_dim();
+    double partial_rotary_factor = get_or<double>("partial_rotary_factor", 1.0);
+
+    if (partial_rotary_factor <= 0.0 || partial_rotary_factor >= 1.0) {
+        return head_dim;
+    }
+
+    size_t rotary_dim = static_cast<size_t>(std::llround(
+        static_cast<double>(head_dim) * partial_rotary_factor));
+    rotary_dim = std::clamp(rotary_dim, static_cast<size_t>(2), head_dim);
+
+    if (rotary_dim % 2 != 0) {
+        rotary_dim -= 1;
+    }
+    return std::max(rotary_dim, static_cast<size_t>(2));
 }
 
 std::ostream &operator<<(std::ostream &os, const ModelConfig &config) {

--- a/csrc/config/model_config.hpp
+++ b/csrc/config/model_config.hpp
@@ -58,6 +58,9 @@ public:
         return get<size_t>("hidden_size") / get<size_t>("num_attention_heads");
     }
 
+    // Compute the actual rotary dimension based on partial rotation factor
+    size_t get_rotary_dim() const;
+
     QuantConfig get_quant_config() const {
         return quant_config;
     }
@@ -68,7 +71,7 @@ public:
 
     infinicore::DataType get_dtype() const;
     infinilm::quantization::QuantScheme get_quant_scheme() const;
-    std::shared_ptr<infinicore::nn::RoPE::ScalingConfig> get_rope_scaling() const;
+
     void set_kv_quant_scheme(infinicore::DataType kv_cache_dtype) {
         this->quant_config.set_kv_quant_scheme(kv_cache_dtype);
     }
@@ -102,8 +105,18 @@ public:
     // Stream output operator
     friend std::ostream &operator<<(std::ostream &os, const ModelConfig &config);
 
+    infinicore::nn::RoPE::Algo get_rope_algo() const {
+        return rope_algo_;
+    }
+
+    void set_rope_algo(infinicore::nn::RoPE::Algo algo) {
+        rope_algo_ = algo;
+    }
+
 private:
     nlohmann::json config_json;
     QuantConfig quant_config;
+
+    infinicore::nn::RoPE::Algo rope_algo_ = infinicore::nn::RoPE::Algo::GPT_NEOX;
 };
 } // namespace infinilm::config

--- a/csrc/layers/rotary_embedding/rope_scaling_creators.cpp
+++ b/csrc/layers/rotary_embedding/rope_scaling_creators.cpp
@@ -1,0 +1,66 @@
+#include "../../config/model_config.hpp"
+#include "infinicore/nn/rope_scaling_configs.hpp"
+#include "rotary_embedding_factory.hpp"
+#include <vector>
+
+namespace infinilm::layers::rotary_embedding {
+namespace {
+/**
+ * @brief Default creator for types that apply no scaling.
+ * Returns nullptr, which the InfiniCore RoPE layer interprets as a 1.0x pass-through.
+ */
+std::shared_ptr<infinicore::nn::RopeScalingConfig>
+create_default_scaling_config(const std::shared_ptr<config::ModelConfig> &) {
+    return nullptr;
+}
+
+// TODO(rubik) create_dynamic_scaling
+
+/**
+ * @brief Creator function for LongRoPE scaling configuration.
+ * Extracts 'short_factor', 'long_factor', etc., from the model config.
+ */
+std::shared_ptr<infinicore::nn::RopeScalingConfig>
+create_longrope_config(const std::shared_ptr<config::ModelConfig> &cfg) {
+    const auto &rope_scaling = cfg->get_config_json()["rope_scaling"];
+
+    // Required fields for LongRopeConfig
+    if (!rope_scaling.contains("short_factor") || !rope_scaling.contains("long_factor") || !rope_scaling.contains("original_max_position_embeddings")) {
+        throw std::runtime_error(
+            "LongRopeConfig requires 'short_factor', 'long_factor', and 'original_max_position_embeddings'");
+    }
+
+    auto short_factor = rope_scaling["short_factor"].get<std::vector<float>>();
+    auto long_factor = rope_scaling["long_factor"].get<std::vector<float>>();
+    size_t original_max_position_embeddings = rope_scaling["original_max_position_embeddings"].get<size_t>();
+
+    float factor = 1.0f;
+    if (rope_scaling.contains("factor")) {
+        factor = rope_scaling["factor"].get<float>();
+    }
+
+    return std::make_shared<infinicore::nn::LongRopeScalingConfig>(
+        std::move(short_factor),
+        std::move(long_factor),
+        original_max_position_embeddings,
+        factor);
+}
+
+// Future scaling creators go here (e.g., create_llama3, create_linear)
+
+} // anonymous namespace
+
+// Static self-registration block
+// Registers creator functions into the factory registry upon program startup.
+static bool _registered = []() {
+    auto &registry = get_scaling_registry();
+    registry["default"] = create_default_scaling_config;
+    registry["none"] = create_default_scaling_config;
+    registry["dynamic"] = create_default_scaling_config;
+    registry["longrope"] = create_longrope_config;
+    // add new scaling
+    // registry["llama3"] = create_llama3_scaling;
+    return true;
+}();
+
+} // namespace infinilm::layers::rotary_embedding

--- a/csrc/layers/rotary_embedding/rotary_embedding.cpp
+++ b/csrc/layers/rotary_embedding/rotary_embedding.cpp
@@ -1,46 +1,44 @@
 #include "rotary_embedding.hpp"
-#include <algorithm> // std::clamp
-#include <cmath>     // std::llround
+#include "../../config/model_config.hpp"
+#include "rotary_embedding_factory.hpp"
+#include <memory>
 #include <string>
-#include <unordered_map>
 
 namespace infinilm::layers::rotary_embedding {
-namespace {
+
+// Cache dictionary to avoid redundant allocations of RoPE instances.
+// thread_local ensures it is only visible within this compilation unit.
 thread_local std::unordered_map<std::string, std::shared_ptr<infinicore::nn::RoPE>> _ROPE_DICT;
-} // namespace
 
-size_t get_rotary_dim(size_t head_dim, double partial_rotary_factor) {
-    if (partial_rotary_factor <= 0.0 || partial_rotary_factor >= 1.0) {
-        return head_dim;
-    }
+std::shared_ptr<infinicore::nn::RoPE>
+get_rope(const std::shared_ptr<infinilm::config::ModelConfig> &model_config,
+         const infinicore::Device &device) {
 
-    size_t rotary_dim = static_cast<size_t>(std::llround(
-        static_cast<double>(head_dim) * partial_rotary_factor));
-    rotary_dim = std::clamp(rotary_dim, static_cast<size_t>(2), head_dim);
-
-    // RoPE operates on complex pairs, so the rotary dimension must be even
-    if (rotary_dim % 2 != 0) {
-        rotary_dim -= 1;
-    }
-    return std::max(rotary_dim, static_cast<size_t>(2));
-}
-
-std::shared_ptr<infinicore::nn::RoPE> get_rope(const std::shared_ptr<infinilm::config::ModelConfig> &model_config,
-                                               const infinicore::Device &device,
-                                               infinicore::nn::RoPE::Algo algo) {
-    // 1. Get head dimension
+    // 1. Compute the actual rotary dimension
+    size_t rotary_dim = model_config->get_rotary_dim();
     size_t head_dim = model_config->get_head_dim();
 
-    // 2. Safely get partial_rotary_factor, defaulting to 1.0 (full rotation)
-    double partial_rotary_factor = model_config->get_or<double>("partial_rotary_factor", 1.0);
+    // 2. Resolve scaling config via the internal factory
+    auto scaling = make_scaling_config(model_config);
 
-    // 3. Compute the actual rotary dimension
-    size_t rotary_dim = get_rotary_dim(head_dim, partial_rotary_factor);
+    // 3. Cache key must include rotary_dim AND the actual scaling type
+    //    to avoid reusing the same RoPE instance across models with different settings
+    //    (Enhancement: dynamically determine scaling_type instead of hardcoding "default")
+    std::string scaling_type_str = "default";
+    if (scaling) {
+        // Assuming we can get the type string from the JSON for cache key generation,
+        // or ideally, ScalingConfig should have a virtual std::string type_name() const method.
+        // Here we read it from JSON for the cache key purpose only, keeping it decoupled from InfiniCore.
+        const auto &rope_scaling_json = model_config->get_config_json()["rope_scaling"];
+        if (rope_scaling_json.contains("type")) {
+            scaling_type_str = rope_scaling_json["type"].get<std::string>();
+        } else if (rope_scaling_json.contains("rope_type")) {
+            scaling_type_str = rope_scaling_json["rope_type"].get<std::string>();
+        }
+    }
 
-    // 4. Cache key must include rotary_dim to avoid reusing the same RoPE instance
-    //    across models with different partial_rotary_factor values
-    const std::string scaling_type = "default";
-    std::string cache_key = scaling_type + "_rope_dim_" + std::to_string(rotary_dim);
+    std::string cache_key = scaling_type_str + "_rope_dim_" + std::to_string(rotary_dim)
+                          + "_dev_" + device.toString();
     auto it = _ROPE_DICT.find(cache_key);
     if (it != _ROPE_DICT.end()) {
         return it->second;
@@ -49,9 +47,10 @@ std::shared_ptr<infinicore::nn::RoPE> get_rope(const std::shared_ptr<infinilm::c
     const auto &dtype = model_config->get_dtype();
     size_t max_position_embeddings = model_config->get<size_t>("max_position_embeddings");
     double rope_theta = model_config->get<double>("rope_theta");
-    auto rope = std::make_shared<infinicore::nn::RoPE>(rotary_dim, max_position_embeddings, rope_theta,
-                                                       algo, dtype, device,
-                                                       model_config->get_rope_scaling());
+
+    infinicore::nn::RoPE::Algo algo = model_config->get_rope_algo();
+    auto rope = std::make_shared<infinicore::nn::RoPE>(head_dim, rotary_dim, max_position_embeddings, rope_theta,
+                                                       algo, dtype, device, scaling);
 
     _ROPE_DICT.emplace(cache_key, rope);
     return rope;

--- a/csrc/layers/rotary_embedding/rotary_embedding.hpp
+++ b/csrc/layers/rotary_embedding/rotary_embedding.hpp
@@ -1,17 +1,23 @@
 #pragma once
 
-#include "../../config/model_config.hpp"
 #include "infinicore/nn/rope.hpp"
 #include <memory>
 
+namespace infinilm::config {
+class ModelConfig; // Forward declaration
+}
+
 namespace infinilm::layers::rotary_embedding {
 
-// Compute the actual number of dimensions involved in rotary position embedding.
-// For partial rotation, the dimension is clamped to [2, head_dim] and must be even.
-size_t get_rotary_dim(size_t head_dim, double partial_rotary_factor);
-
-std::shared_ptr<infinicore::nn::RoPE> get_rope(const std::shared_ptr<infinilm::config::ModelConfig> &model_config,
-                                               const infinicore::Device &device,
-                                               infinicore::nn::RoPE::Algo algo = infinicore::nn::RoPE::Algo::GPT_NEOX);
+/**
+ * @brief Public API to assemble and construct a complete RoPE module.
+ *
+ * @param model_config Model configuration.
+ * @param device Device to create the cache on.
+ * @param algo RoPE algorithm type (default: Algo::GPT_NEOX).
+ */
+std::shared_ptr<infinicore::nn::RoPE>
+get_rope(const std::shared_ptr<infinilm::config::ModelConfig> &model_config,
+         const infinicore::Device &device);
 
 } // namespace infinilm::layers::rotary_embedding

--- a/csrc/layers/rotary_embedding/rotary_embedding_factory.cpp
+++ b/csrc/layers/rotary_embedding/rotary_embedding_factory.cpp
@@ -1,0 +1,42 @@
+#include "rotary_embedding_factory.hpp"
+#include "../../config/model_config.hpp"
+#include <stdexcept>
+
+namespace infinilm::layers::rotary_embedding {
+
+std::unordered_map<std::string, ScalingCreator> &get_scaling_registry() {
+    static std::unordered_map<std::string, ScalingCreator> registry;
+    return registry;
+}
+
+std::shared_ptr<infinicore::nn::RopeScalingConfig>
+make_scaling_config(const std::shared_ptr<config::ModelConfig> &model_config) {
+    if (!model_config || !model_config->get_config_json().contains("rope_scaling") || model_config->get_config_json()["rope_scaling"].is_null()) {
+        return nullptr;
+    }
+
+    const auto &rope_scaling = model_config->get_config_json()["rope_scaling"];
+    if (!rope_scaling.is_object()) {
+        throw std::runtime_error("rope_scaling must be an object");
+    }
+
+    std::string scaling_type;
+    if (rope_scaling.contains("type")) {
+        scaling_type = rope_scaling["type"].get<std::string>();
+    } else if (rope_scaling.contains("rope_type")) {
+        scaling_type = rope_scaling["rope_type"].get<std::string>();
+    } else {
+        throw std::runtime_error("rope_scaling must contain 'type' or 'rope_type' field");
+    }
+
+    // Registry routing: delegate construction to the specific creator
+    auto &registry = get_scaling_registry();
+    auto it = registry.find(scaling_type);
+    if (it != registry.end()) {
+        return it->second(model_config);
+    }
+
+    throw std::runtime_error("Unsupported rope_scaling_type: " + scaling_type);
+}
+
+} // namespace infinilm::layers::rotary_embedding

--- a/csrc/layers/rotary_embedding/rotary_embedding_factory.hpp
+++ b/csrc/layers/rotary_embedding/rotary_embedding_factory.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "infinicore/nn/rope.hpp"
+#include "infinicore/nn/rope_scaling_configs.hpp"
+#include <functional>
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+namespace infinilm::config {
+class ModelConfig; // Forward declaration
+}
+
+namespace infinilm::layers::rotary_embedding {
+
+/**
+ * @brief Function pointer type for creating specific RopeScalingConfig instances.
+ * Implementations should extract parameters from ModelConfig and construct the corresponding Config object.
+ */
+using ScalingCreator = std::function<std::shared_ptr<infinicore::nn::RopeScalingConfig>(
+    const std::shared_ptr<infinilm::config::ModelConfig> &)>;
+
+/**
+ * @brief Get the singleton registry mapping scaling type strings to their creator functions.
+ */
+std::unordered_map<std::string, ScalingCreator> &get_scaling_registry();
+
+/**
+ * @brief Factory method to create a RopeScalingConfig based on the ModelConfig.
+ * Routes the "rope_scaling_type" string to the corresponding registered creator.
+ */
+std::shared_ptr<infinicore::nn::RopeScalingConfig>
+make_scaling_config(const std::shared_ptr<infinilm::config::ModelConfig> &model_config);
+
+} // namespace infinilm::layers::rotary_embedding

--- a/csrc/models/chatglm/chatglm_for_causal_lm.cpp
+++ b/csrc/models/chatglm/chatglm_for_causal_lm.cpp
@@ -37,6 +37,9 @@ std::shared_ptr<infinilm::config::ModelConfig> create_chatglm_model_config(
         config_json["rope_theta"] = 10000.0;
     }
 
+    // Use GPT-J style RoPE (interleaved dimensions) for chatglm, chatglm/GLM4 share same attention layer
+    model_config->set_rope_algo(infinicore::nn::RoPE::Algo::GPT_J);
+
     return model_config;
 }
 

--- a/csrc/models/glm4/glm4_attention.cpp
+++ b/csrc/models/glm4/glm4_attention.cpp
@@ -21,7 +21,7 @@ Glm4Attention::Glm4Attention(std::shared_ptr<infinilm::config::ModelConfig> mode
       num_attention_heads_(model_config->get<size_t>("num_attention_heads")),
       num_key_value_heads_(model_config->get<size_t>("num_key_value_heads")),
       head_dim_(model_config->get_head_dim()),
-      rotary_dim_(infinilm::layers::rotary_embedding::get_rotary_dim(model_config->get_head_dim(), model_config->get_or<double>("partial_rotary_factor", 1.0))),
+      rotary_dim_(model_config->get_rotary_dim()),
       use_bias_(model_config->get_or<bool>("attention_bias", true)),
       use_output_bias_(model_config->get_or<bool>("attention_output_bias", false)) {
 
@@ -52,7 +52,7 @@ Glm4Attention::Glm4Attention(std::shared_ptr<infinilm::config::ModelConfig> mode
 
     // RoPE initialization
     attention_backend_ = infinilm::global_state::get_infinilm_config().attention_backend;
-    rotary_emb_ = infinilm::layers::rotary_embedding::get_rope(model_config, device, infinicore::nn::RoPE::Algo::GPT_J);
+    rotary_emb_ = infinilm::layers::rotary_embedding::get_rope(model_config, device);
 
     attn_ = std::make_shared<infinilm::layers::attention::AttentionLayer>(
         num_attention_heads_, head_dim_, scaling_,

--- a/csrc/models/glm4/glm4_for_causal_lm.cpp
+++ b/csrc/models/glm4/glm4_for_causal_lm.cpp
@@ -18,6 +18,9 @@ std::shared_ptr<infinilm::config::ModelConfig> create_glm4_model_config(
         config_json["attention_bias"] = false;
     }
 
+    // Use GPT-J style RoPE (interleaved dimensions) for GLM4
+    model_config->set_rope_algo(infinicore::nn::RoPE::Algo::GPT_J);
+
     return model_config;
 }
 

--- a/csrc/models/llama_legacy/llama_config.hpp
+++ b/csrc/models/llama_legacy/llama_config.hpp
@@ -36,7 +36,7 @@ struct LlamaConfig : public InfinilmModel::Config {
     size_t max_position_embeddings = 2048; // Maximum sequence length
     double rope_theta = 10000.0;           // RoPE base frequency
 
-    std::shared_ptr<infinicore::nn::RoPE::ScalingConfig> rope_scaling = nullptr; // RoPE scaling type
+    std::shared_ptr<infinicore::nn::RopeScalingConfig> rope_scaling = nullptr; // RoPE scaling type
 
     // Normalization
     double rms_norm_eps = 1e-6; // RMSNorm epsilon

--- a/csrc/models/llama_legacy/llama_model.cpp
+++ b/csrc/models/llama_legacy/llama_model.cpp
@@ -1,4 +1,5 @@
 #include "llama_model.hpp"
+#include "../../layers/rotary_embedding/rotary_embedding_factory.hpp"
 #include "infinicore/nn/embedding.hpp"
 #include "infinicore/nn/rmsnorm.hpp"
 #include "infinicore/nn/rope.hpp"
@@ -22,9 +23,10 @@ LlamaModel::LlamaModel(std::shared_ptr<infinilm::config::ModelConfig> model_conf
     }
     INFINICORE_NN_MODULE_INIT(norm, model_config_->get<size_t>("hidden_size"), model_config_->get<double>("rms_norm_eps"),
                               dtype, device);
-    INFINICORE_NN_MODULE_INIT(rotary_emb, model_config_->get_head_dim(), model_config_->get<size_t>("max_position_embeddings"),
+    auto rope_scaling_config = infinilm::layers::rotary_embedding::make_scaling_config(model_config_);
+    INFINICORE_NN_MODULE_INIT(rotary_emb, model_config_->get_head_dim(), model_config->get_rotary_dim(), model_config_->get<size_t>("max_position_embeddings"),
                               model_config_->get<double>("rope_theta"), infinicore::nn::RoPE::Algo::GPT_NEOX,
-                              dtype, device, model_config_->get_rope_scaling());
+                              dtype, device, rope_scaling_config);
 
     for (auto &layer : layers_) {
         if (layer) {

--- a/csrc/pybind11/models/llama_legacy.hpp
+++ b/csrc/pybind11/models/llama_legacy.hpp
@@ -104,8 +104,8 @@ inline void bind_llama(py::module &m) {
                     return py::none();
                 }
 
-                using ScalingConfig = infinicore::nn::RoPE::ScalingConfig;
-                using LongRopeConfig = infinicore::nn::RoPE::LongRopeConfig;
+                using ScalingConfig = infinicore::nn::RopeScalingConfig;
+                using LongRopeConfig = infinicore::nn::LongRopeScalingConfig;
 
                 py::dict d;
 
@@ -148,7 +148,7 @@ inline void bind_llama(py::module &m) {
                                      : get_str("type");
 
                 if (type == "longrope") {
-                    using LongRopeConfig = infinicore::nn::RoPE::LongRopeConfig;
+                    using LongRopeConfig = infinicore::nn::LongRopeScalingConfig;
 
                     if (!d.contains("short_factor") || !d.contains("long_factor") || !d.contains("original_max_position_embeddings")) {
                         throw py::value_error(


### PR DESCRIPTION
- Decouple scaling config instantiation from ModelConfig via factory and registry pattern.
- Add thread-local RoPE cache with device-scoped keys to reduce VRAM usage and ensure TP safety.
- Centralize rotary dimension calculation into ModelConfig.

ModelConfig 扩展（纯粹的数据承载）
ModelConfig 不再掺杂任何具体模型的业务判断，仅提供默认值和读写接口。RoPE::Algo 的差异由具体的模型构建入口（如 csrc/models/chatglm/chatglm_for_causal_lm.cpp）显式指定：
// model_config.hpp
class ModelConfig {
private:
    infinicore::nn::RoPE::Algo rope_algo_ = infinicore::nn::RoPE::Algo::GPT_NEOX; // 默认值
public:
    infinicore::nn::RoPE::Algo get_rope_algo() const { return rope_algo_; }
    
};
// csrc/models/chatglm/chatglm_for_causal_lm.cpp
std::shared_ptr<ModelConfig> create_chatglm_config(const json& hf_config) {
    auto config = std::make_shared<ModelConfig>(hf_config);
    // 只有 ChatGLM/GLM4 需要 GPT_J，在此处显式注入，不污染基类
    config->set_rope_algo(infinicore::nn::RoPE::Algo::GPT_J); 
    return config;
}
工厂与注册表机制（字符串路由分发）
引入注册表模式，将 JSON 中的字符串（如 "longrope"）映射到具体的对象构造逻辑，替代冗长的 if-else。
// rotary_embedding_factory.hpp
using ScalingCreator = std::function<std::shared_ptr<infinicore::nn::ScalingConfig>(
    const std::shared_ptr<infinilm::config::ModelConfig>&)>;
std::unordered_map<std::string, ScalingCreator>& get_scaling_registry();
std::shared_ptr<infinicore::nn::RoPE> make_rope(/* ... */);
工厂核心实现极简，仅负责组装与路由，不因为新增类型而修改：
// rotary_embedding_factory.cpp
std::shared_ptr<infinicore::nn::ScalingConfig> 
make_scaling_config(const std::shared_ptr<infinilm::config::ModelConfig>& model_config) {
    std::string scaling_type = model_config->get_or<std::string>("rope_scaling_type", "default");

    // 分发点：注册表路由，将字符串映射到具体的 Creator 函数
    auto& registry = get_scaling_registry();
    auto it = registry.find(scaling_type);
    if (it != registry.end()) {
        return it->second(model_config); 
    }
    throw std::runtime_error("Unsupported rope_scaling_type: " + scaling_type);
}

需要与InfiniCore的下面PR一起合入，
https://github.com/InfiniTensor/InfiniCore/pull/1181

重构后，新增的rope实现都集中在csrc/layers/rotary_embedding/rope_scaling_creators.cpp增加，其它地方无需修改，跟rotary_embedding.cpp和model_config.cpp解耦掉。

之前@pengcheng888 给的建议是把algo参数收编进model_config中，然后在xx_for_causal_lm.cpp 中写入，我实现了一版，但感觉特别别扭，我理解model_config还是纯粹一点好，能从json中读出来或者加工出来的。后来，我又改动了一下，还是直接放到运行时传参更加优雅吧。

重构后所有现有支持的模型已经跑通

<img width="1471" height="896" alt="image" src="https://github.com/user-attachments/assets/9afc5288-2280-4ad8-8d2f-65fe4513e0df" />
<img width="1476" height="478" alt="image" src="https://github.com/user-attachments/assets/8dee629a-2907-444d-a121-907906e11f24" />
<img width="1488" height="651" alt="image" src="https://github.com/user-attachments/assets/82b7c15e-f890-4f1f-a6d3-cf030365b555" />
<img width="1488" height="671" alt="image" src="https://github.com/user-attachments/assets/731ffe88-5866-4bab-a480-0b5f10812869" />
<img width="1469" height="704" alt="image" src="https://github.com/user-attachments/assets/909fb76f-4180-457f-9baf-a382958812f1" />
<img width="1464" height="906" alt="image" src="https://github.com/user-attachments/assets/6894ee17-298e-46b7-9be2-fd6c1105c5b1" />
<img width="1490" height="680" alt="image" src="https://github.com/user-attachments/assets/e643567e-4ccd-4a29-ad2a-56cbc2170b66" />
<img width="1477" height="629" alt="image" src="https://github.com/user-attachments/assets/602e0000-3c29-4e1b-b30f-c4d2d93c1342" />
<img width="1463" height="743" alt="image" src="https://github.com/user-attachments/assets/71892da4-2e46-45ff-a67c-712b94959512" />
<img width="1469" height="898" alt="image" src="https://github.com/user-attachments/assets/f9c9e881-b659-4199-b854-761d55474732" />
<img width="1460" height="807" alt="image" src="https://github.com/user-attachments/assets/cd7d8c0b-2b97-4ca8-a3db-67a4b7a806fc" />
<img width="1474" height="893" alt="image" src="https://github.com/user-attachments/assets/cb3ee410-f33a-4529-a734-b83a1da1b45b" />
<img width="1467" height="509" alt="image" src="https://github.com/user-attachments/assets/5de4b96b-fcf9-4491-8e01-88f9a3c82e50" />
<img width="1463" height="538" alt="image" src="https://github.com/user-attachments/assets/9d503384-c235-43ff-8622-f42508741845" />
<img width="1474" height="530" alt="image" src="https://github.com/user-attachments/assets/adfef354-e467-414b-bb71-b6298519803e" />
<img width="1470" height="611" alt="image" src="https://github.com/user-attachments/assets/b62c1145-9a46-4629-ba95-b0cf2827d653" />
<img width="1465" height="588" alt="image" src="https://github.com/user-attachments/assets/22555d0d-e169-4611-b6c6-6536c1053973" />
<img width="1472" height="602" alt="image" src="https://github.com/user-attachments/assets/14e1b2ac-7b9d-4d50-9ada-78676761b89e" />

