### PR TITLE
issue/392 [Feature](rope): wire up Llama3 RoPE scaling config creator

### DIFF
--- a/csrc/layers/rotary_embedding/rope_scaling_creators.cpp
+++ b/csrc/layers/rotary_embedding/rope_scaling_creators.cpp
@@ -46,6 +46,33 @@ create_longrope_config(const std::shared_ptr<config::ModelConfig> &cfg) {
         factor);
 }
 
+/**
+ * @brief Creator function for Llama3 RoPE scaling configuration.
+ * Extracts 'factor', 'low_freq_factor', 'high_freq_factor', and
+ * 'original_max_position_embeddings' from the model config.
+ */
+std::shared_ptr<infinicore::nn::RopeScalingConfig>
+create_llama3_scaling_config(const std::shared_ptr<config::ModelConfig> &cfg) {
+    const auto &rope_scaling = cfg->get_config_json()["rope_scaling"];
+
+    // Validate required fields for Llama3 scaling
+    if (!rope_scaling.contains("factor") || !rope_scaling.contains("low_freq_factor") || !rope_scaling.contains("high_freq_factor") || !rope_scaling.contains("original_max_position_embeddings")) {
+        throw std::runtime_error(
+            "Llama3RopeScalingConfig requires 'factor', 'low_freq_factor', 'high_freq_factor', and 'original_max_position_embeddings'");
+    }
+
+    float factor = rope_scaling["factor"].get<float>();
+    float low_freq_factor = rope_scaling["low_freq_factor"].get<float>();
+    float high_freq_factor = rope_scaling["high_freq_factor"].get<float>();
+    size_t original_max_position_embeddings = rope_scaling["original_max_position_embeddings"].get<size_t>();
+
+    return std::make_shared<infinicore::nn::Llama3RopeScalingConfig>(
+        factor,
+        low_freq_factor,
+        high_freq_factor,
+        original_max_position_embeddings);
+}
+
 // Future scaling creators go here (e.g., create_llama3, create_linear)
 
 } // anonymous namespace
@@ -58,8 +85,7 @@ static bool _registered = []() {
     registry["none"] = create_default_scaling_config;
     registry["dynamic"] = create_default_scaling_config;
     registry["longrope"] = create_longrope_config;
-    // add new scaling
-    // registry["llama3"] = create_llama3_scaling;
+    registry["llama3"] = create_llama3_scaling_config;
     return true;
 }();
 


### PR DESCRIPTION
Add the `create_llama3_scaling_config` factory function to adapt to the implemented Llama3RopeScalingConfig in InfiniCore. It extracts the required parameters from the model config and registers the creator in the RoPE scaling factory registry.

支持llama3旋转编码，不影响其它类型的模型

基础验证：
<img width="1537" height="893" alt="image" src="https://github.com/user-attachments/assets/47829309-4b20-4c60-9d83-48ebcd7e8bfe" />
<img width="1535" height="656" alt="image" src="https://github.com/user-attachments/assets/fa86b17a-bcb8-4096-8494-5dad02a2e220" />
<img width="1537" height="649" alt="image" src="https://github.com/user-attachments/assets/6289d213-6483-453f-8ad8-862ee5e36565" />
