### PR TITLE
feat: auto detect devices

### DIFF
--- a/python/infinilm/base_config.py
+++ b/python/infinilm/base_config.py
@@ -1,5 +1,8 @@
 import argparse
+import importlib
 import json
+import os
+import shutil
 import warnings
 
 
@@ -113,7 +116,16 @@ class BaseConfig:
     def _add_common_args(self):
         # --- base configuration ---
         self.parser.add_argument("--model", type=str, required=True)
-        self.parser.add_argument("--device", type=str, default="cpu")
+        self.parser.add_argument(
+            "--device",
+            type=str,
+            default="auto",
+            help=(
+                "device platform: auto, cpu, nvidia, qy, metax, moore, iluvatar, "
+                "ali, cambricon, ascend, kunlun, hygon, or backend name "
+                "(cuda/mlu/musa/npu)"
+            ),
+        )
         self.parser.add_argument("--tp", "--tensor-parallel-size", type=int, default=1)
 
         # --- Infer backend optimization ---
@@ -298,10 +310,81 @@ class BaseConfig:
             ),
         )
 
+    def _torch_device_available(self, device_type):
+        module_name = {
+            "cuda": None,
+            "mlu": "torch_mlu",
+            "musa": "torch_musa",
+            "npu": "torch_npu",
+        }.get(device_type)
+
+        try:
+            if module_name is not None:
+                importlib.import_module(module_name)
+            torch = importlib.import_module("torch")
+        except Exception:
+            return False
+
+        device_module = getattr(torch, device_type, None)
+        if device_module is None:
+            return False
+
+        is_available = getattr(device_module, "is_available", None)
+        if not callable(is_available):
+            return False
+
+        try:
+            return bool(is_available())
+        except Exception:
+            return False
+
+    def detect_device(self):
+        """Detect the local accelerator platform, falling back to CPU."""
+        torch_checks = [
+            ("cambricon", "mlu"),
+            ("ascend", "npu"),
+            ("moore", "musa"),
+        ]
+        for device_name, device_type in torch_checks:
+            if self._torch_device_available(device_type):
+                return device_name
+
+        env_checks = [
+            ("metax", ["MACA_PATH", "MACA_HOME", "MACA_ROOT"]),
+            ("hygon", ["DTK_HOME", "DTK_PATH"]),
+            ("ali", ["PPU_VISIBLE_DEVICES"]),
+        ]
+        for device_name, env_names in env_checks:
+            if any(os.getenv(env_name) for env_name in env_names):
+                return device_name
+
+        command_checks = [
+            ("cambricon", ["cnmon"]),
+            ("ascend", ["npu-smi"]),
+            ("moore", ["mthreads-gmi"]),
+            ("metax", ["mx-smi", "ht-smi"]),
+            ("hygon", ["hy-smi"]),
+            ("ali", ["ppu-smi"]),
+            ("iluvatar", ["ixsmi"]),
+            ("nvidia", ["nvidia-smi"]),
+        ]
+        for device_name, commands in command_checks:
+            if any(shutil.which(command) for command in commands):
+                return device_name
+
+        if self._torch_device_available("cuda"):
+            return "nvidia"
+
+        return "cpu"
+
     def get_device_str(self, device):
         """Convert device name to backend string (cuda/cpu/musa/mlu)"""
         DEVICE_STR_MAP = {
             "cpu": "cpu",
+            "cuda": "cuda",
+            "mlu": "mlu",
+            "musa": "musa",
+            "npu": "npu",
             "nvidia": "cuda",
             "qy": "cuda",
             "cambricon": "mlu",
@@ -313,7 +396,11 @@ class BaseConfig:
             "hygon": "cuda",
             "ali": "cuda",
         }
-        return DEVICE_STR_MAP.get(device.lower(), "cpu")
+        device = device.lower()
+        if device == "auto":
+            device = self.detect_device()
+            print(f"Auto-detected device platform: {device}")
+        return DEVICE_STR_MAP.get(device, "cpu")
 
     def __repr__(self):
         """String representation of configuration"""


### PR DESCRIPTION
<!--
Thanks for contributing to InfiniLM! Please read `CONTRIBUTING.md` before
opening a pull request and fill out every section below. Delete any section
that is genuinely not applicable (and note why), but do not delete the
"Checklist" section — it must be filled in for every PR.

The PR title MUST follow Conventional Commits, e.g.
  feat: support Llama 3 models
  fix: correct linear attention calculations
See: https://www.conventionalcommits.org/
-->

## Summary

<!--
A concise description of **what** this PR changes. Prefer bullet points over
prose. Reference files with backtick-fenced paths (e.g. `csrc/models/llama/*`).
-->

-
-

## Motivation

<!--
Explain **why** this change is needed. Link to any related issue, bug, or
discussion. If this is a performance change, include before/after numbers
(hardware, shape, dtype, and the measurement methodology).
-->

Closes #

## Type of Change

<!-- Tick one or more. -->

- [x] `feat` — new feature / new model
- [ ] `fix` — bug fix
- [ ] `perf` — performance improvement (no behavioral change)
- [ ] `refactor` — code restructuring without behavior change
- [ ] `test` — adding or fixing tests only
- [ ] `docs` — documentation only
- [ ] `build` / `ci` — build system or CI configuration
- [ ] `chore` — tooling, formatting, or other non-code changes
- [ ] Breaking change

## Test Results of Involved Models on Supported Platforms (Please attach screenshots)

<!--
For now, provide the screenshots for involved tests performed on platforms supposed to support the changes.

Tests that might be involved:
Single request test: examples/test_infer.py
Offline performance: examples/bench.py
Sanity test: test/bench/test_benchmark.py
Service: python/infinilm/server/inference_server.py + scripts/test_perf.py

Model adaptations may involve all four tests, unless specifying partial support for vastly new structures and confirmed with admin.

Python-level changes may involve less tests depending on which files/features are modified. 

Framework-level and Python-level changes may affect different models. Test a few models that might be affected.
-->

## Benchmark / Performance Impact

<!--
Required for `perf` PRs; optional otherwise. Describe the benchmark harness,
shapes, dtypes, hardware, and include baseline vs. new numbers. If the PR is
not performance-sensitive, write "N/A".
-->

## Notes for Reviewers

<!--
Anything reviewers should focus on: subtle invariants, known trade-offs,
follow-up work intentionally left out of scope, etc.
-->

## CI / ChatOps

<!--
the repository pull requests run CI automatically on open, reopen and ready_for_review.
Maintainers can comment `/retest` to rerun CI for the current commit.
-->

---

## Checklist

> Every contributor **must** verify every item below before requesting
> review. Tick each box only after the check has actually been performed —
> do not tick speculatively. If an item truly does not apply, replace the
> checkbox with `N/A` and briefly explain why in an inline comment.

### Title, Branch, and Commits

- [ ] PR **title** follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(nvidia): …`, `fix(cuda/gemm): …`).
- [ ] Branch name follows `<type>/xxx-yyyy-zzzz` where `<type>` matches the PR title's Conventional Commits type and words are joined with hyphens (see `CONTRIBUTING.md` §Branches).
- [ ] Each **commit** message follows Conventional Commits.
- [ ] Small PR is a **single squashable commit**; or, for a large PR, every commit is meaningful, well-formed, and independently reviewable (see `CONTRIBUTING.md` §Pull Requests).
- [ ] No stray merge commits from `main` — the branch is rebased cleanly on top of the current `main`.
- [ ] No `fixup!` / `squash!` / `wip` commits remain.
- [ ] Existing PR/branch/commit that followed the legacy issue format.

### Scope and Design

- [ ] Changes are **minimal** — nothing unrelated to the stated motivation was added (`CONTRIBUTING.md` §Code/General).
- [ ] No dead code, commented-out blocks, debug prints, `printf`/`std::cout`/`print(...)` left behind, or `TODO` without an owner and issue link.
- [ ] No unrelated formatting churn that would obscure the diff.
- [ ] Public API changes (if any) are intentional, documented, and reflected in affected callers/tests.

### General Code Hygiene (applies to all languages)

- [ ] The code is self-explanatory; comments were added **only** where the *why* is non-obvious (`CONTRIBUTING.md` §Code/General).
- [ ] Every modified or added file **ends with a single trailing newline** (`CONTRIBUTING.md` §Code/General).
- [ ] No trailing whitespace, tab/space mixing, or stray BOMs.
- [ ] Identifiers in comments and error messages are wrapped in backticks (e.g. ``the `seqlens_k` tensor``) (`CONTRIBUTING.md` §Code/General).
- [ ] All comments and error messages are in **English** (`CONTRIBUTING.md` §Code/General).
- [ ] Comments and error messages are complete sentences — capitalized first letter, terminal punctuation — **unless** the language/framework convention says otherwise (`CONTRIBUTING.md` §Code/General; §Python).

### C++ Specific (if C++ files changed)

- [ ] Code follows the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) strictly.
- [ ] Error and warning message wording follows the [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html#error-and-warning-messages) (`CONTRIBUTING.md` §C++).
- [ ] Constructor **initializer list order matches member declaration order** (`CONTRIBUTING.md` §C++).
- [ ] No raw `new`/`delete`; RAII / smart pointers / existing allocators are used.
- [ ] Changed files are formatted by `scripts/format.py`.
- [ ] No changes/reference to `csrc/models/llama_legacy/`.

### Python Specific (if Python files changed)

- [ ] Code is [PEP 8](https://peps.python.org/pep-0008/) compliant.
- [ ] Comments are complete English sentences, starting with a capital letter and ending with punctuation; Markdown backticks are used for code references (`CONTRIBUTING.md` §Python).
- [ ] Docstrings (if any) follow [PEP 257](https://peps.python.org/pep-0257/) (`CONTRIBUTING.md` §Python).
- [ ] Changed files are formatted by `scripts/format.py`.
- [ ] No changes/reference to `python/infinilm/auto_config.py`.

### Testing

- [ ] For any platform that could not be tested, an explicit reason is given in the table and a reviewer with access has been tagged.
- [ ] Passed single request test (`examples/test_infer.py`), or specify the reason for skipping.
- [ ] Passed offline performance test (`examples/bench.py`), or specify the reason for skipping.
- [ ] Passed sanity test (`test/bench/test_benchmark.py`), or specify the reason for skipping.
- [ ] Passed service test (`python/infinilm/server/inference_server.py` + `scripts/test_perf.py`), or specify the reason for skipping.

### Build, CI, and Tooling

- [ ] The project builds cleanly from a fresh directory on at least one affected platform.
- [ ] CI has been triggered automatically, or `/retest` was requested if a rerun is needed.

### Documentation

- [ ] `README.md`, `CONTRIBUTING.md`, or inline docs updated when behavior, build flags, or developer workflow changed.
- [ ] Any user-visible breaking change is called out explicitly under "Motivation" **and** in the commit/PR title with a `!` or `BREAKING CHANGE:` footer.

### Security and Safety

- [ ] No secrets, access tokens, internal URLs, customer data, or personal hardware identifiers have been committed.
- [ ] Third-party code is license-compatible and attributed.
- [ ] No unsafe pointer arithmetic, uninitialized reads, or missing bounds checks were introduced.
