### PR TITLE
feat: use gpu marlin repack for quant weights

### DIFF
--- a/csrc/layers/quantization/marlin_support.hpp
+++ b/csrc/layers/quantization/marlin_support.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#if __has_include("infinicore/ops/gptq_marlin_gemm.hpp")
+#if __has_include("infinicore/ops/gptq_marlin_gemm.hpp") && __has_include("infiniop/ops/awq_marlin_repack.h") && __has_include("infiniop/ops/gptq_marlin_repack.h")
 #define INFINILM_ENABLE_MARLIN 1
 #else
 #define INFINILM_ENABLE_MARLIN 0

--- a/csrc/layers/quantization/marlin_utils.cpp
+++ b/csrc/layers/quantization/marlin_utils.cpp
@@ -1,13 +1,139 @@
 #include "marlin_utils.hpp"
+#include "marlin_support.hpp"
 
+#include "infinicore/context/context.hpp"
 #include <algorithm>
 #include <cstring>
 #include <numeric>
 #include <stdexcept>
 
+#if INFINILM_ENABLE_MARLIN
+#include <infiniop/ops/awq_marlin_repack.h>
+#include <infiniop/ops/gptq_marlin_repack.h>
+#endif
+
 namespace infinilm::quantization::marlin {
 
 namespace {
+
+#if INFINILM_ENABLE_MARLIN
+void check_infiniop_status(infiniStatus_t status, const char *expr) {
+    if (status != INFINI_STATUS_SUCCESS) {
+        throw std::runtime_error(std::string(expr) + " failed with status " + std::to_string(static_cast<int>(status)));
+    }
+}
+
+template <typename Desc, auto Destroy>
+class DescriptorGuard {
+public:
+    explicit DescriptorGuard(Desc desc) : desc_(desc) {}
+    DescriptorGuard(const DescriptorGuard &) = delete;
+    DescriptorGuard &operator=(const DescriptorGuard &) = delete;
+    ~DescriptorGuard() {
+        if (desc_ != nullptr) {
+            Destroy(desc_);
+        }
+    }
+    Desc get() const {
+        return desc_;
+    }
+
+private:
+    Desc desc_;
+};
+
+infinicore::Tensor make_workspace(size_t workspace_size, const infinicore::Device &device) {
+    if (workspace_size == 0) {
+        return infinicore::Tensor();
+    }
+    return infinicore::Tensor::empty({workspace_size}, infinicore::DataType::U8, device);
+}
+
+void *workspace_data(infinicore::Tensor &workspace) {
+    return workspace ? workspace->data() : nullptr;
+}
+
+infinicore::Tensor awq_marlin_repack_gpu(const infinicore::Tensor &qweight, size_t size_k, size_t size_n, int num_bits) {
+    const size_t pack_factor = 32 / num_bits;
+    auto qweight_contiguous = qweight->is_contiguous() ? qweight : qweight->contiguous();
+    auto output = infinicore::Tensor::empty({size_k / 16, size_n * 16 / pack_factor}, infinicore::DataType::I32, qweight_contiguous->device());
+
+    infiniopAwqMarlinRepackDescriptor_t raw_desc = nullptr;
+    check_infiniop_status(
+        infiniopCreateAwqMarlinRepackDescriptor(
+            infinicore::context::getInfiniopHandle(qweight_contiguous->device()),
+            &raw_desc,
+            output->desc(),
+            qweight_contiguous->desc(),
+            num_bits,
+            false),
+        "infiniopCreateAwqMarlinRepackDescriptor");
+    DescriptorGuard<infiniopAwqMarlinRepackDescriptor_t, infiniopDestroyAwqMarlinRepackDescriptor> desc(raw_desc);
+
+    size_t workspace_size = 0;
+    check_infiniop_status(
+        infiniopGetAwqMarlinRepackWorkspaceSize(desc.get(), &workspace_size),
+        "infiniopGetAwqMarlinRepackWorkspaceSize");
+    auto workspace = make_workspace(workspace_size, qweight_contiguous->device());
+
+    check_infiniop_status(
+        infiniopAwqMarlinRepack(
+            desc.get(),
+            workspace_data(workspace),
+            workspace_size,
+            output->data(),
+            qweight_contiguous->data(),
+            infinicore::context::getStream()),
+        "infiniopAwqMarlinRepack");
+    infinicore::context::syncStream();
+    return output;
+}
+
+infinicore::Tensor gptq_marlin_repack_gpu(
+    const infinicore::Tensor &qweight,
+    const infinicore::Tensor &perm,
+    size_t size_k,
+    size_t size_n,
+    int num_bits) {
+    const size_t pack_factor = 32 / num_bits;
+    auto qweight_contiguous = qweight->is_contiguous() ? qweight : qweight->contiguous();
+    auto output = infinicore::Tensor::empty({size_k / 16, size_n * 16 / pack_factor}, infinicore::DataType::I32, qweight_contiguous->device());
+    auto perm_desc = (perm && perm->numel() != 0) ? perm->desc() : nullptr;
+    const void *perm_data = (perm && perm->numel() != 0) ? perm->data() : nullptr;
+
+    infiniopGptqMarlinRepackDescriptor_t raw_desc = nullptr;
+    check_infiniop_status(
+        infiniopCreateGptqMarlinRepackDescriptor(
+            infinicore::context::getInfiniopHandle(qweight_contiguous->device()),
+            &raw_desc,
+            output->desc(),
+            qweight_contiguous->desc(),
+            perm_desc,
+            num_bits,
+            false),
+        "infiniopCreateGptqMarlinRepackDescriptor");
+    DescriptorGuard<infiniopGptqMarlinRepackDescriptor_t, infiniopDestroyGptqMarlinRepackDescriptor> desc(raw_desc);
+
+    size_t workspace_size = 0;
+    check_infiniop_status(
+        infiniopGetGptqMarlinRepackWorkspaceSize(desc.get(), &workspace_size),
+        "infiniopGetGptqMarlinRepackWorkspaceSize");
+    auto workspace = make_workspace(workspace_size, qweight_contiguous->device());
+
+    check_infiniop_status(
+        infiniopGptqMarlinRepack(
+            desc.get(),
+            workspace_data(workspace),
+            workspace_size,
+            output->data(),
+            qweight_contiguous->data(),
+            perm_data,
+            infinicore::context::getStream()),
+        "infiniopGptqMarlinRepack");
+    infinicore::context::syncStream();
+    return output;
+}
+#endif
 
 std::vector<int> scale_perm() {
     std::vector<int> perm;
@@ -153,13 +279,10 @@ std::vector<int32_t> repack_to_marlin_tiles(size_t size_k, size_t size_n, int nu
                     }
 
                     if (num_bits == 4) {
-                        out[out_offset + static_cast<size_t>(th * 4 + warp)] =
-                            static_cast<int32_t>(pack_repack_values(vals, num_bits, false));
+                        out[out_offset + static_cast<size_t>(th * 4 + warp)] = static_cast<int32_t>(pack_repack_values(vals, num_bits, false));
                     } else {
-                        out[out_offset + static_cast<size_t>(th * 8 + warp * 2)] =
-                            static_cast<int32_t>(pack_repack_values(vals, num_bits, false));
-                        out[out_offset + static_cast<size_t>(th * 8 + warp * 2 + 1)] =
-                            static_cast<int32_t>(pack_repack_values(vals, num_bits, true));
+                        out[out_offset + static_cast<size_t>(th * 8 + warp * 2)] = static_cast<int32_t>(pack_repack_values(vals, num_bits, false));
+                        out[out_offset + static_cast<size_t>(th * 8 + warp * 2 + 1)] = static_cast<int32_t>(pack_repack_values(vals, num_bits, true));
                     }
                 }
             }
@@ -191,6 +314,14 @@ infinicore::Tensor make_i32_tensor(const std::vector<int32_t> &data, const std::
 infinicore::Tensor awq_marlin_repack(const infinicore::Tensor &qweight, size_t size_k, size_t size_n, int num_bits) {
     check_repack_shape(size_k, size_n, num_bits);
     const size_t pack_factor = 32 / num_bits;
+#if INFINILM_ENABLE_MARLIN
+    if (qweight->dtype() != infinicore::DataType::I32 || qweight->shape() != std::vector<size_t>{size_k, size_n / pack_factor}) {
+        throw std::runtime_error("awq_marlin_repack: unexpected qweight shape or dtype");
+    }
+    if (qweight->device().getType() == infinicore::Device::Type::NVIDIA) {
+        return awq_marlin_repack_gpu(qweight, size_k, size_n, num_bits);
+    }
+#endif
     auto cpu = to_cpu_contiguous(qweight);
     if (cpu->dtype() != infinicore::DataType::I32 || cpu->shape() != std::vector<size_t>{size_k, size_n / pack_factor}) {
         throw std::runtime_error("awq_marlin_repack: unexpected qweight shape or dtype");
@@ -205,6 +336,17 @@ infinicore::Tensor awq_marlin_repack(const infinicore::Tensor &qweight, size_t s
 infinicore::Tensor gptq_marlin_repack(const infinicore::Tensor &qweight, const infinicore::Tensor &perm, size_t size_k, size_t size_n, int num_bits) {
     check_repack_shape(size_k, size_n, num_bits);
     const size_t pack_factor = 32 / num_bits;
+#if INFINILM_ENABLE_MARLIN
+    if (qweight->dtype() != infinicore::DataType::I32 || qweight->shape() != std::vector<size_t>{size_k / pack_factor, size_n}) {
+        throw std::runtime_error("gptq_marlin_repack: unexpected qweight shape or dtype");
+    }
+    if (perm && perm->numel() != 0 && (perm->dtype() != infinicore::DataType::I32 || perm->numel() != size_k)) {
+        throw std::runtime_error("gptq_marlin_repack: unexpected perm shape or dtype");
+    }
+    if (qweight->device().getType() == infinicore::Device::Type::NVIDIA) {
+        return gptq_marlin_repack_gpu(qweight, perm, size_k, size_n, num_bits);
+    }
+#endif
     auto cpu = to_cpu_contiguous(qweight);
     if (cpu->dtype() != infinicore::DataType::I32 || cpu->shape() != std::vector<size_t>{size_k / pack_factor, size_n}) {
         throw std::runtime_error("gptq_marlin_repack: unexpected qweight shape or dtype");
@@ -283,8 +425,7 @@ infinicore::Tensor awq_to_marlin_zero_points(const infinicore::Tensor &qzeros, s
     std::vector<int32_t> unpermuted(unpacked.size());
     for (size_t row = 0; row < unpacked.size() / undo_interleave.size(); ++row) {
         for (size_t i = 0; i < undo_interleave.size(); ++i) {
-            unpermuted[row * undo_interleave.size() + i] =
-                unpacked[row * undo_interleave.size() + static_cast<size_t>(undo_interleave[i])];
+            unpermuted[row * undo_interleave.size() + i] = unpacked[row * undo_interleave.size() + static_cast<size_t>(undo_interleave[i])];
         }
     }
 
@@ -300,7 +441,7 @@ infinicore::Tensor awq_to_marlin_zero_points(const infinicore::Tensor &qzeros, s
     }
 
     const std::vector<int> interleave = num_bits == 4 ? std::vector<int>{0, 2, 4, 6, 1, 3, 5, 7}
-                                                     : std::vector<int>{0, 2, 1, 3};
+                                                      : std::vector<int>{0, 2, 1, 3};
     std::vector<int32_t> interleaved(permuted.size());
     for (size_t row = 0; row < permuted.size() / interleave.size(); ++row) {
         for (size_t i = 0; i < interleave.size(); ++i) {


### PR DESCRIPTION
## Summary

- Use InfiniCore GPU Marlin repack operators for AWQ/GPTQ Marlin weight processing on NVIDIA.
- Keep the existing CPU repack path as a fallback when Marlin support is unavailable.
- Guard Marlin-specific code with `INFINILM_ENABLE_MARLIN` so builds without InfiniCore Marlin headers do not fail.
- Preserve the existing quantized linear flow while making future weight-processing extensions easier to integrate.

## Motivation

AWQ/GPTQ Marlin inference requires weights to be converted into Marlin-compatible layouts. The existing CPU repack path works, but it increases model loading cost and does not use the new InfiniCore GPU repack operators.

This PR connects InfiniLM's AWQ/GPTQ Marlin weight processing to InfiniCore GPU repack on NVIDIA, while preserving fallback behavior for unsupported builds.

Closes #

## Type of Change

- [x] `feat` - new feature / new model
- [ ] `fix` - bug fix
- [x] `perf` - performance improvement (no behavioral change)
- [x] `refactor` - code restructuring without behavior change
- [ ] `test` - adding or fixing tests only
- [ ] `docs` - documentation only
- [ ] `build` / `ci` - build system or CI configuration
- [ ] `chore` - tooling, formatting, or other non-code changes
- [ ] Breaking change

## Test Results of Involved Models on Supported Platforms (Please attach screenshots)

| Platform | Model | Quantization | Test | Result |
| --- | --- | --- | --- | --- |
| NVIDIA | Qwen2.5-7B-Instruct-GPTQ-Int4 | GPTQ Marlin | `examples/bench.py --device=nvidia --enable-paged-attn --attn=flash-attn --tp=1 --enable-graph` | Passed during local integration |
| NVIDIA | Qwen3-8B-AWQ-FP16 | AWQ Marlin | `examples/bench.py --device=nvidia --enable-paged-attn --attn=flash-attn --tp=1 --enable-graph` | Passed during local integration |
| NVIDIA | InfiniLM C++ extension | N/A | `xmake build _infinilm` | Passed locally during development |

Representative GPTQ command:

```bash
export TVM_ROOT=/xxx/InfiniCore/third_party/tvm-ffi
CUDA_VISIBLE_DEVICES=5,7 python examples/bench.py \
  --device=nvidia \
  --model=/xxx/Qwen2.5-7B-Instruct-GPTQ-Int4/ \
  --enable-paged-attn \
  --attn=flash-attn \
  --tp=1 \
  --input-len=5120 \
  --output-len=1024 \
  --batch-size=1 \
  --enable-graph
```

Representative AWQ command:

```bash
export TVM_ROOT=/xxx/InfiniCore/third_party/tvm-ffi
CUDA_VISIBLE_DEVICES=0 python examples/bench.py \
  --device=nvidia \
  --model=/xxx/Qwen3-8B-AWQ-FP16/ \
  --enable-paged-attn \
  --attn=flash-attn \
  --tp=1 \
  --input-len=2048 \
  --output-len=1024 \
  --batch-size=1 \
  --enable-graph
```

## Benchmark / Performance Impact

This PR moves AWQ/GPTQ Marlin repack from the CPU path to the InfiniCore GPU repack path on NVIDIA, reducing CPU-side preprocessing work during model loading.

Decode performance is not fully optimized in this PR. Known follow-up items include:

- Marlin workspace/cache reuse.
- Server-side lifecycle integration.
- Tensor-parallel communication overhead.
- Further decode performance comparison against vLLM.

## Notes for Reviewers

- `INFINILM_ENABLE_MARLIN` is determined by the availability of InfiniCore Marlin GEMM and repack headers.
- GPU repack is only selected for NVIDIA tensors.
- The CPU repack fallback is preserved for unsupported builds.
- This PR focuses on integrating GPU repack into the existing weight-processing flow. Runtime performance tuning is intentionally left as follow-up work.

## CI / ChatOps

The repository pull requests run CI automatically on open, reopen, and ready-for-review.

Maintainers can comment `/retest` to rerun CI for the current commit.

---

## Checklist

### Title, Branch, and Commits

- [x] PR **title** follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(nvidia): ...`, `fix(cuda/gemm): ...`).
- N/A - The current branch is an existing integration branch and does not follow the new `<type>/xxx-yyyy-zzzz` naming rule.
- [x] Each **commit** message follows Conventional Commits.
- [x] Small PR is a **single squashable commit**; or, for a large PR, every commit is meaningful, well-formed, and independently reviewable.
- [x] No stray merge commits from `main` - the branch is rebased cleanly on top of the current `main`.
- [x] No `fixup!` / `squash!` / `wip` commits remain.
- N/A - This PR does not use the legacy issue branch format.

### Scope and Design

- [x] Changes are **minimal** - nothing unrelated to the stated motivation was added.
- [x] No dead code, commented-out blocks, debug prints, `printf`/`std::cout`/`print(...)` left behind, or `TODO` without an owner and issue link.
- [x] No unrelated formatting churn that would obscure the diff.
- [x] Public API changes, if any, are intentional and reflected in affected callers.

### General Code Hygiene (applies to all languages)

- [x] The code is self-explanatory; comments were added only where the reason is non-obvious.
- [x] Every modified or added file ends with a single trailing newline.
- [x] No trailing whitespace, tab/space mixing, or stray BOMs.
- [x] Identifiers in comments and error messages are wrapped in backticks where applicable.
- [x] All comments and error messages are in English.
- [x] Comments and error messages are complete sentences where applicable.

### C++ Specific (if C++ files changed)

- [x] Code follows the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) strictly.
- [x] Error and warning message wording follows the [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html#error-and-warning-messages).
- [x] Constructor initializer list order matches member declaration order.
- [x] No raw `new`/`delete`; RAII / smart pointers / existing allocators are used.
- [x] Changed files are formatted.
- [x] No changes/reference to `csrc/models/llama_legacy/`.

### Python Specific (if Python files changed)

- N/A - No Python files were changed.
- N/A - No Python comments were changed.
- N/A - No Python docstrings were changed.
- N/A - No Python files were changed.
- N/A - No changes/reference to `python/infinilm/auto_config.py`.

### Testing

- [x] For any platform that could not be tested, an explicit reason is given in the table.
- [ ] Passed single request test (`examples/test_infer.py`), or specify the reason for skipping.
  - Skipped because this PR changes the C++ quantized weight-processing path; validation used `examples/bench.py` with AWQ/GPTQ Marlin models.
- [x] Passed offline performance test (`examples/bench.py`), or specify the reason for skipping.
- [ ] Passed sanity test (`test/bench/test_benchmark.py`), or specify the reason for skipping.
  - Skipped because this PR targets NVIDIA Marlin quantized model loading and inference paths.
- [ ] Passed service test (`python/infinilm/server/inference_server.py` + `scripts/test_perf.py`), or specify the reason for skipping.
  - Skipped. Server lifecycle and cache reuse are listed as follow-up work.

### Build, CI, and Tooling

- [x] The project builds cleanly on the affected NVIDIA development platform.
- [x] CI has been triggered automatically, or `/retest` was requested if a rerun is needed.

### Documentation

- N/A - No user-facing behavior, command-line option, or developer workflow was changed.
- N/A - This PR does not introduce a breaking change.

### Security and Safety

- [x] No secrets, access tokens, internal URLs, customer data, or personal hardware identifiers have been committed.
- [x] Third-party code is license-compatible and attributed.
- [x] No unsafe pointer arithmetic, uninitialized reads, or missing bounds checks were intentionally introduced.