### PR TITLE
Issue/457 deepseek_v2中 使用infinicore的yarn

### DIFF
--- a/csrc/layers/rotary_embedding/rope_scaling_creators.cpp
+++ b/csrc/layers/rotary_embedding/rope_scaling_creators.cpp
@@ -73,7 +73,31 @@ create_llama3_scaling_config(const std::shared_ptr<config::ModelConfig> &cfg) {
         original_max_position_embeddings);
 }
 
-// Future scaling creators go here (e.g., create_llama3, create_linear)
+/**
+ * @brief Creator function for YaRN RoPE scaling configuration.
+ */
+std::shared_ptr<infinicore::nn::RopeScalingConfig>
+create_yarn_scaling_config(const std::shared_ptr<config::ModelConfig> &cfg) {
+    const auto &rope_scaling = cfg->get_config_json()["rope_scaling"];
+
+    if (!rope_scaling.contains("factor") || !rope_scaling.contains("original_max_position_embeddings")) {
+        throw std::runtime_error(
+            "YarnRopeScalingConfig requires 'factor' and 'original_max_position_embeddings'");
+    }
+
+    const float factor = rope_scaling["factor"].get<float>();
+    const size_t original_max_position_embeddings = rope_scaling["original_max_position_embeddings"].get<size_t>();
+    const int beta_fast = static_cast<int>(rope_scaling.value("beta_fast", 32.0f));
+    const int beta_slow = static_cast<int>(rope_scaling.value("beta_slow", 1.0f));
+    const float mscale = rope_scaling.value("mscale", 1.0f);
+    const float mscale_all_dim = rope_scaling.value("mscale_all_dim", 0.0f);
+    const size_t rotary_dim = cfg->get_rotary_dim();
+    const float rope_theta = static_cast<float>(cfg->get<double>("rope_theta"));
+
+    return std::make_shared<infinicore::nn::YarnRopeScalingConfig>(
+        factor, original_max_position_embeddings, rotary_dim, rope_theta,
+        beta_fast, beta_slow, mscale, mscale_all_dim);
+}
 
 } // anonymous namespace
 
@@ -86,6 +110,7 @@ static bool _registered = []() {
     registry["dynamic"] = create_default_scaling_config;
     registry["longrope"] = create_longrope_config;
     registry["llama3"] = create_llama3_scaling_config;
+    registry["yarn"] = create_yarn_scaling_config;
     return true;
 }();
 

--- a/csrc/models/deepseek/deepseek_decoder_layer.cpp
+++ b/csrc/models/deepseek/deepseek_decoder_layer.cpp
@@ -1,0 +1,59 @@
+#include "deepseek_decoder_layer.hpp"
+
+#include "infinicore/ops.hpp"
+
+namespace infinilm::models::deepseek {
+
+DeepseekDecoderLayer::DeepseekDecoderLayer(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+                                           size_t layer_idx,
+                                           const infinicore::Device &device) {
+    const auto &dtype{model_config->get_dtype()};
+    const size_t hidden_size = model_config->get<size_t>("hidden_size");
+    const double rms_norm_eps = model_config->get<double>("rms_norm_eps");
+    INFINICORE_NN_MODULE_INIT(input_layernorm, hidden_size, rms_norm_eps, dtype, device);
+    INFINICORE_NN_MODULE_INIT(post_attention_layernorm, hidden_size, rms_norm_eps, dtype, device);
+    INFINICORE_NN_MODULE_INIT(self_attn, model_config, layer_idx, device);
+
+    const size_t first_k_dense_replace = model_config->get_or<size_t>("first_k_dense_replace", 0);
+    const size_t moe_layer_freq = model_config->get_or<size_t>("moe_layer_freq", 1);
+    const bool use_moe = model_config->get_or<size_t>("n_routed_experts", 0) > 0
+                      && layer_idx >= first_k_dense_replace
+                      && (moe_layer_freq == 0 || layer_idx % moe_layer_freq == 0);
+
+    if (use_moe) {
+        mlp_ = std::make_shared<DeepseekMLP>(
+            this->register_module<deepseek_v2::DeepseekV2MoE>("mlp", model_config, device));
+    } else {
+        mlp_ = std::make_shared<DeepseekMLP>(
+            this->register_module<deepseek_v2::DeepseekV2MLP>("mlp", model_config, device));
+    }
+}
+
+std::tuple<infinicore::Tensor, infinicore::Tensor>
+DeepseekDecoderLayer::forward(const infinicore::Tensor &positions,
+                              infinicore::Tensor &hidden_states,
+                              infinicore::Tensor &residual) {
+    input_layernorm_->forward_inplace(hidden_states, residual);
+    hidden_states = self_attn_->forward(positions, hidden_states);
+    post_attention_layernorm_->forward_inplace(hidden_states, residual);
+    hidden_states = std::visit(
+        [&](auto &mlp_ptr) { return mlp_ptr->forward(hidden_states); }, *mlp_);
+    return std::make_tuple(hidden_states, residual);
+}
+
+infinicore::Tensor DeepseekDecoderLayer::forward(const infinicore::Tensor &positions,
+                                                 infinicore::Tensor &hidden_states) {
+    auto residual = hidden_states;
+    hidden_states = input_layernorm_->forward(hidden_states);
+    hidden_states = self_attn_->forward(positions, hidden_states);
+    hidden_states = infinicore::op::add(residual, hidden_states);
+
+    residual = hidden_states;
+    hidden_states = post_attention_layernorm_->forward(hidden_states);
+    hidden_states = std::visit(
+        [&](auto &mlp_ptr) { return mlp_ptr->forward(hidden_states); }, *mlp_);
+    hidden_states = infinicore::op::add(residual, hidden_states);
+    return hidden_states;
+}
+
+} // namespace infinilm::models::deepseek

--- a/csrc/models/deepseek/deepseek_decoder_layer.hpp
+++ b/csrc/models/deepseek/deepseek_decoder_layer.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "../../config/model_config.hpp"
+#include "../../layers/attention/attention.hpp"
+#include "../deepseek_v2/deepseek_v2_moe.hpp"
+#include "infinicore/device.hpp"
+#include "infinicore/nn/module.hpp"
+#include "infinicore/nn/rmsnorm.hpp"
+#include "infinicore/tensor.hpp"
+
+#include <memory>
+#include <tuple>
+#include <variant>
+
+namespace infinilm::models::deepseek {
+
+using DeepseekMLP = std::variant<std::shared_ptr<deepseek_v2::DeepseekV2MLP>,
+                                 std::shared_ptr<deepseek_v2::DeepseekV2MoE>>;
+
+using DeepseekAttention = infinilm::layers::attention::Attention;
+
+class DeepseekDecoderLayer : public infinicore::nn::Module {
+public:
+    DeepseekDecoderLayer(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+                         size_t layer_idx,
+                         const infinicore::Device &device);
+
+    std::tuple<infinicore::Tensor, infinicore::Tensor> forward(const infinicore::Tensor &positions,
+                                                               infinicore::Tensor &hidden_states,
+                                                               infinicore::Tensor &residual);
+
+    infinicore::Tensor forward(const infinicore::Tensor &positions,
+                               infinicore::Tensor &hidden_states);
+
+private:
+    INFINICORE_NN_MODULE(infinicore::nn::RMSNorm, input_layernorm);
+    INFINICORE_NN_MODULE(infinicore::nn::RMSNorm, post_attention_layernorm);
+    INFINICORE_NN_MODULE(DeepseekAttention, self_attn);
+    INFINICORE_NN_MODULE(DeepseekMLP, mlp);
+};
+
+} // namespace infinilm::models::deepseek

--- a/csrc/models/deepseek/deepseek_for_causal_lm.cpp
+++ b/csrc/models/deepseek/deepseek_for_causal_lm.cpp
@@ -1,0 +1,48 @@
+#include "deepseek_for_causal_lm.hpp"
+#include "../models_registry.hpp"
+
+namespace infinilm::models::deepseek {
+
+std::shared_ptr<infinilm::config::ModelConfig> create_deepseek_model_config(
+    std::shared_ptr<infinilm::config::ModelConfig> model_config) {
+    const std::string &model_type = model_config->get<std::string>("model_type");
+    if ("deepseek" != model_type) {
+        throw std::runtime_error(
+            "infinilm::models::deepseek::create_deepseek_model_config: model_type is not deepseek");
+    }
+
+    nlohmann::json &config_json = model_config->get_config_json();
+
+    if (!config_json.contains("head_dim")) {
+        config_json["head_dim"] = model_config->get<size_t>("hidden_size")
+                                / model_config->get<size_t>("num_attention_heads");
+    }
+
+    config_json["num_experts"] = config_json.value("n_routed_experts", 0);
+    config_json["mlp_bias"] = false;
+
+    if (!config_json.contains("norm_topk_prob")) {
+        config_json["norm_topk_prob"] = false;
+    }
+    if (!config_json.contains("attention_bias")) {
+        config_json["attention_bias"] = false;
+    }
+    if (!config_json.contains("attention_output_bias")) {
+        config_json["attention_output_bias"] = config_json.value("attention_bias", false);
+    }
+    if (!config_json.contains("dtype") && config_json.contains("torch_dtype")) {
+        config_json["dtype"] = config_json["torch_dtype"];
+    }
+
+    return model_config;
+}
+
+} // namespace infinilm::models::deepseek
+
+namespace {
+
+INFINILM_REGISTER_CAUSAL_LM_MODEL(
+    deepseek,
+    infinilm::models::deepseek::DeepseekForCausalLM,
+    infinilm::models::deepseek::create_deepseek_model_config);
+} // namespace

--- a/csrc/models/deepseek/deepseek_for_causal_lm.hpp
+++ b/csrc/models/deepseek/deepseek_for_causal_lm.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "../../layers/common_modules.hpp"
+#include "deepseek_decoder_layer.hpp"
+#include <memory>
+
+namespace infinilm::models::deepseek {
+
+using DeepseekModel = infinilm::layers::causal_lm_templates::TextModel<DeepseekDecoderLayer>;
+
+using DeepseekForCausalLM = infinilm::layers::causal_lm_templates::TextCausalLM<DeepseekModel>;
+
+std::shared_ptr<infinilm::config::ModelConfig> create_deepseek_model_config(
+    std::shared_ptr<infinilm::config::ModelConfig> model_config);
+
+} // namespace infinilm::models::deepseek

--- a/csrc/models/deepseek_v2/deepseek_v2_attention.cpp
+++ b/csrc/models/deepseek_v2/deepseek_v2_attention.cpp
@@ -1,26 +1,18 @@
 #include "deepseek_v2_attention.hpp"
 
 #include "../../global_state/global_state.hpp"
+#include "../../layers/attention/attention.hpp"
+#include "../../layers/rotary_embedding/rotary_embedding.hpp"
 #include "../../utils.hpp"
+#include "deepseek_v2_utils.hpp"
 #include "infinicore/ops.hpp"
 #include "infinicore/ops/broadcast_to.hpp"
 #include "infinicore/ops/cat.hpp"
 #include "infinicore/ops/pad.hpp"
 
-#include <cmath>
 #include <stdexcept>
 
 namespace infinilm::models::deepseek_v2 {
-namespace {
-
-float yarn_get_mscale(float scale, float mscale) {
-    if (scale <= 1.0f) {
-        return 1.0f;
-    }
-    return 0.1f * mscale * std::log(scale) + 1.0f;
-}
-
-} // namespace
 
 DeepseekV2Attention::DeepseekV2Attention(std::shared_ptr<infinilm::config::ModelConfig> model_config,
                                          size_t layer_idx,
@@ -54,23 +46,8 @@ DeepseekV2Attention::DeepseekV2Attention(std::shared_ptr<infinilm::config::Model
     INFINICORE_NN_MODULE_INIT(kv_b_proj, kv_lora_rank, total_num_heads * (qk_nope_head_dim_ + v_head_dim_), quantization_method, false, dtype, device, tp_rank, tp_size);
     INFINICORE_NN_MODULE_INIT(o_proj, total_num_heads * v_head_dim_, hidden_size_, quantization_method, attention_bias, dtype, device, tp_rank, tp_size, rank_info.comm);
 
-    const size_t max_position_embeddings = model_config->get<size_t>("max_position_embeddings");
-    const double rope_theta = model_config->get<double>("rope_theta");
-    rotary_emb_ = std::make_shared<infinicore::nn::RoPE>(
-        qk_rope_head_dim_, qk_rope_head_dim_, max_position_embeddings, rope_theta,
-        infinicore::nn::RoPE::Algo::GPT_J, dtype, device, nullptr);
-
-    softmax_scale_ = 1.0f / std::sqrt(static_cast<float>(q_head_dim_));
-    auto &config_json = model_config->get_config_json();
-    if (config_json.contains("rope_scaling") && config_json["rope_scaling"].is_object()) {
-        const auto &rope_scaling = config_json["rope_scaling"];
-        const float mscale_all_dim = rope_scaling.value("mscale_all_dim", 0.0f);
-        if (mscale_all_dim != 0.0f) {
-            const float scaling_factor = rope_scaling.value("factor", 1.0f);
-            const float mscale = yarn_get_mscale(scaling_factor, mscale_all_dim);
-            softmax_scale_ *= mscale * mscale;
-        }
-    }
+    rotary_emb_ = infinilm::layers::rotary_embedding::get_rope(model_config, device);
+    softmax_scale_ = deepseek_v2_attention_softmax_scale(model_config, static_cast<float>(q_head_dim_));
 
     attn_ = std::make_shared<infinilm::layers::attention::AttentionLayer>(
         num_attention_heads_, q_head_dim_, softmax_scale_, num_attention_heads_, layer_idx_,

--- a/csrc/models/deepseek_v2/deepseek_v2_for_causal_lm.cpp
+++ b/csrc/models/deepseek_v2/deepseek_v2_for_causal_lm.cpp
@@ -2,7 +2,6 @@
 
 #include "../../global_state/global_state.hpp"
 #include "../models_registry.hpp"
-#include "infinicore/ops.hpp"
 
 #include <stdexcept>
 #include <string>
@@ -78,6 +77,10 @@ std::shared_ptr<infinilm::config::ModelConfig> create_deepseek_v2_model_config(s
     auto &config_json = model_config->get_config_json();
     const size_t q_head_dim = config_json.at("qk_nope_head_dim").get<size_t>() + config_json.at("qk_rope_head_dim").get<size_t>();
     config_json["head_dim"] = q_head_dim;
+    
+    const size_t qk_rope_head_dim = config_json.at("qk_rope_head_dim").get<size_t>();
+    config_json["partial_rotary_factor"] = static_cast<double>(qk_rope_head_dim) / static_cast<double>(q_head_dim);
+    
     config_json["num_experts"] = config_json.value("n_routed_experts", 0);
     config_json["mlp_bias"] = false;
     if (!config_json.contains("attention_output_bias")) {
@@ -86,6 +89,10 @@ std::shared_ptr<infinilm::config::ModelConfig> create_deepseek_v2_model_config(s
     if (!config_json.contains("dtype") && config_json.contains("torch_dtype")) {
         config_json["dtype"] = config_json["torch_dtype"];
     }
+
+    // Use GPT-J style for DeepseekV2
+    model_config->set_rope_algo(infinicore::nn::RoPE::Algo::GPT_J);
+
     return model_config;
 }
 

--- a/csrc/models/deepseek_v2/deepseek_v2_mla_attention.cpp
+++ b/csrc/models/deepseek_v2/deepseek_v2_mla_attention.cpp
@@ -1,17 +1,16 @@
 #include "deepseek_v2_mla_attention.hpp"
 
 #include "../../global_state/global_state.hpp"
+#include "../../layers/attention/attention.hpp"
+#include "../../layers/rotary_embedding/rotary_embedding.hpp"
 #include "../../utils.hpp"
+#include "deepseek_v2_utils.hpp"
 #include "infinicore/ops.hpp"
 #include "infinicore/ops/cat.hpp"
 #include "infinicore/ops/mha_varlen.hpp"
 #include "infinicore/ops/pad.hpp"
-#include "infinicore/ops/paged_attention.hpp"
-#include "infinicore/ops/paged_attention_prefill.hpp"
-#include "infinicore/ops/paged_caching.hpp"
 
 #include <atomic>
-#include <cmath>
 #include <stdexcept>
 #include <string>
 
@@ -24,13 +23,6 @@ bool is_dense_mla_prefill_unavailable(const std::runtime_error &err) {
     const std::string msg = err.what();
     return msg.find("ATen is not enabled") != std::string::npos
         || msg.find("FlashAttention is not enabled") != std::string::npos;
-}
-
-float yarn_get_mscale(float scale, float mscale) {
-    if (scale <= 1.0f) {
-        return 1.0f;
-    }
-    return 0.1f * mscale * std::log(scale) + 1.0f;
 }
 
 } // namespace
@@ -72,23 +64,8 @@ DeepseekV2MLAAttention::DeepseekV2MLAAttention(std::shared_ptr<infinilm::config:
     INFINICORE_NN_MODULE_INIT(kv_b_proj, kv_lora_rank_, total_num_heads * (qk_nope_head_dim_ + v_head_dim_), quantization_method, false, dtype, device, tp_rank, tp_size);
     INFINICORE_NN_MODULE_INIT(o_proj, total_num_heads * v_head_dim_, hidden_size_, quantization_method, attention_bias, dtype, device, tp_rank, tp_size, rank_info.comm);
 
-    const size_t max_position_embeddings = model_config->get<size_t>("max_position_embeddings");
-    const double rope_theta = model_config->get<double>("rope_theta");
-    rotary_emb_ = std::make_shared<infinicore::nn::RoPE>(
-        qk_rope_head_dim_, qk_rope_head_dim_, max_position_embeddings, rope_theta,
-        infinicore::nn::RoPE::Algo::GPT_J, dtype, device, nullptr);
-
-    softmax_scale_ = 1.0f / std::sqrt(static_cast<float>(q_head_dim_));
-    auto &config_json = model_config->get_config_json();
-    if (config_json.contains("rope_scaling") && config_json["rope_scaling"].is_object()) {
-        const auto &rope_scaling = config_json["rope_scaling"];
-        const float mscale_all_dim = rope_scaling.value("mscale_all_dim", 0.0f);
-        if (mscale_all_dim != 0.0f) {
-            const float scaling_factor = rope_scaling.value("factor", 1.0f);
-            const float mscale = yarn_get_mscale(scaling_factor, mscale_all_dim);
-            softmax_scale_ *= mscale * mscale;
-        }
-    }
+    rotary_emb_ = infinilm::layers::rotary_embedding::get_rope(model_config, device);
+    softmax_scale_ = deepseek_v2_attention_softmax_scale(model_config, static_cast<float>(q_head_dim_));
 
     latent_attn_ = std::make_shared<infinilm::layers::attention::AttentionLayer>(
         num_attention_heads_, mla_head_dim_, softmax_scale_, 1, layer_idx_,

--- a/csrc/models/deepseek_v2/deepseek_v2_utils.hpp
+++ b/csrc/models/deepseek_v2/deepseek_v2_utils.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "../../config/model_config.hpp"
+
+#include <cmath>
+#include <memory>
+
+namespace infinilm::models::deepseek_v2 {
+
+inline float deepseek_v2_attention_softmax_scale(
+    const std::shared_ptr<infinilm::config::ModelConfig> &model_config,
+    float q_head_dim) {
+    auto yarn_get_mscale = [](float scale, float mscale) {
+        if (scale <= 1.0f) {
+            return 1.0f;
+        }
+        return 0.1f * mscale * std::log(scale) + 1.0f;
+    };
+
+    float scale = 1.0f / std::sqrt(q_head_dim);
+    const auto &config_json = model_config->get_config_json();
+    if (!config_json.contains("rope_scaling") || !config_json["rope_scaling"].is_object()) {
+        return scale;
+    }
+
+    const auto &rope_scaling = config_json["rope_scaling"];
+    const float mscale_all_dim = rope_scaling.value("mscale_all_dim", 0.0f);
+    if (mscale_all_dim == 0.0f) {
+        return scale;
+    }
+
+    const float scaling_factor = rope_scaling.value("factor", 1.0f);
+    const float mscale = yarn_get_mscale(scaling_factor, mscale_all_dim);
+    return scale * mscale * mscale;
+}
+
+} // namespace infinilm::models::deepseek_v2

--- a/python/infinilm/processors/deepseek_processor.py
+++ b/python/infinilm/processors/deepseek_processor.py
@@ -1,0 +1,43 @@
+from .basic_llm_processor import BasicLLMProcessor
+from .processor import register_processor
+
+from typing import List, Optional, Union
+
+from transformers.models.llama import LlamaTokenizerFast
+
+
+class DeepseekTokenizerFast(LlamaTokenizerFast):
+    """Fast tokenizer for DeepSeek models (MoE V1, V2, etc.).
+
+    HuggingFace AutoTokenizer may load these checkpoints as generic LlamaTokenizer
+    when tokenization_deepseek_fast.py is missing from the model directory, which
+    breaks Chinese tokenization. Use this class directly instead.
+    """
+
+    def convert_ids_to_tokens(
+        self, ids: Union[int, List[int]], skip_special_tokens: bool = False
+    ) -> Union[str, List[str]]:
+        if isinstance(ids, int):
+            return self._convert_id_to_token(ids)
+        tokens = []
+        for index in ids:
+            index = int(index)
+            if skip_special_tokens and index in self.all_special_ids:
+                continue
+            token = self._tokenizer.id_to_token(index)
+            tokens.append(token if token is not None else "")
+        return tokens
+
+    def _convert_id_to_token(self, index: int) -> Optional[str]:
+        token = self._tokenizer.id_to_token(int(index))
+        return token if token is not None else ""
+
+
+@register_processor("deepseek")
+class DeepSeekProcessor(BasicLLMProcessor):
+    """Processor for DeepSeek MoE V1 models (model_type=deepseek)."""
+
+    def __init__(self, model_dir_path: str):
+        self.tokenizer = DeepseekTokenizerFast.from_pretrained(
+            model_dir_path, trust_remote_code=True
+        )


### PR DESCRIPTION
<!--
Thanks for contributing to InfiniLM! Please read `CONTRIBUTING.md` before
opening a pull request and fill out every section below. Delete any section
that is genuinely not applicable (and note why), but do not delete the
"Checklist" section — it must be filled in for every PR.

The PR title MUST follow Conventional Commits, e.g.
  feat: support Llama 3 models
  fix: correct linear attention calculations
See: https://www.conventionalcommits.org/
-->

## Summary

<!--
A concise description of **what** this PR changes. Prefer bullet points over
prose. Reference files with backtick-fenced paths (e.g. `csrc/models/llama/*`).
-->
(1) deepseek_v2中 使用infinicore的yarn
(2) 添加deepseek v1


**测试截图**
deepseek的离线推理 **tp=2**
<img width="1541" height="838" alt="Screenshot from 2026-06-25 13-35-16" src="https://github.com/user-attachments/assets/3b0ce830-7e58-4269-913f-660952e3a0ce" />

**deepseek_v2的离线推理 tp=2**
<img width="1541" height="840" alt="Screenshot from 2026-06-25 14-43-14" src="https://github.com/user-attachments/assets/70b6f09e-f4d1-4b9f-940b-99cf2bd2622f" />

**deepseek的服务推理 tp=1**
<img width="1126" height="787" alt="Screenshot from 2026-06-25 14-50-56" src="https://github.com/user-attachments/assets/f7fb7ec7-4b75-4056-a018-271e5c708bd9" />
<img width="1432" height="889" alt="Screenshot from 2026-06-25 14-54-11" src="https://github.com/user-attachments/assets/21fb4dcf-c0d7-49cb-a2c5-b061cc414749" />

**deepseek_v2的服务推理 tp=1**
<img width="893" height="848" alt="Screenshot from 2026-06-25 14-55-47" src="https://github.com/user-attachments/assets/b8aa27cd-20e5-474c-b2c7-547cadc9bc41" />
<img width="1118" height="665" alt="Screenshot from 2026-06-25 15-01-37" src="https://github.com/user-attachments/assets/5adc5892-f7d3-4a2d-9fbd-4c2800aedf26" />

-
-

## Motivation

<!--
Explain **why** this change is needed. Link to any related issue, bug, or
discussion. If this is a performance change, include before/after numbers
(hardware, shape, dtype, and the measurement methodology).
-->

Closes #

## Type of Change

<!-- Tick one or more. -->

- [x] `feat` — new feature / new model
- [ ] `fix` — bug fix
- [ ] `perf` — performance improvement (no behavioral change)
- [ ] `refactor` — code restructuring without behavior change
- [ ] `test` — adding or fixing tests only
- [ ] `docs` — documentation only
- [ ] `build` / `ci` — build system or CI configuration
- [ ] `chore` — tooling, formatting, or other non-code changes
- [ ] Breaking change

## Test Results of Involved Models on Supported Platforms (Please attach screenshots)

<!--
For now, provide the screenshots for involved tests performed on platforms supposed to support the changes.

Tests that might be involved:
Single request test: examples/test_infer.py
Offline performance: examples/bench.py
Sanity test: test/bench/test_benchmark.py
Service: python/infinilm/server/inference_server.py + scripts/test_perf.py

Model adaptations may involve all four tests, unless specifying partial support for vastly new structures and confirmed with admin.

Python-level changes may involve less tests depending on which files/features are modified. 

Framework-level and Python-level changes may affect different models. Test a few models that might be affected.
-->

## Benchmark / Performance Impact

<!--
Required for `perf` PRs; optional otherwise. Describe the benchmark harness,
shapes, dtypes, hardware, and include baseline vs. new numbers. If the PR is
not performance-sensitive, write "N/A".
-->

## Notes for Reviewers

<!--
Anything reviewers should focus on: subtle invariants, known trade-offs,
follow-up work intentionally left out of scope, etc.
-->

## CI / ChatOps

<!--
the repository pull requests run CI automatically on open, reopen and ready_for_review.
Maintainers can comment `/retest` to rerun CI for the current commit.
-->

---

## Checklist

> Every contributor **must** verify every item below before requesting
> review. Tick each box only after the check has actually been performed —
> do not tick speculatively. If an item truly does not apply, replace the
> checkbox with `N/A` and briefly explain why in an inline comment.

### Title, Branch, and Commits

- [ ] PR **title** follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(nvidia): …`, `fix(cuda/gemm): …`).
- [ ] Branch name follows `<type>/xxx-yyyy-zzzz` where `<type>` matches the PR title's Conventional Commits type and words are joined with hyphens (see `CONTRIBUTING.md` §Branches).
- [ ] Each **commit** message follows Conventional Commits.
- [ ] Small PR is a **single squashable commit**; or, for a large PR, every commit is meaningful, well-formed, and independently reviewable (see `CONTRIBUTING.md` §Pull Requests).
- [ ] No stray merge commits from `main` — the branch is rebased cleanly on top of the current `main`.
- [ ] No `fixup!` / `squash!` / `wip` commits remain.
- [ ] Existing PR/branch/commit that followed the legacy issue format.

### Scope and Design

- [ ] Changes are **minimal** — nothing unrelated to the stated motivation was added (`CONTRIBUTING.md` §Code/General).
- [ ] No dead code, commented-out blocks, debug prints, `printf`/`std::cout`/`print(...)` left behind, or `TODO` without an owner and issue link.
- [ ] No unrelated formatting churn that would obscure the diff.
- [ ] Public API changes (if any) are intentional, documented, and reflected in affected callers/tests.

### General Code Hygiene (applies to all languages)

- [ ] The code is self-explanatory; comments were added **only** where the *why* is non-obvious (`CONTRIBUTING.md` §Code/General).
- [ ] Every modified or added file **ends with a single trailing newline** (`CONTRIBUTING.md` §Code/General).
- [ ] No trailing whitespace, tab/space mixing, or stray BOMs.
- [ ] Identifiers in comments and error messages are wrapped in backticks (e.g. ``the `seqlens_k` tensor``) (`CONTRIBUTING.md` §Code/General).
- [ ] All comments and error messages are in **English** (`CONTRIBUTING.md` §Code/General).
- [ ] Comments and error messages are complete sentences — capitalized first letter, terminal punctuation — **unless** the language/framework convention says otherwise (`CONTRIBUTING.md` §Code/General; §Python).

### C++ Specific (if C++ files changed)

- [ ] Code follows the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) strictly.
- [ ] Error and warning message wording follows the [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html#error-and-warning-messages) (`CONTRIBUTING.md` §C++).
- [ ] Constructor **initializer list order matches member declaration order** (`CONTRIBUTING.md` §C++).
- [ ] No raw `new`/`delete`; RAII / smart pointers / existing allocators are used.
- [ ] Changed files are formatted by `scripts/format.py`.
- [ ] No changes/reference to `csrc/models/llama_legacy/`.

### Python Specific (if Python files changed)

- [ ] Code is [PEP 8](https://peps.python.org/pep-0008/) compliant.
- [ ] Comments are complete English sentences, starting with a capital letter and ending with punctuation; Markdown backticks are used for code references (`CONTRIBUTING.md` §Python).
- [ ] Docstrings (if any) follow [PEP 257](https://peps.python.org/pep-0257/) (`CONTRIBUTING.md` §Python).
- [ ] Changed files are formatted by `scripts/format.py`.
- [ ] No changes/reference to `python/infinilm/auto_config.py`.

### Testing

- [ ] For any platform that could not be tested, an explicit reason is given in the table and a reviewer with access has been tagged.
- [ ] Passed single request test (`examples/test_infer.py`), or specify the reason for skipping.
- [ ] Passed offline performance test (`examples/bench.py`), or specify the reason for skipping.
- [ ] Passed sanity test (`test/bench/test_benchmark.py`), or specify the reason for skipping.
- [ ] Passed service test (`python/infinilm/server/inference_server.py` + `scripts/test_perf.py`), or specify the reason for skipping.

### Build, CI, and Tooling

- [ ] The project builds cleanly from a fresh directory on at least one affected platform.
- [ ] CI has been triggered automatically, or `/retest` was requested if a rerun is needed.

### Documentation

- [ ] `README.md`, `CONTRIBUTING.md`, or inline docs updated when behavior, build flags, or developer workflow changed.
- [ ] Any user-visible breaking change is called out explicitly under "Motivation" **and** in the commit/PR title with a `!` or `BREAKING CHANGE:` footer.

### Security and Safety

- [ ] No secrets, access tokens, internal URLs, customer data, or personal hardware identifiers have been committed.
- [ ] Third-party code is license-compatible and attributed.
- [ ] No unsafe pointer arithmetic, uninitialized reads, or missing bounds checks were introduced.
