### PR TITLE
issue/467 [BUG]: enforce safetensors index-based weight loading for robustness

### DIFF
--- a/python/infinilm/infer_engine.py
+++ b/python/infinilm/infer_engine.py
@@ -12,8 +12,20 @@ from .exception_utils import handle_oom_and_exit
 import json
 import os
 
+_MODEL_DEFAULTS = {
+    "gpt2": {"torch_dtype": "float32"},
+    "mistral": {"torch_dtype": "bfloat16"},
+}
 
-def normalize_hf_config_for_infinilm(config_dict):
+def _apply_torch_dtype_defaults(config: dict) -> dict:
+    if config.get("torch_dtype") is None:
+        config["torch_dtype"] = (
+            config.get("dtype") or
+            _MODEL_DEFAULTS.get(config.get("model_type"), {}).get("torch_dtype")
+        )
+    return config
+
+def _normalize_videonsa_config(config_dict):
     model_type = config_dict.get("model_type")
 
     if model_type == "qwen2_5_vl" and config_dict.get("architectures") == [
@@ -36,24 +48,20 @@ def normalize_hf_config_for_infinilm(config_dict):
 
     return config_dict
 
-
 def read_hf_config(model_path):
     config_path = os.path.join(model_path, "config.json")
     with open(config_path, "r") as f:
         config_dict = json.load(f)
 
-    if (
-        config_dict.get("model_type") == "gpt2"
-        and config_dict.get("torch_dtype") is None
-        and config_dict.get("dtype") is None
-    ):
-        config_dict["torch_dtype"] = "float32"
     if "model_type" not in config_dict:
         raise ValueError(
             f"`model_type` is not specified in the config file `{config_path}`."
         )
-    return normalize_hf_config_for_infinilm(config_dict)
 
+    config_dict = _apply_torch_dtype_defaults(config_dict)
+    config_dict = _normalize_videonsa_config(config_dict)
+
+    return config_dict
 
 # config.json (required) defines model architecture, while generation_config.json
 # (optional) defines generation behavior. They are kept as separate readers

--- a/python/infinilm/modeling_utils.py
+++ b/python/infinilm/modeling_utils.py
@@ -183,7 +183,21 @@ def load_model_state_dict_by_file(
     already_loaded_keys = []
     embed_tokens_torch_unscaled = None
 
-    file_list = glob.glob(os.path.join(model_path, "*.safetensors"))
+    index_file_path = os.path.join(model_path, "model.safetensors.index.json")
+    if os.path.exists(index_file_path):
+        # Priority 1: If the index file exists, strictly load exactly what it maps to.
+        # This handles all standard sharded models perfectly, regardless of their actual prefix.
+        print(f"Found index file: {index_file_path}. Loading shards by index.")
+        with open(index_file_path, "r") as f:
+            index_data = json.load(f)
+        weight_map = index_data.get("weight_map", {})
+        unique_filenames = set(weight_map.values())
+        file_list = [os.path.join(model_path, fname) for fname in unique_filenames]
+    else:
+        # Priority 2: If no index file, scan all safetensors files.
+        print("No index file found. Scanning all safetensors files...")
+        file_list = glob.glob(os.path.join(model_path, "*.safetensors"))
+
     if len(file_list) > 0:
         for file_path in tqdm(file_list, desc="Processing files"):
             tqdm.write(f"Processing: {os.path.basename(file_path)}")


### PR DESCRIPTION
Replace fragile glob with model.safetensors.index.json lookup to handle non-standard names (e.g., Mistral-Large-Instruct). Includes glob fallback

一般模型都包含model.safetensors.index.json文件，该文件描述了权重文件组成。

而有的模型，会有多种格式的权重文件，不能简单把所有safetensors文件加载到显存上。

<img width="2009" height="431" alt="image" src="https://github.com/user-attachments/assets/378c5efd-e453-4113-82ef-09548080fda3" />


模型验证：python examples/test_infer.py --device moore --model /home/rubik/models/Mistral-Large-Instruct-2411 --tp 8  --prompt 'introduce yourself'

<img width="2250" height="1014" alt="image" src="https://github.com/user-attachments/assets/10af41a6-3e37-4b1a-856a-f6e5e649420d" />


为了验证不影响其它模型推理，其它模型验证截图
<img width="1488" height="803" alt="image" src="https://github.com/user-attachments/assets/702dcf3a-5d43-4de0-9864-07e2ac07c843" />
<img width="1488" height="903" alt="image" src="https://github.com/user-attachments/assets/3d42a394-e2ce-4997-befd-764674dde96b" />
<img width="1491" height="886" alt="image" src="https://github.com/user-attachments/assets/1cfd248f-0560-4456-a535-a3e95632bf2d" />
<img width="1497" height="846" alt="image" src="https://github.com/user-attachments/assets/54957b2d-94e6-4637-b2b0-6422a6efd480" />
<img width="1482" height="879" alt="image" src="https://github.com/user-attachments/assets/854c7246-1a21-4231-a825-911859cc975a" />
<img width="1496" height="908" alt="image" src="https://github.com/user-attachments/assets/c4c01f84-eed0-4974-8827-9cf5c1d9c4cd" />

