### PR TITLE
feat: qwen3.5 vision model

### DIFF
--- a/csrc/engine/infer_engine.cpp
+++ b/csrc/engine/infer_engine.cpp
@@ -175,6 +175,8 @@ InferEngine::Input::to_model_input(infinicore::Device device) const {
         to_device_vec(image_bound),
         to_device_vec(tgt_sizes),
         visual_token_ranges,
+        to_device_vec(image_grid_thw),
+        image_req_ids,
     };
 
     infinilm::global_state::get_forward_context().attn_metadata = {

--- a/csrc/engine/rank_worker.hpp
+++ b/csrc/engine/rank_worker.hpp
@@ -62,6 +62,8 @@ public:
         std::optional<std::vector<infinicore::Tensor>> image_bound;
         /// Target patch sizes for each image (MiniCPM-V).
         std::optional<std::vector<infinicore::Tensor>> tgt_sizes;
+        /// Qwen-style image grids. Vector of tensors shape: [3] with temporal, height, width.
+        std::optional<std::vector<infinicore::Tensor>> image_grid_thw;
         /// req_id for each pixel_values among a batch
         std::optional<std::vector<size_t>> image_req_ids;
         /// Flattened [start, end) visual token ranges in the packed language sequence.

--- a/csrc/models/infinilm_model.hpp
+++ b/csrc/models/infinilm_model.hpp
@@ -49,6 +49,10 @@ public:
         std::optional<std::vector<infinicore::Tensor>> tgt_sizes;
         /// Flattened [start, end) visual token ranges in the packed language sequence.
         std::optional<std::vector<size_t>> visual_token_ranges;
+        /// Qwen-style image grids. Vector of tensors shape: [3] with temporal, height, width.
+        std::optional<std::vector<infinicore::Tensor>> image_grid_thw;
+        /// req_id for each pixel_values among a batch.
+        std::optional<std::vector<size_t>> image_req_ids;
     };
 
     struct Output {

--- a/csrc/models/qwen3_5/qwen3_5_attention.cpp
+++ b/csrc/models/qwen3_5/qwen3_5_attention.cpp
@@ -1,9 +1,15 @@
 #include "qwen3_5_attention.hpp"
 #include "../../global_state/global_state.hpp"
 #include "../../layers/attention/attention.hpp"
+#include "../../layers/rotary_embedding/rotary_embedding.hpp"
+#include "../../layers/rotary_embedding/rotary_embedding_factory.hpp"
 #include "../../utils.hpp"
+#include <algorithm>
+#include <cmath>
 #include <infinicore/ops/mul.hpp>
 #include <infinicore/ops/sigmoid.hpp>
+#include <optional>
+#include <vector>
 
 namespace infinilm::models::qwen3_5 {
 
@@ -43,7 +49,33 @@ Qwen35Attention::Qwen35Attention(std::shared_ptr<infinilm::config::ModelConfig> 
         "o_proj", total_num_heads * head_dim_, hidden_size_, quantization_method,
         use_output_bias, dtype, device, tp_rank, tp_size, rank_info.comm);
 
-    rotary_emb_ = infinilm::layers::rotary_embedding::get_rope(model_config, device);
+    const auto &rope_params = model_config->get_config_json()["rope_parameters"];
+    const double partial_rotary_factor = rope_params["partial_rotary_factor"].get<double>();
+    rotary_dim_ = static_cast<size_t>(std::llround(static_cast<double>(head_dim_) * partial_rotary_factor));
+    rotary_dim_ = std::clamp(rotary_dim_, static_cast<size_t>(2), head_dim_);
+    if (rotary_dim_ % 2 != 0) {
+        rotary_dim_ -= 1;
+    }
+    rotary_dim_ = std::max(rotary_dim_, static_cast<size_t>(2));
+
+    auto mrope_section = rope_params["mrope_section"].get<std::vector<int>>();
+    if (mrope_section.size() != 3) {
+        throw std::runtime_error("infinilm::models::qwen3_5::Qwen35Attention: mrope_section must have 3 elements");
+    }
+    const bool mrope_interleaved = rope_params["mrope_interleaved"].get<bool>();
+    const double rope_theta = rope_params["rope_theta"].get<double>();
+    const size_t max_position_embeddings = model_config->get<size_t>("max_position_embeddings");
+    auto rope_scaling = infinilm::layers::rotary_embedding::make_scaling_config(model_config);
+    mrope_ = infinilm::layers::rotary_embedding::get_rope(head_dim_,
+                                                          rotary_dim_,
+                                                          max_position_embeddings,
+                                                          rope_theta,
+                                                          model_config->get_rope_algo(),
+                                                          dtype,
+                                                          device,
+                                                          rope_scaling,
+                                                          mrope_section,
+                                                          mrope_interleaved);
 
     float scaling = 1.0f / std::sqrt(static_cast<float>(head_dim_));
     attn_ = std::make_shared<infinilm::layers::attention::AttentionLayer>(num_attention_heads_, head_dim_, scaling, num_key_value_heads_, layer_idx_,
@@ -72,28 +104,18 @@ infinicore::Tensor Qwen35Attention::forward_static_(const infinicore::Tensor &po
 
     auto [q, gate, k, v] = qkv_proj_->forward_split(hidden_states_mutable);
 
-    q = q_norm_->forward(q->view({batch_size * seq_len, num_attention_heads_, head_dim_}));
-    k = k_norm_->forward(k->view({batch_size * seq_len, num_key_value_heads_, head_dim_}));
-
-    auto q_reshaped = q->view({batch_size, seq_len, num_attention_heads_, head_dim_});
-    auto k_reshaped = k->view({batch_size, seq_len, num_key_value_heads_, head_dim_});
-    auto v_reshaped = v->view({batch_size, seq_len, num_key_value_heads_, head_dim_});
+    auto q_reshaped = q_norm_->forward(q->view({batch_size * seq_len, num_attention_heads_, head_dim_}));
+    auto k_reshaped = k_norm_->forward(k->view({batch_size * seq_len, num_key_value_heads_, head_dim_}));
 
     auto pos_shape = position_ids->shape();
-    infinicore::Tensor pos_ids_for_rope = position_ids;
-    if (pos_shape.size() == 2) {
-        auto pos_narrowed = position_ids->narrow({{0, 0, 1}});
-        pos_ids_for_rope = pos_narrowed->view({pos_shape[1]});
-    } else if (pos_shape.size() == 1) {
-        pos_ids_for_rope = position_ids;
-    } else {
+    if (pos_shape.size() != 2 && pos_shape.size() != 1) {
         throw std::runtime_error("infinilm::models::qwen3_5::Qwen35Attention: Unexpected position_ids shape");
     }
+    std::tie(q_reshaped, k_reshaped) = mrope_->forward(q_reshaped, k_reshaped, position_ids);
 
-    auto q_rotary = q_reshaped->narrow({{3, 0, rotary_dim_}});
-    auto k_rotary = k_reshaped->narrow({{3, 0, rotary_dim_}});
-    rotary_emb_->forward(q_rotary, pos_ids_for_rope, true);
-    rotary_emb_->forward(k_rotary, pos_ids_for_rope, true);
+    q_reshaped = q_reshaped->view({batch_size, seq_len, num_attention_heads_, head_dim_});
+    k_reshaped = k_reshaped->view({batch_size, seq_len, num_key_value_heads_, head_dim_});
+    auto v_reshaped = v->view({batch_size, seq_len, num_key_value_heads_, head_dim_});
 
     auto attn_output = attn_->forward(q_reshaped, k_reshaped, v_reshaped);
     attn_output = infinicore::op::mul(attn_output, infinicore::op::sigmoid(gate));
@@ -118,20 +140,10 @@ infinicore::Tensor Qwen35Attention::forward_paged_(const infinicore::Tensor &pos
     k_reshaped = k_norm_->forward(k_reshaped);
 
     auto pos_shape = position_ids->shape();
-    infinicore::Tensor pos_ids_for_rope = position_ids;
-    if (pos_shape.size() == 2) {
-        auto pos_narrowed = position_ids->narrow({{0, 0, 1}});
-        pos_ids_for_rope = pos_narrowed->view({pos_shape[1]});
-    } else if (pos_shape.size() == 1) {
-        pos_ids_for_rope = position_ids;
-    } else {
+    if (pos_shape.size() != 2 && pos_shape.size() != 1) {
         throw std::runtime_error("Unexpected position_ids shape");
     }
-
-    auto q_rotary = q_reshaped->narrow({{2, 0, rotary_dim_}});
-    auto k_rotary = k_reshaped->narrow({{2, 0, rotary_dim_}});
-    rotary_emb_->forward(q_rotary, pos_ids_for_rope, true);
-    rotary_emb_->forward(k_rotary, pos_ids_for_rope, true);
+    std::tie(q_reshaped, k_reshaped) = mrope_->forward(q_reshaped, k_reshaped, position_ids);
 
     auto attn_output = attn_->forward(q_reshaped, k_reshaped, v_reshaped);
     attn_output = infinicore::op::mul(attn_output, infinicore::op::sigmoid(gate)->view(attn_output->shape()));

--- a/csrc/models/qwen3_5/qwen3_5_attention.hpp
+++ b/csrc/models/qwen3_5/qwen3_5_attention.hpp
@@ -31,7 +31,7 @@ protected:
     std::shared_ptr<infinilm::layers::linear::RowParallelLinear> o_proj_;
     INFINICORE_NN_MODULE(infinicore::nn::RMSNorm, q_norm);
     INFINICORE_NN_MODULE(infinicore::nn::RMSNorm, k_norm);
-    std::shared_ptr<infinicore::nn::RoPE> rotary_emb_;
+    std::shared_ptr<infinicore::nn::RoPE> mrope_;
 
     std::shared_ptr<infinilm::layers::attention::AttentionLayer> attn_;
     ::infinilm::backends::AttentionBackend attention_backend_;

--- a/csrc/models/qwen3_5/qwen3_5_model.cpp
+++ b/csrc/models/qwen3_5/qwen3_5_model.cpp
@@ -3,9 +3,33 @@
 #include "../../global_state/global_state.hpp"
 #include "../qwen3_next/qwen3_next_allocate_kv_cache_tensors.hpp"
 
+#include <cstdint>
+#include <stdexcept>
 #include <utility>
+#include <vector>
 
 namespace infinilm::models::qwen3_5 {
+namespace {
+
+std::vector<int32_t> tensor_to_i32_vector(const infinicore::Tensor &tensor) {
+    auto cpu_tensor = tensor->to(infinicore::Device::cpu());
+    std::vector<int32_t> values(cpu_tensor->numel());
+    if (cpu_tensor->dtype() == infinicore::DataType::I32) {
+        const auto *ptr = reinterpret_cast<const int32_t *>(cpu_tensor->data());
+        values.assign(ptr, ptr + cpu_tensor->numel());
+        return values;
+    }
+    if (cpu_tensor->dtype() == infinicore::DataType::I64) {
+        const auto *ptr = reinterpret_cast<const int64_t *>(cpu_tensor->data());
+        for (size_t i = 0; i < cpu_tensor->numel(); ++i) {
+            values[i] = static_cast<int32_t>(ptr[i]);
+        }
+        return values;
+    }
+    throw std::runtime_error("Qwen35Model: expected int32 or int64 tensor");
+}
+
+} // namespace
 
 Qwen35Model::Qwen35Model(std::shared_ptr<infinilm::config::ModelConfig> model_config,
                          const infinicore::Device &device)
@@ -19,7 +43,76 @@ Qwen35Model::Qwen35Model(std::shared_ptr<infinilm::config::ModelConfig> model_co
     INFINICORE_NN_MODULE_INIT(language_model, model_config, device);
 }
 
+void Qwen35Model::replace_image_embeddings(infinicore::Tensor &inputs_embeds,
+                                           const InfinilmModel::Input &input) const {
+    if (!input.pixel_values.has_value() || input.pixel_values->empty()) {
+        return;
+    }
+    if (!input.image_grid_thw.has_value()) {
+        throw std::runtime_error("Qwen35Model: image_grid_thw must be provided with pixel_values");
+    }
+    if (!input.image_bound.has_value()) {
+        throw std::runtime_error("Qwen35Model: image_bound must be provided with pixel_values");
+    }
+    if (!input.input_offsets.has_value()) {
+        throw std::runtime_error("Qwen35Model: input_offsets are required for image replacement");
+    }
+    if (!visual_) {
+        throw std::runtime_error("Qwen35Model: visual module is not initialized");
+    }
+
+    const auto &pixel_values = input.pixel_values.value();
+    const auto &image_grid_thw = input.image_grid_thw.value();
+    const auto &image_bound = input.image_bound.value();
+    if (pixel_values.size() != image_grid_thw.size() || pixel_values.size() != image_bound.size()) {
+        throw std::runtime_error("Qwen35Model: pixel_values, image_grid_thw and image_bound size mismatch");
+    }
+
+    const auto &image_req_ids_opt = infinilm::global_state::get_forward_context().mm_metadata.image_req_ids;
+    if (!image_req_ids_opt.has_value() || image_req_ids_opt->size() != pixel_values.size()) {
+        throw std::runtime_error("Qwen35Model: image_req_ids must match pixel_values");
+    }
+
+    auto offsets = tensor_to_i32_vector(input.input_offsets.value());
+
+    for (size_t image_idx = 0; image_idx < pixel_values.size(); ++image_idx) {
+        const size_t req_id = image_req_ids_opt.value().at(image_idx);
+        if (req_id + 1 >= offsets.size()) {
+            throw std::runtime_error("Qwen35Model: image request id is out of range");
+        }
+
+        auto bound = tensor_to_i32_vector(image_bound.at(image_idx));
+        if (bound.size() < 2) {
+            throw std::runtime_error("Qwen35Model: image_bound must contain start and end positions");
+        }
+        if (bound[0] < 0 || bound[1] < bound[0]) {
+            throw std::runtime_error("Qwen35Model: invalid image_bound range");
+        }
+
+        auto vision_hidden = visual_->forward(pixel_values.at(image_idx), image_grid_thw.at(image_idx));
+        const size_t vision_len = vision_hidden->size(0);
+        const size_t req_start = static_cast<size_t>(offsets[req_id]);
+        const size_t req_len = static_cast<size_t>(offsets[req_id + 1] - offsets[req_id]);
+        const size_t local_start = static_cast<size_t>(bound[0]);
+        const size_t local_end = static_cast<size_t>(bound[1]);
+        const size_t span_len = local_end - local_start;
+        if (local_end > req_len) {
+            throw std::runtime_error("Qwen35Model: image_bound is out of request range");
+        }
+        if (span_len != vision_len) {
+            throw std::runtime_error("Qwen35Model: image_bound length does not match visual embedding length");
+        }
+
+        inputs_embeds->narrow({{1, req_start + local_start, span_len}})->copy_from(vision_hidden->unsqueeze(0));
+    }
+}
+
 infinicore::Tensor Qwen35Model::forward(const InfinilmModel::Input &input) const {
+    if (input.pixel_values.has_value() && !input.pixel_values->empty()) {
+        auto inputs_embeds = language_model_->embed_tokens(input.input_ids.value());
+        replace_image_embeddings(inputs_embeds, input);
+        return language_model_->forward_embeds(inputs_embeds, input.position_ids.value());
+    }
     return language_model_->forward(input);
 }
 

--- a/csrc/models/qwen3_5/qwen3_5_model.hpp
+++ b/csrc/models/qwen3_5/qwen3_5_model.hpp
@@ -2,6 +2,7 @@
 
 #include "../../layers/common_modules.hpp"
 #include "../infinilm_model.hpp"
+#include "infinicore/tensor.hpp"
 #include "qwen3_5_decoderLayer.hpp"
 #include "qwen3_5_vision.hpp"
 
@@ -18,11 +19,14 @@ public:
 
     void reset_cache(const cache::CacheConfig *cache_config);
 
+private:
+    void replace_image_embeddings(infinicore::Tensor &inputs_embeds,
+                                  const infinilm::InfinilmModel::Input &input) const;
+
 protected:
     INFINICORE_NN_MODULE(Qwen35VisionModel, visual);
     INFINICORE_NN_MODULE(Qwen35LanguageModel, language_model);
 
-private:
     std::shared_ptr<infinilm::config::ModelConfig> model_config_;
 };
 

--- a/csrc/models/qwen3_5/qwen3_5_vision.cpp
+++ b/csrc/models/qwen3_5/qwen3_5_vision.cpp
@@ -1,8 +1,19 @@
 #include "qwen3_5_vision.hpp"
 
+#include "../../utils.hpp"
+
+#include <infinicore/ops.hpp>
+#include <infinicore/ops/mha.hpp>
+#include <infinicore/ops/upsample_bilinear.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
 #include <optional>
 #include <stdexcept>
 #include <string>
+#include <utility>
+#include <vector>
 
 namespace infinilm::models::qwen3_5 {
 namespace {
@@ -16,6 +27,24 @@ size_t get_size_or_first(const nlohmann::json &config, const char *key, size_t d
         return value.empty() ? default_value : value.at(0).get<size_t>();
     }
     return value.get<size_t>();
+}
+
+std::vector<int64_t> tensor_to_i64_vector(const infinicore::Tensor &tensor) {
+    auto cpu_tensor = tensor->to(infinicore::Device::cpu());
+    std::vector<int64_t> values(cpu_tensor->numel());
+    if (cpu_tensor->dtype() == infinicore::DataType::I64) {
+        const auto *ptr = reinterpret_cast<const int64_t *>(cpu_tensor->data());
+        values.assign(ptr, ptr + cpu_tensor->numel());
+        return values;
+    }
+    if (cpu_tensor->dtype() == infinicore::DataType::I32) {
+        const auto *ptr = reinterpret_cast<const int32_t *>(cpu_tensor->data());
+        for (size_t i = 0; i < cpu_tensor->numel(); ++i) {
+            values[i] = static_cast<int64_t>(ptr[i]);
+        }
+        return values;
+    }
+    throw std::runtime_error("Qwen35VisionModel: grid_thw must be int32 or int64");
 }
 
 } // namespace
@@ -35,7 +64,12 @@ Qwen35VisionPatchProj::Qwen35VisionPatchProj(size_t in_channels,
 }
 
 infinicore::Tensor Qwen35VisionPatchProj::forward(const infinicore::Tensor &hidden_states) const {
-    throw std::runtime_error("Qwen35VisionPatchProj::forward is not implemented yet");
+    const size_t patch_dim = in_channels_ * temporal_patch_size_ * patch_size_ * patch_size_;
+    if (hidden_states->shape().size() != 2 || hidden_states->size(1) != patch_dim) {
+        throw std::runtime_error("Qwen35VisionPatchProj: expected pixel_values shape [num_patches, patch_dim]");
+    }
+    auto weight_2d = weight_->view({hidden_size_, patch_dim});
+    return infinicore::op::linear(hidden_states, weight_2d, std::make_optional<infinicore::Tensor>(bias_));
 }
 
 Qwen35VisionPatchEmbed::Qwen35VisionPatchEmbed(const nlohmann::json &config,
@@ -56,18 +90,60 @@ Qwen35VisionAttention::Qwen35VisionAttention(const nlohmann::json &config,
                                              const infinicore::DataType &dtype,
                                              const infinicore::Device &device)
     : hidden_size_(config.value("hidden_size", 1152)),
-      num_heads_(config.value("num_heads", 16)) {
+      num_heads_(config.value("num_heads", 16)),
+      head_dim_(hidden_size_ / num_heads_),
+      scale_(1.0f / std::sqrt(static_cast<float>(head_dim_))) {
+    if (hidden_size_ % num_heads_ != 0) {
+        throw std::runtime_error("Qwen35VisionAttention: hidden_size must be divisible by num_heads");
+    }
+    if (head_dim_ % 4 != 0) {
+        throw std::runtime_error("Qwen35VisionAttention: head_dim must be divisible by 4 for 2D RoPE");
+    }
+    const size_t axis_head_dim = head_dim_ / 2;
+    INFINICORE_NN_MODULE_INIT(rotary_emb, axis_head_dim, axis_head_dim, 8192, 10000.0, infinicore::nn::RoPE::Algo::GPT_NEOX, dtype, device);
     INFINICORE_NN_MODULE_INIT(qkv, hidden_size_, hidden_size_ * 3, true, dtype, device);
     INFINICORE_NN_MODULE_INIT(proj, hidden_size_, hidden_size_, true, dtype, device);
 }
 
-infinicore::Tensor Qwen35VisionAttention::forward(const infinicore::Tensor &hidden_states) const {
-    throw std::runtime_error("Qwen35VisionAttention::forward is not implemented yet");
+infinicore::Tensor Qwen35VisionAttention::forward(const infinicore::Tensor &hidden_states,
+                                                  const infinicore::Tensor &row_position_ids,
+                                                  const infinicore::Tensor &col_position_ids) const {
+    const size_t seq_len = hidden_states->size(0);
+    const size_t axis_head_dim = head_dim_ / 2;
+    auto hidden_mut = hidden_states;
+    auto qkv = qkv_->forward(hidden_mut)->view({seq_len, 3, num_heads_, head_dim_});
+    auto q = qkv->narrow({{1, 0, 1}})->squeeze(1)->contiguous();
+    auto k = qkv->narrow({{1, 1, 1}})->squeeze(1)->contiguous();
+    auto v = qkv->narrow({{1, 2, 1}})->squeeze(1)->contiguous()->unsqueeze(0);
+
+    const size_t axis_pair_dim = axis_head_dim / 2;
+    auto apply_2d_rope = [&](const infinicore::Tensor &x) {
+        auto row = infinicore::Tensor::empty({seq_len, num_heads_, axis_head_dim}, x->dtype(), x->device());
+        auto col = infinicore::Tensor::empty({seq_len, num_heads_, axis_head_dim}, x->dtype(), x->device());
+        row->narrow({{2, 0, axis_pair_dim}})->copy_from(x->narrow({{2, 0, axis_pair_dim}}));
+        row->narrow({{2, axis_pair_dim, axis_pair_dim}})->copy_from(x->narrow({{2, axis_head_dim, axis_pair_dim}}));
+        col->narrow({{2, 0, axis_pair_dim}})->copy_from(x->narrow({{2, axis_pair_dim, axis_pair_dim}}));
+        col->narrow({{2, axis_pair_dim, axis_pair_dim}})->copy_from(x->narrow({{2, axis_head_dim + axis_pair_dim, axis_pair_dim}}));
+
+        rotary_emb_->forward(row, row_position_ids, true);
+        rotary_emb_->forward(col, col_position_ids, true);
+
+        x->narrow({{2, 0, axis_pair_dim}})->copy_from(row->narrow({{2, 0, axis_pair_dim}}));
+        x->narrow({{2, axis_head_dim, axis_pair_dim}})->copy_from(row->narrow({{2, axis_pair_dim, axis_pair_dim}}));
+        x->narrow({{2, axis_pair_dim, axis_pair_dim}})->copy_from(col->narrow({{2, 0, axis_pair_dim}}));
+        x->narrow({{2, axis_head_dim + axis_pair_dim, axis_pair_dim}})->copy_from(col->narrow({{2, axis_pair_dim, axis_pair_dim}}));
+    };
+    apply_2d_rope(q);
+    apply_2d_rope(k);
+
+    auto out = infinicore::op::mha(q->unsqueeze(0), k->unsqueeze(0), v, std::nullopt, scale_, false)->view({seq_len, hidden_size_});
+    return proj_->forward(out);
 }
 
 Qwen35VisionMLP::Qwen35VisionMLP(const nlohmann::json &config,
                                  const infinicore::DataType &dtype,
-                                 const infinicore::Device &device) {
+                                 const infinicore::Device &device)
+    : activation_(config.value("hidden_act", "gelu_pytorch_tanh")) {
     const size_t hidden_size = config.value("hidden_size", 1152);
     const size_t intermediate_size = config.value("intermediate_size", 4304);
     INFINICORE_NN_MODULE_INIT(linear_fc1, hidden_size, intermediate_size, true, dtype, device);
@@ -75,7 +151,14 @@ Qwen35VisionMLP::Qwen35VisionMLP(const nlohmann::json &config,
 }
 
 infinicore::Tensor Qwen35VisionMLP::forward(const infinicore::Tensor &hidden_states) const {
-    throw std::runtime_error("Qwen35VisionMLP::forward is not implemented yet");
+    auto hidden_mut = hidden_states;
+    auto x = linear_fc1_->forward(hidden_mut);
+    if (activation_ == "gelu" || activation_ == "gelu_pytorch_tanh") {
+        x = activation_ == "gelu" ? infinicore::op::gelu(x) : infinicore::op::gelu_tanh(x);
+    } else {
+        throw std::runtime_error("Qwen35VisionMLP: unsupported activation " + activation_);
+    }
+    return linear_fc2_->forward(x);
 }
 
 Qwen35VisionBlock::Qwen35VisionBlock(const nlohmann::json &config,
@@ -89,36 +172,50 @@ Qwen35VisionBlock::Qwen35VisionBlock(const nlohmann::json &config,
     INFINICORE_NN_MODULE_INIT(mlp, config, dtype, device);
 }
 
-infinicore::Tensor Qwen35VisionBlock::forward(const infinicore::Tensor &hidden_states) const {
-    throw std::runtime_error("Qwen35VisionBlock::forward is not implemented yet");
+infinicore::Tensor Qwen35VisionBlock::forward(const infinicore::Tensor &hidden_states,
+                                              const infinicore::Tensor &row_position_ids,
+                                              const infinicore::Tensor &col_position_ids) const {
+    auto x = norm1_->forward(hidden_states);
+    x = attn_->forward(x, row_position_ids, col_position_ids);
+    x = infinicore::op::add(x, hidden_states);
+    auto residual = x;
+    x = norm2_->forward(x);
+    x = mlp_->forward(x);
+    return infinicore::op::add(x, residual);
 }
 
 Qwen35VisionPatchMerger::Qwen35VisionPatchMerger(const nlohmann::json &config,
                                                  const infinicore::DataType &dtype,
-                                                 const infinicore::Device &device) {
-    const size_t hidden_size = config.value("hidden_size", 1152);
-    const size_t out_hidden_size = config.value("out_hidden_size", hidden_size);
-    const size_t spatial_merge_size = config.value("spatial_merge_size", 2);
-    const size_t merged_size = hidden_size * spatial_merge_size * spatial_merge_size;
+                                                 const infinicore::Device &device)
+    : hidden_size_(config.value("hidden_size", 1152)),
+      merged_size_(hidden_size_ * config.value("spatial_merge_size", 2) * config.value("spatial_merge_size", 2)) {
+    const size_t out_hidden_size = config.value("out_hidden_size", hidden_size_);
     const double norm_eps = config.value("layer_norm_eps", config.value("rms_norm_eps", 1e-6));
-    INFINICORE_NN_MODULE_INIT(norm, hidden_size, norm_eps, dtype, device);
-    INFINICORE_NN_MODULE_INIT(linear_fc1, merged_size, merged_size, true, dtype, device);
-    INFINICORE_NN_MODULE_INIT(linear_fc2, merged_size, out_hidden_size, true, dtype, device);
+    INFINICORE_NN_MODULE_INIT(norm, hidden_size_, norm_eps, dtype, device);
+    INFINICORE_NN_MODULE_INIT(linear_fc1, merged_size_, merged_size_, true, dtype, device);
+    INFINICORE_NN_MODULE_INIT(linear_fc2, merged_size_, out_hidden_size, true, dtype, device);
 }
 
 infinicore::Tensor Qwen35VisionPatchMerger::forward(const infinicore::Tensor &hidden_states) const {
-    throw std::runtime_error("Qwen35VisionPatchMerger::forward is not implemented yet");
+    auto x = norm_->forward(hidden_states)->view({hidden_states->size(0) / (merged_size_ / hidden_size_), merged_size_});
+    x = linear_fc1_->forward(x);
+    x = infinicore::op::gelu(x);
+    return linear_fc2_->forward(x);
 }
 
 Qwen35VisionModel::Qwen35VisionModel(const nlohmann::json &config,
                                      const infinicore::DataType &dtype,
-                                     const infinicore::Device &device) {
-    const size_t hidden_size = config.value("hidden_size", 1152);
+                                     const infinicore::Device &device)
+    : hidden_size_(config.value("hidden_size", 1152)),
+      num_heads_(config.value("num_heads", 16)),
+      head_dim_(hidden_size_ / num_heads_),
+      spatial_merge_size_(config.value("spatial_merge_size", 2)),
+      num_grid_per_side_(static_cast<size_t>(std::sqrt(static_cast<double>(config.value("num_position_embeddings", 2304))))) {
     const size_t num_position_embeddings = config.value("num_position_embeddings", 2304);
     const size_t depth = config.value("depth", config.value("num_hidden_layers", 27));
 
     INFINICORE_NN_MODULE_INIT(patch_embed, config, dtype, device);
-    INFINICORE_NN_MODULE_INIT(pos_embed, num_position_embeddings, hidden_size, std::nullopt, dtype, device);
+    INFINICORE_NN_MODULE_INIT(pos_embed, num_position_embeddings, hidden_size_, std::nullopt, dtype, device);
     blocks_.reserve(depth);
     for (size_t i = 0; i < depth; ++i) {
         blocks_.push_back(this->register_module<Qwen35VisionBlock>("blocks." + std::to_string(i), config, dtype, device));
@@ -126,8 +223,101 @@ Qwen35VisionModel::Qwen35VisionModel(const nlohmann::json &config,
     INFINICORE_NN_MODULE_INIT(merger, config, dtype, device);
 }
 
-infinicore::Tensor Qwen35VisionModel::forward(const infinicore::Tensor &pixel_values) const {
-    throw std::runtime_error("Qwen35VisionModel::forward is not implemented yet");
+infinicore::Tensor Qwen35VisionModel::fast_pos_embed_interpolate(const infinicore::Tensor &image_grid_thw) const {
+    auto grid = tensor_to_i64_vector(image_grid_thw);
+    if (grid.size() != 3) {
+        throw std::runtime_error("Qwen35VisionModel: image_grid_thw must have shape [3]");
+    }
+    const size_t grid_t = static_cast<size_t>(grid[0]);
+    const size_t grid_h = static_cast<size_t>(grid[1]);
+    const size_t grid_w = static_cast<size_t>(grid[2]);
+    if (grid_h % spatial_merge_size_ != 0 || grid_w % spatial_merge_size_ != 0) {
+        throw std::runtime_error("Qwen35VisionModel: grid_h and grid_w must be divisible by spatial_merge_size");
+    }
+
+    auto pos_nchw = pos_embed_->weight()
+                        ->view({num_grid_per_side_, num_grid_per_side_, hidden_size_})
+                        ->permute({2, 0, 1})
+                        ->unsqueeze(0);
+    auto resized = infinicore::op::upsample_bilinear(
+        pos_nchw,
+        {static_cast<int64_t>(grid_h), static_cast<int64_t>(grid_w)},
+        true);
+    auto one_frame = resized->squeeze(0)
+                         ->permute({1, 2, 0})
+                         ->view({1, grid_h / spatial_merge_size_, spatial_merge_size_, grid_w / spatial_merge_size_, spatial_merge_size_, hidden_size_})
+                         ->permute({0, 1, 3, 2, 4, 5})
+                         ->contiguous()
+                         ->view({grid_h * grid_w, hidden_size_});
+    if (grid_t == 1) {
+        return one_frame;
+    }
+
+    auto pos_embeds = infinicore::Tensor::empty({grid_t * grid_h * grid_w, hidden_size_}, one_frame->dtype(), one_frame->device());
+    for (size_t t = 0; t < grid_t; ++t) {
+        pos_embeds->narrow({{0, t * grid_h * grid_w, grid_h * grid_w}})->copy_from(one_frame);
+    }
+    return pos_embeds;
+}
+
+infinicore::Tensor Qwen35VisionModel::build_rotary_position_ids(const infinicore::Tensor &image_grid_thw) const {
+    auto grid = tensor_to_i64_vector(image_grid_thw);
+    if (grid.size() % 3 != 0) {
+        throw std::runtime_error("Qwen35VisionModel: image_grid_thw must have shape [3] or [num_images, 3]");
+    }
+
+    size_t total_tokens = 0;
+    for (size_t i = 0; i < grid.size(); i += 3) {
+        total_tokens += static_cast<size_t>(grid[i]) * static_cast<size_t>(grid[i + 1]) * static_cast<size_t>(grid[i + 2]);
+    }
+
+    auto position_ids_cpu = infinicore::Tensor::empty({2, total_tokens}, infinicore::DataType::I64, infinicore::Device::cpu());
+    auto *position_ids = reinterpret_cast<int64_t *>(position_ids_cpu->data());
+
+    size_t out_token = 0;
+    for (size_t i = 0; i < grid.size(); i += 3) {
+        const size_t grid_t = static_cast<size_t>(grid[i]);
+        const size_t grid_h = static_cast<size_t>(grid[i + 1]);
+        const size_t grid_w = static_cast<size_t>(grid[i + 2]);
+        if (grid_h % spatial_merge_size_ != 0 || grid_w % spatial_merge_size_ != 0) {
+            throw std::runtime_error("Qwen35VisionModel: grid_h and grid_w must be divisible by spatial_merge_size");
+        }
+        const size_t merged_h = grid_h / spatial_merge_size_;
+        const size_t merged_w = grid_w / spatial_merge_size_;
+        for (size_t t = 0; t < grid_t; ++t) {
+            (void)t;
+            for (size_t bh = 0; bh < merged_h; ++bh) {
+                for (size_t bw = 0; bw < merged_w; ++bw) {
+                    for (size_t ih = 0; ih < spatial_merge_size_; ++ih) {
+                        const size_t row = bh * spatial_merge_size_ + ih;
+                        for (size_t iw = 0; iw < spatial_merge_size_; ++iw) {
+                            const size_t col = bw * spatial_merge_size_ + iw;
+                            position_ids[out_token] = static_cast<int64_t>(row);
+                            position_ids[total_tokens + out_token] = static_cast<int64_t>(col);
+                            ++out_token;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return position_ids_cpu->to(image_grid_thw->device());
+}
+
+infinicore::Tensor Qwen35VisionModel::forward(const infinicore::Tensor &pixel_values,
+                                              const infinicore::Tensor &image_grid_thw) const {
+    auto hidden_states = patch_embed_->forward(pixel_values);
+    auto pos_embeds = fast_pos_embed_interpolate(image_grid_thw);
+    hidden_states = infinicore::op::add(hidden_states, pos_embeds);
+
+    auto position_ids = build_rotary_position_ids(image_grid_thw);
+    auto row_position_ids = position_ids->narrow({{0, 0, 1}})->view({position_ids->size(1)});
+    auto col_position_ids = position_ids->narrow({{0, 1, 1}})->view({position_ids->size(1)});
+
+    for (const auto &block : blocks_) {
+        hidden_states = block->forward(hidden_states, row_position_ids, col_position_ids);
+    }
+    return merger_->forward(hidden_states);
 }
 
 } // namespace infinilm::models::qwen3_5

--- a/csrc/models/qwen3_5/qwen3_5_vision.hpp
+++ b/csrc/models/qwen3_5/qwen3_5_vision.hpp
@@ -6,8 +6,11 @@
 #include "infinicore/nn/embedding.hpp"
 #include "infinicore/nn/layer_norm.hpp"
 #include "infinicore/nn/module.hpp"
+#include "infinicore/nn/rope.hpp"
 #include "infinicore/tensor.hpp"
 #include <nlohmann/json.hpp>
+#include <string>
+#include <vector>
 
 namespace infinilm::models::qwen3_5 {
 
@@ -50,14 +53,19 @@ public:
                           const infinicore::DataType &dtype,
                           const infinicore::Device &device);
 
-    infinicore::Tensor forward(const infinicore::Tensor &hidden_states) const;
+    infinicore::Tensor forward(const infinicore::Tensor &hidden_states,
+                               const infinicore::Tensor &row_position_ids,
+                               const infinicore::Tensor &col_position_ids) const;
 
 private:
     size_t hidden_size_;
     size_t num_heads_;
+    size_t head_dim_;
+    float scale_;
 
     INFINICORE_NN_MODULE(infinilm::layers::linear::ReplicatedLinear, qkv);
     INFINICORE_NN_MODULE(infinilm::layers::linear::ReplicatedLinear, proj);
+    INFINICORE_NN_MODULE(infinicore::nn::RoPE, rotary_emb);
 };
 
 class Qwen35VisionMLP : public infinicore::nn::Module {
@@ -69,6 +77,7 @@ public:
     infinicore::Tensor forward(const infinicore::Tensor &hidden_states) const;
 
 private:
+    std::string activation_;
     INFINICORE_NN_MODULE(infinilm::layers::linear::ReplicatedLinear, linear_fc1);
     INFINICORE_NN_MODULE(infinilm::layers::linear::ReplicatedLinear, linear_fc2);
 };
@@ -79,7 +88,9 @@ public:
                       const infinicore::DataType &dtype,
                       const infinicore::Device &device);
 
-    infinicore::Tensor forward(const infinicore::Tensor &hidden_states) const;
+    infinicore::Tensor forward(const infinicore::Tensor &hidden_states,
+                               const infinicore::Tensor &row_position_ids,
+                               const infinicore::Tensor &col_position_ids) const;
 
 private:
     INFINICORE_NN_MODULE(infinicore::nn::LayerNorm, norm1);
@@ -97,6 +108,8 @@ public:
     infinicore::Tensor forward(const infinicore::Tensor &hidden_states) const;
 
 private:
+    size_t hidden_size_;
+    size_t merged_size_;
     INFINICORE_NN_MODULE(infinicore::nn::LayerNorm, norm);
     INFINICORE_NN_MODULE(infinilm::layers::linear::ReplicatedLinear, linear_fc1);
     INFINICORE_NN_MODULE(infinilm::layers::linear::ReplicatedLinear, linear_fc2);
@@ -108,9 +121,19 @@ public:
                       const infinicore::DataType &dtype,
                       const infinicore::Device &device);
 
-    infinicore::Tensor forward(const infinicore::Tensor &pixel_values) const;
+    infinicore::Tensor forward(const infinicore::Tensor &pixel_values,
+                               const infinicore::Tensor &image_grid_thw) const;
 
 private:
+    infinicore::Tensor fast_pos_embed_interpolate(const infinicore::Tensor &image_grid_thw) const;
+    infinicore::Tensor build_rotary_position_ids(const infinicore::Tensor &image_grid_thw) const;
+
+    size_t hidden_size_;
+    size_t num_heads_;
+    size_t head_dim_;
+    size_t spatial_merge_size_;
+    size_t num_grid_per_side_;
+
     INFINICORE_NN_MODULE(Qwen35VisionPatchEmbed, patch_embed);
     INFINICORE_NN_MODULE(infinicore::nn::Embedding, pos_embed);
     INFINICORE_NN_MODULE_VEC(Qwen35VisionBlock, blocks);

--- a/csrc/pybind11/engine/engine.hpp
+++ b/csrc/pybind11/engine/engine.hpp
@@ -145,6 +145,7 @@ inline void bind_infer_engine(py::module &m) {
                          std::optional<std::vector<infinicore::Tensor>> pixel_values,
                          std::optional<std::vector<infinicore::Tensor>> image_bound,
                          std::optional<std::vector<infinicore::Tensor>> tgt_sizes,
+                         std::optional<std::vector<infinicore::Tensor>> image_grid_thw,
                          std::optional<std::vector<size_t>> image_req_ids,
                          std::optional<std::vector<size_t>> visual_token_ranges,
                          py::kwargs kwargs) {
@@ -162,6 +163,7 @@ inline void bind_infer_engine(py::module &m) {
                     std::move(pixel_values),
                     std::move(image_bound),
                     std::move(tgt_sizes),
+                    std::move(image_grid_thw),
                     std::move(image_req_ids),
                     std::move(visual_token_ranges),
                 };
@@ -210,6 +212,7 @@ inline void bind_infer_engine(py::module &m) {
             py::arg("pixel_values") = std::nullopt,
             py::arg("image_bound") = std::nullopt,
             py::arg("tgt_sizes") = std::nullopt,
+            py::arg("image_grid_thw") = std::nullopt,
             py::arg("image_req_ids") = std::nullopt,
             py::arg("visual_token_ranges") = std::nullopt)
         .def_readwrite("input_ids", &InferEngine::Input::input_ids)
@@ -225,6 +228,7 @@ inline void bind_infer_engine(py::module &m) {
         .def_readwrite("pixel_values", &InferEngine::Input::pixel_values)
         .def_readwrite("image_bound", &InferEngine::Input::image_bound)
         .def_readwrite("tgt_sizes", &InferEngine::Input::tgt_sizes)
+        .def_readwrite("image_grid_thw", &InferEngine::Input::image_grid_thw)
         .def_readwrite("image_req_ids", &InferEngine::Input::image_req_ids)
         .def_readwrite("visual_token_ranges", &InferEngine::Input::visual_token_ranges)
         .def_readwrite("temperature", &InferEngine::Input::temperature)

--- a/python/infinilm/infer_engine.py
+++ b/python/infinilm/infer_engine.py
@@ -211,6 +211,7 @@ class InferEngine(_infinilm.InferEngine):
         pixel_values=None,
         image_bound=None,
         tgt_sizes=None,
+        image_grid_thw=None,
         image_req_ids=None,
         visual_token_ranges=None,
         temperature=None,
@@ -262,6 +263,7 @@ class InferEngine(_infinilm.InferEngine):
             pixel_values = convert_tensor_list(pixel_values)
             image_bound = convert_tensor_list(image_bound)
             tgt_sizes = convert_tensor_list(tgt_sizes)
+            image_grid_thw = convert_tensor_list(image_grid_thw)
 
             return infinicore.Tensor(
                 super()
@@ -280,6 +282,7 @@ class InferEngine(_infinilm.InferEngine):
                         pixel_values=pixel_values,
                         image_bound=image_bound,
                         tgt_sizes=tgt_sizes,
+                        image_grid_thw=image_grid_thw,
                         image_req_ids=image_req_ids,
                         visual_token_ranges=visual_token_ranges,
                         temperature=temperature,

--- a/python/infinilm/llm/request.py
+++ b/python/infinilm/llm/request.py
@@ -165,6 +165,9 @@ class InferenceRequest:
         # Mamba cache management. None means no mamba cache row is currently owned.
         self.mamba_cache_index: Optional[int] = None
 
+        # Qwen-style MRoPE decode offset. It is zero for pure text requests.
+        self.mrope_position_delta: int = 0
+
         # PD disaggregation support
         self.kv_transfer_params: Optional[dict] = (
             None  # KV transfer parameters from the router

--- a/python/infinilm/processors/qwen3_5_processor.py
+++ b/python/infinilm/processors/qwen3_5_processor.py
@@ -1,3 +1,6 @@
+import json
+import os
+
 from transformers import AutoProcessor, AutoTokenizer
 from typing_extensions import override
 
@@ -10,6 +13,26 @@ from .processor import register_processor
 @register_processor("qwen3_5")
 class Qwen35Processor(BasicLLMProcessor):
     def __init__(self, model_dir_path: str):
+        self.pixel_values_dtype = None
+        config_path = os.path.join(model_dir_path, "config.json")
+        if os.path.exists(config_path):
+            with open(config_path, "r") as f:
+                config_json = json.load(f)
+            dtype_name = (
+                config_json.get("torch_dtype")
+                or config_json.get("dtype")
+                or config_json.get("text_config", {}).get("torch_dtype")
+                or config_json.get("text_config", {}).get("dtype")
+            )
+            self.spatial_merge_size = int(
+                config_json.get("vision_config", {}).get("spatial_merge_size", 2)
+            )
+            if dtype_name is not None:
+                import torch
+
+                self.pixel_values_dtype = getattr(torch, str(dtype_name))
+        else:
+            self.spatial_merge_size = 2
         try:
             self.processor = AutoProcessor.from_pretrained(
                 model_dir_path, trust_remote_code=True
@@ -39,13 +62,67 @@ class Qwen35Processor(BasicLLMProcessor):
         if self.processor is None:
             raise RuntimeError("Qwen3.5 multimodal processor is not available")
 
-        return self.processor(
+        media_kwargs = {}
+        if images:
+            media_kwargs["images"] = images
+            images_kwargs = dict(kwargs.pop("images_kwargs", {}) or {})
+            image_size = dict(images_kwargs.get("size", {}) or {})
+            image_size.setdefault("shortest_edge", 3136)
+            image_size.setdefault("longest_edge", 2000000)
+            images_kwargs["size"] = image_size
+            kwargs["images_kwargs"] = images_kwargs
+        if videos:
+            media_kwargs["videos"] = videos
+
+        results = self.processor(
             text=prompt,
-            images=images,
-            videos=videos,
             return_tensors=return_tensors or "pt",
+            **media_kwargs,
             **kwargs,
         )
+        self._append_image_bound(results)
+        return results
+
+    def _get_image_token_id(self) -> int:
+        image_token_id = getattr(self.tokenizer, "image_token_id", None)
+        if image_token_id is None:
+            image_token_id = self.tokenizer.convert_tokens_to_ids("<|image_pad|>")
+        return int(image_token_id)
+
+    def _append_image_bound(self, processed_inputs: dict) -> None:
+        if (
+            "input_ids" not in processed_inputs
+            or "pixel_values" not in processed_inputs
+        ):
+            return
+
+        import torch
+
+        input_ids = processed_inputs["input_ids"]
+        if isinstance(input_ids, torch.Tensor):
+            token_ids = (
+                input_ids[0].tolist() if input_ids.ndim == 2 else input_ids.tolist()
+            )
+        else:
+            token_ids = (
+                input_ids[0]
+                if input_ids and isinstance(input_ids[0], list)
+                else input_ids
+            )
+
+        image_token_id = self._get_image_token_id()
+        bounds = []
+        i = 0
+        while i < len(token_ids):
+            if int(token_ids[i]) != image_token_id:
+                i += 1
+                continue
+            start = i
+            while i < len(token_ids) and int(token_ids[i]) == image_token_id:
+                i += 1
+            bounds.append([start, i])
+
+        processed_inputs["image_bound"] = torch.tensor(bounds, dtype=torch.int64)
 
     @override
     def apply_chat_template(
@@ -105,11 +182,13 @@ class Qwen35Processor(BasicLLMProcessor):
             model_inputs = self._build_model_input_from_static_scheduler_output(
                 scheduler_output, temperature, top_p, top_k
             )
+            self._append_qwen35_position_ids(model_inputs, scheduler_output)
         elif isinstance(scheduler_output, SchedulerOutput):
             model_inputs = self._build_model_input_from_batch_scheduler_output(
                 scheduler_output, temperature, top_p, top_k
             )
             self._append_qwen35_mm_inputs(model_inputs, scheduler_output)
+            self._append_qwen35_position_ids(model_inputs, scheduler_output)
         else:
             raise ValueError(
                 "scheduler_output must be an instance of SchedulerOutput or StaticSchedulerOutput"
@@ -138,6 +217,201 @@ class Qwen35Processor(BasicLLMProcessor):
         )
         return model_inputs
 
+    def _request_uses_mrope(self, req) -> bool:
+        if req.processed_inputs is None:
+            return False
+        if (
+            "image_grid_thw" in req.processed_inputs
+            and "image_bound" in req.processed_inputs
+        ):
+            return True
+        return "video_grid_thw" in req.processed_inputs
+
+    def _mrope_delta(self, req) -> int:
+        return int(getattr(req, "mrope_position_delta", 0))
+
+    def _as_grid_list(self, grid_thw):
+        import torch
+
+        if isinstance(grid_thw, list):
+            return [
+                g if isinstance(g, torch.Tensor) else torch.as_tensor(g)
+                for g in grid_thw
+            ]
+        grid_tensor = (
+            grid_thw
+            if isinstance(grid_thw, torch.Tensor)
+            else torch.as_tensor(grid_thw)
+        )
+        if grid_tensor.ndim == 1:
+            return [grid_tensor]
+        return [grid_tensor[i] for i in range(grid_tensor.shape[0])]
+
+    def _get_image_bounds(self, processed_inputs):
+        import torch
+
+        bounds = processed_inputs.get("image_bound")
+        if bounds is None:
+            return None
+        bounds = bounds if isinstance(bounds, torch.Tensor) else torch.as_tensor(bounds)
+        if bounds.ndim == 3 and bounds.shape[0] == 1:
+            bounds = bounds.squeeze(0)
+        if bounds.ndim != 2 or bounds.shape[-1] != 2:
+            raise RuntimeError("Qwen3.5 image_bound must have shape [num_images, 2]")
+        return bounds.to(dtype=torch.int64)
+
+    def _mrope_position_metadata(self, req):
+        if not self._request_uses_mrope(req):
+            return None
+        processed_inputs = req.processed_inputs
+        bounds = self._get_image_bounds(processed_inputs)
+        if bounds is None or bounds.numel() == 0:
+            return None
+        grids = self._as_grid_list(processed_inputs["image_grid_thw"])
+        if len(grids) != bounds.shape[0]:
+            raise RuntimeError("Qwen3.5 image grid count does not match image bounds")
+        return bounds, grids
+
+    def _compute_mrope_delta(self, req) -> int:
+        metadata = self._mrope_position_metadata(req)
+        if metadata is None:
+            return 0
+
+        bounds, grids = metadata
+        seq_len = len(req.get_input_tokens())
+        cursor = 0
+        current_pos = 0
+        max_pos = -1
+        for bound, grid in zip(bounds, grids):
+            start = int(bound[0].item())
+            end = int(bound[1].item())
+            if start < cursor or end < start or end > seq_len:
+                raise RuntimeError("Qwen3.5 image_bound is invalid")
+
+            text_len = start - cursor
+            if text_len > 0:
+                max_pos = max(max_pos, current_pos + text_len - 1)
+                current_pos += text_len
+
+            grid = grid.cpu().flatten()
+            grid_t = int(grid[0].item())
+            grid_h = int(grid[1].item())
+            grid_w = int(grid[2].item())
+            if (
+                grid_h % self.spatial_merge_size != 0
+                or grid_w % self.spatial_merge_size != 0
+            ):
+                raise RuntimeError(
+                    "Qwen3.5 image grid must be divisible by spatial_merge_size"
+                )
+            llm_grid_h = grid_h // self.spatial_merge_size
+            llm_grid_w = grid_w // self.spatial_merge_size
+            max_pos = max(
+                max_pos, current_pos + max(grid_t, llm_grid_h, llm_grid_w) - 1
+            )
+            current_pos += max(llm_grid_h, llm_grid_w)
+            cursor = end
+
+        if cursor < seq_len:
+            text_len = seq_len - cursor
+            max_pos = max(max_pos, current_pos + text_len - 1)
+
+        return max_pos + 1 - seq_len
+
+    def _build_mrope_position_ids(self, req, num_cached: int, compute_len: int):
+        import torch
+
+        metadata = self._mrope_position_metadata(req)
+        if metadata is None:
+            pos = torch.arange(num_cached, num_cached + compute_len, dtype=torch.int64)
+            return pos.view(1, -1).expand(3, -1)
+
+        bounds, grids = metadata
+        seq_len = len(req.get_input_tokens())
+        full_pos = torch.empty((3, seq_len), dtype=torch.int64)
+        cursor = 0
+        current_pos = 0
+        for bound, grid in zip(bounds, grids):
+            start = int(bound[0].item())
+            end = int(bound[1].item())
+            if start > cursor:
+                text_len = start - cursor
+                text_pos = torch.arange(
+                    current_pos, current_pos + text_len, dtype=torch.int64
+                )
+                full_pos[:, cursor:start] = text_pos.view(1, -1).expand(3, -1)
+                current_pos += text_len
+
+            grid = grid.cpu().flatten()
+            grid_t = int(grid[0].item())
+            grid_h = int(grid[1].item())
+            grid_w = int(grid[2].item())
+            llm_grid_h = grid_h // self.spatial_merge_size
+            llm_grid_w = grid_w // self.spatial_merge_size
+            spatial_tokens = llm_grid_h * llm_grid_w
+            temporal_pos = (
+                torch.arange(grid_t, dtype=torch.int64).repeat_interleave(
+                    spatial_tokens
+                )
+                + current_pos
+            )
+            height_pos = (
+                torch.arange(llm_grid_h, dtype=torch.int64)
+                .view(1, llm_grid_h, 1)
+                .expand(grid_t, llm_grid_h, llm_grid_w)
+                .reshape(-1)
+                + current_pos
+            )
+            width_pos = (
+                torch.arange(llm_grid_w, dtype=torch.int64)
+                .view(1, 1, llm_grid_w)
+                .expand(grid_t, llm_grid_h, llm_grid_w)
+                .reshape(-1)
+                + current_pos
+            )
+            if temporal_pos.numel() != end - start:
+                raise RuntimeError("Qwen3.5 image token span does not match image grid")
+            full_pos[:, start:end] = torch.stack(
+                [temporal_pos, height_pos, width_pos], dim=0
+            )
+            current_pos += max(llm_grid_h, llm_grid_w)
+            cursor = end
+
+        if cursor < seq_len:
+            text_len = seq_len - cursor
+            text_pos = torch.arange(
+                current_pos, current_pos + text_len, dtype=torch.int64
+            )
+            full_pos[:, cursor:] = text_pos.view(1, -1).expand(3, -1)
+
+        return full_pos[:, num_cached : num_cached + compute_len]
+
+    def _update_request_mrope_delta(self, req) -> None:
+        req.mrope_position_delta = self._compute_mrope_delta(req)
+
+    def _append_qwen35_position_ids(self, model_inputs: dict, scheduler_output) -> None:
+        import infinicore
+        import torch
+
+        position_chunks = []
+        for req in scheduler_output.scheduled_requests:
+            if scheduler_output.is_prefill:
+                self._update_request_mrope_delta(req)
+                num_cached = req.num_local_cached_tokens
+                compute_len = len(req.get_input_tokens()) - num_cached
+                position_chunks.append(
+                    self._build_mrope_position_ids(req, num_cached, compute_len)
+                )
+            else:
+                current_position = req.get_total_length() - 1 + self._mrope_delta(req)
+                pos = torch.tensor([current_position], dtype=torch.int64)
+                position_chunks.append(pos.view(1, 1).expand(3, -1))
+
+        if position_chunks:
+            model_inputs["position_ids"] = infinicore.from_torch(
+                torch.cat(position_chunks, dim=1).contiguous()
+            )
+
     def _append_qwen35_mm_inputs(
         self, model_inputs: dict, scheduler_output: SchedulerOutput
     ) -> None:
@@ -145,7 +419,41 @@ class Qwen35Processor(BasicLLMProcessor):
         import torch
 
         pixel_values = []
+        image_grid_thw = []
+        image_bound = []
         image_req_ids = []
+
+        def as_grid_list(grid_thw):
+            if isinstance(grid_thw, list):
+                return [
+                    g if isinstance(g, torch.Tensor) else torch.as_tensor(g)
+                    for g in grid_thw
+                ]
+            grid_tensor = (
+                grid_thw
+                if isinstance(grid_thw, torch.Tensor)
+                else torch.as_tensor(grid_thw)
+            )
+            if grid_tensor.ndim == 1:
+                return [grid_tensor]
+            return [grid_tensor[i] for i in range(grid_tensor.shape[0])]
+
+        def split_pixel_values(pixel_value, grids):
+            if isinstance(pixel_value, list):
+                return [
+                    p if isinstance(p, torch.Tensor) else torch.as_tensor(p)
+                    for p in pixel_value
+                ]
+            pixel_tensor = (
+                pixel_value
+                if isinstance(pixel_value, torch.Tensor)
+                else torch.as_tensor(pixel_value)
+            )
+            if len(grids) == 1:
+                return [pixel_tensor]
+            counts = [int(g[0].item() * g[1].item() * g[2].item()) for g in grids]
+            return list(torch.split(pixel_tensor, counts, dim=0))
+
         for req_id, req in enumerate(scheduler_output.scheduled_requests):
             processed_inputs = req.processed_inputs
             if (
@@ -155,21 +463,74 @@ class Qwen35Processor(BasicLLMProcessor):
             ):
                 continue
 
-            pixel_value = processed_inputs["pixel_values"]
-            if isinstance(pixel_value, list):
-                pixel_values.extend(pixel_value)
-            else:
-                pixel_values.append(pixel_value)
-            image_req_ids.append(req_id)
+            grid_thw = processed_inputs.get("image_grid_thw")
+            bounds = processed_inputs.get("image_bound")
+            if grid_thw is None or bounds is None:
+                raise RuntimeError(
+                    "Qwen3.5 image input requires image_grid_thw and image_bound"
+                )
+
+            grids = as_grid_list(grid_thw)
+            pixels = split_pixel_values(processed_inputs["pixel_values"], grids)
+            bounds = (
+                bounds if isinstance(bounds, torch.Tensor) else torch.as_tensor(bounds)
+            )
+            if bounds.ndim == 3 and bounds.shape[0] == 1:
+                bounds = bounds.squeeze(0)
+            if bounds.ndim != 2 or bounds.shape[-1] != 2:
+                raise RuntimeError(
+                    "Qwen3.5 image_bound must have shape [num_images, 2]"
+                )
+            if len(pixels) != len(grids) or len(pixels) != bounds.shape[0]:
+                raise RuntimeError("Qwen3.5 image input count mismatch")
+
+            num_cached = req.num_local_cached_tokens
+            partial_cached = (bounds[:, 0] < num_cached) & (bounds[:, 1] > num_cached)
+            if partial_cached.any().item():
+                raise RuntimeError(
+                    "Qwen3.5 does not support partially cached image spans"
+                )
+
+            for image_idx, (pixel, grid) in enumerate(zip(pixels, grids)):
+                if bounds[image_idx, 1].item() <= num_cached:
+                    continue
+                pixel_values.append(pixel)
+                image_grid_thw.append(grid)
+                image_bound.append((bounds[image_idx] - num_cached).to(torch.int64))
+                image_req_ids.append(req_id)
 
         if pixel_values:
+            if len(pixel_values) != len(image_grid_thw) or len(pixel_values) != len(
+                image_bound
+            ):
+                raise RuntimeError("Qwen3.5 multimodal input count mismatch")
             pixel_values = [
                 infinicore.from_torch(
-                    t if isinstance(t, torch.Tensor) else torch.as_tensor(t)
+                    (t if isinstance(t, torch.Tensor) else torch.as_tensor(t)).to(
+                        self.pixel_values_dtype
+                    )
+                    if self.pixel_values_dtype is not None
+                    else (t if isinstance(t, torch.Tensor) else torch.as_tensor(t))
                 )
                 for t in pixel_values
             ]
+            image_grid_thw = [
+                infinicore.from_torch(
+                    t if isinstance(t, torch.Tensor) else torch.as_tensor(t)
+                )
+                for t in image_grid_thw
+            ]
+            image_bound = [
+                infinicore.from_torch(
+                    t
+                    if isinstance(t, torch.Tensor)
+                    else torch.as_tensor(t, dtype=torch.int64)
+                )
+                for t in image_bound
+            ]
             model_inputs["pixel_values"] = pixel_values
+            model_inputs["image_grid_thw"] = image_grid_thw
+            model_inputs["image_bound"] = image_bound
             model_inputs["image_req_ids"] = image_req_ids
 
     @override
@@ -177,5 +538,35 @@ class Qwen35Processor(BasicLLMProcessor):
         self, prompt_token_ids, image_ids=None, video_ids=None, audio_ids=None, **kwargs
     ):
         mm_token_index_list = []
+        image_ids = image_ids or []
+        image_token_id = self._get_image_token_id()
 
+        image_idx = 0
+        i = 0
+        while i < len(prompt_token_ids):
+            if prompt_token_ids[i] != image_token_id:
+                i += 1
+                continue
+
+            start = i
+            while i < len(prompt_token_ids) and prompt_token_ids[i] == image_token_id:
+                i += 1
+
+            if image_idx >= len(image_ids):
+                raise RuntimeError(
+                    "The number of Qwen3.5 image token spans exceeds image inputs"
+                )
+            mm_token_index_list.append(
+                {
+                    "start_index": start,
+                    "end_index": i - 1,
+                    "identifier": image_ids[image_idx],
+                }
+            )
+            image_idx += 1
+
+        if image_idx != len(image_ids):
+            raise RuntimeError(
+                "The number of Qwen3.5 image token spans does not match image inputs"
+            )
         return mm_token_index_list


### PR DESCRIPTION
<!--
Thanks for contributing to InfiniLM! Please read `CONTRIBUTING.md` before
opening a pull request and fill out every section below. Delete any section
that is genuinely not applicable (and note why), but do not delete the
"Checklist" section — it must be filled in for every PR.

The PR title MUST follow Conventional Commits, e.g.
  feat: support Llama 3 models
  fix: correct linear attention calculations
See: https://www.conventionalcommits.org/
-->

## Summary

<!--
A concise description of **what** this PR changes. Prefer bullet points over
prose. Reference files with backtick-fenced paths (e.g. `csrc/models/llama/*`).
-->

- Implement vision model part of qwen3.5
- Support serving qwen3.6-27B with image inputs.

## Motivation

<!--
Explain **why** this change is needed. Link to any related issue, bug, or
discussion. If this is a performance change, include before/after numbers
(hardware, shape, dtype, and the measurement methodology).
-->

Closes #465 

## Type of Change

<!-- Tick one or more. -->

- [x] `feat` — new feature / new model
- [ ] `fix` — bug fix
- [ ] `perf` — performance improvement (no behavioral change)
- [ ] `refactor` — code restructuring without behavior change
- [ ] `test` — adding or fixing tests only
- [ ] `docs` — documentation only
- [ ] `build` / `ci` — build system or CI configuration
- [ ] `chore` — tooling, formatting, or other non-code changes
- [ ] Breaking change

## Test Results of Involved Models on Supported Platforms (Please attach screenshots)

<!--
For now, provide the screenshots for involved tests performed on platforms supposed to support the changes.

Tests that might be involved:
Single request test: examples/test_infer.py
Offline performance: examples/bench.py
Sanity test: test/bench/test_benchmark.py
Service: python/infinilm/server/inference_server.py + scripts/test_perf.py

Model adaptations may involve all four tests, unless specifying partial support for vastly new structures and confirmed with admin.

Python-level changes may involve less tests depending on which files/features are modified. 

Framework-level and Python-level changes may affect different models. Test a few models that might be affected.
-->

<img width="2074" height="636" alt="image" src="https://github.com/user-attachments/assets/742112d1-87be-4eb3-aa9c-0b512ecfbd34" />

<img width="2060" height="1012" alt="image" src="https://github.com/user-attachments/assets/80006689-f25d-4ede-bb66-d2dbf9155669" />
## Benchmark / Performance Impact

<!--
Required for `perf` PRs; optional otherwise. Describe the benchmark harness,
shapes, dtypes, hardware, and include baseline vs. new numbers. If the PR is
not performance-sensitive, write "N/A".
-->

## Notes for Reviewers

<!--
Anything reviewers should focus on: subtle invariants, known trade-offs,
follow-up work intentionally left out of scope, etc.
-->

## CI / ChatOps

<!--
CI does not run automatically on pull requests. Trigger it manually from the
Actions tab (workflow: **CI**, branch: this PR's head branch), or ask a
maintainer to comment `/retest` or `/test` on this PR.
-->

---

## Checklist

> Every contributor **must** verify every item below before requesting
> review. Tick each box only after the check has actually been performed —
> do not tick speculatively. If an item truly does not apply, replace the
> checkbox with `N/A` and briefly explain why in an inline comment.

### Title, Branch, and Commits

- [ ] PR **title** follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(nvidia): …`, `fix(cuda/gemm): …`).
- [ ] Branch name follows `<type>/xxx-yyyy-zzzz` where `<type>` matches the PR title's Conventional Commits type and words are joined with hyphens (see `CONTRIBUTING.md` §Branches).
- [ ] Each **commit** message follows Conventional Commits.
- [ ] Small PR is a **single squashable commit**; or, for a large PR, every commit is meaningful, well-formed, and independently reviewable (see `CONTRIBUTING.md` §Pull Requests).
- [ ] No stray merge commits from `main` — the branch is rebased cleanly on top of the current `main`.
- [ ] No `fixup!` / `squash!` / `wip` commits remain.
- [ ] Existing PR/branch/commit that followed the legacy issue format.

### Scope and Design

- [ ] Changes are **minimal** — nothing unrelated to the stated motivation was added (`CONTRIBUTING.md` §Code/General).
- [ ] No dead code, commented-out blocks, debug prints, `printf`/`std::cout`/`print(...)` left behind, or `TODO` without an owner and issue link.
- [ ] No unrelated formatting churn that would obscure the diff.
- [ ] Public API changes (if any) are intentional, documented, and reflected in affected callers/tests.

### General Code Hygiene (applies to all languages)

- [ ] The code is self-explanatory; comments were added **only** where the *why* is non-obvious (`CONTRIBUTING.md` §Code/General).
- [ ] Every modified or added file **ends with a single trailing newline** (`CONTRIBUTING.md` §Code/General).
- [ ] No trailing whitespace, tab/space mixing, or stray BOMs.
- [ ] Identifiers in comments and error messages are wrapped in backticks (e.g. ``the `seqlens_k` tensor``) (`CONTRIBUTING.md` §Code/General).
- [ ] All comments and error messages are in **English** (`CONTRIBUTING.md` §Code/General).
- [ ] Comments and error messages are complete sentences — capitalized first letter, terminal punctuation — **unless** the language/framework convention says otherwise (`CONTRIBUTING.md` §Code/General; §Python).

### C++ Specific (if C++ files changed)

- [ ] Code follows the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) strictly.
- [ ] Error and warning message wording follows the [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html#error-and-warning-messages) (`CONTRIBUTING.md` §C++).
- [ ] Constructor **initializer list order matches member declaration order** (`CONTRIBUTING.md` §C++).
- [ ] No raw `new`/`delete`; RAII / smart pointers / existing allocators are used.
- [ ] Changed files are formatted by `scripts/format.py`.
- [ ] No changes/reference to `csrc/models/llama_legacy/`.

### Python Specific (if Python files changed)

- [ ] Code is [PEP 8](https://peps.python.org/pep-0008/) compliant.
- [ ] Comments are complete English sentences, starting with a capital letter and ending with punctuation; Markdown backticks are used for code references (`CONTRIBUTING.md` §Python).
- [ ] Docstrings (if any) follow [PEP 257](https://peps.python.org/pep-0257/) (`CONTRIBUTING.md` §Python).
- [ ] Changed files are formatted by `scripts/format.py`.
- [ ] No changes/reference to `python/infinilm/auto_config.py`.

### Testing

- [ ] For any platform that could not be tested, an explicit reason is given in the table and a reviewer with access has been tagged.
- [ ] Passed single request test (`examples/test_infer.py`), or specify the reason for skipping.
- [ ] Passed offline performance test (`examples/bench.py`), or specify the reason for skipping.
- [ ] Passed sanity test (`test/bench/test_benchmark.py`), or specify the reason for skipping.
- [ ] Passed service test (`python/infinilm/server/inference_server.py` + `scripts/test_perf.py`), or specify the reason for skipping.

### Build, CI, and Tooling

- [ ] The project builds cleanly from a fresh directory on at least one affected platform.
- [ ] CI has been triggered manually (Actions → **CI** on this branch), or `/retest` was requested.

### Documentation

- [ ] `README.md`, `CONTRIBUTING.md`, or inline docs updated when behavior, build flags, or developer workflow changed.
- [ ] Any user-visible breaking change is called out explicitly under "Motivation" **and** in the commit/PR title with a `!` or `BREAKING CHANGE:` footer.

### Security and Safety

- [ ] No secrets, access tokens, internal URLs, customer data, or personal hardware identifiers have been committed.
- [ ] Third-party code is license-compatible and attributed.
- [ ] No unsafe pointer arithmetic, uninitialized reads, or missing bounds checks were introduced.
