### PR TITLE
chore: formaat qwen 3.5 and processors

### DIFF
--- a/csrc/models/qwen3_5/qwen3_5_for_causal_lm.cpp
+++ b/csrc/models/qwen3_5/qwen3_5_for_causal_lm.cpp
@@ -1,8 +1,8 @@
 #include "qwen3_5_for_causal_lm.hpp"
 
-#include "../qwen3_next/qwen3_next_for_causal_lm.hpp"
 #include "../../global_state/global_state.hpp"
 #include "../models_registry.hpp"
+#include "../qwen3_next/qwen3_next_for_causal_lm.hpp"
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -10,7 +10,7 @@
 namespace infinilm::models::qwen3_5 {
 
 Qwen35ForCausalLM::Qwen35ForCausalLM(std::shared_ptr<infinilm::config::ModelConfig> model_config,
-                                           const infinicore::Device &device) {
+                                     const infinicore::Device &device) {
     model_config_ = model_config;
     size_t hidden_size = model_config->get<size_t>("hidden_size");
     size_t vocab_size = model_config->get<size_t>("vocab_size");
@@ -53,19 +53,13 @@ std::shared_ptr<infinilm::config::ModelConfig> create_qwen3_5_model_config(std::
             config_json["dtype"] = config_json["torch_dtype"];
         }
     }
-    if (!config_json.contains("rope_theta") &&
-        config_json.contains("rope_parameters") &&
-        config_json["rope_parameters"].is_object() &&
-        config_json["rope_parameters"].contains("rope_theta")) {
+    if (!config_json.contains("rope_theta") && config_json.contains("rope_parameters") && config_json["rope_parameters"].is_object() && config_json["rope_parameters"].contains("rope_theta")) {
         // TODO: This is only a temporary loader shim. Qwen3.6 uses mRoPE,
         // which needs proper support in InfiniCore instead of treating it as
         // plain RoPE through a top-level rope_theta.
         config_json["rope_theta"] = config_json["rope_parameters"]["rope_theta"];
     }
-    if (!config_json.contains("partial_rotary_factor") &&
-        config_json.contains("rope_parameters") &&
-        config_json["rope_parameters"].is_object() &&
-        config_json["rope_parameters"].contains("partial_rotary_factor")) {
+    if (!config_json.contains("partial_rotary_factor") && config_json.contains("rope_parameters") && config_json["rope_parameters"].is_object() && config_json["rope_parameters"].contains("partial_rotary_factor")) {
         config_json["partial_rotary_factor"] = config_json["rope_parameters"]["partial_rotary_factor"];
     }
     if (!config_json.contains("layer_types")) {

--- a/csrc/models/qwen3_5/qwen3_5_for_causal_lm.hpp
+++ b/csrc/models/qwen3_5/qwen3_5_for_causal_lm.hpp
@@ -6,11 +6,10 @@
 
 namespace infinilm::models::qwen3_5 {
 
-
 class Qwen35ForCausalLM : public InfinilmModel {
 public:
     Qwen35ForCausalLM(std::shared_ptr<infinilm::config::ModelConfig> model_config,
-                         const infinicore::Device &device);
+                      const infinicore::Device &device);
 
     Output forward(const Input &input) const override;
 

--- a/python/infinilm/llm/cache_manager.py
+++ b/python/infinilm/llm/cache_manager.py
@@ -3,9 +3,10 @@ KV Cache Manager - Paged Attention block-based cache allocation and management.
 """
 
 from collections import deque
-from typing import List, Dict, Set
-import xxhash
+from typing import Dict, List, Set
+
 import numpy as np
+import xxhash
 
 
 class Block:

--- a/python/infinilm/llm/scheduler.py
+++ b/python/infinilm/llm/scheduler.py
@@ -2,12 +2,14 @@
 Scheduler - Request scheduling and batch management with Paged Attention KV Cache.
 """
 
-import queue
-import janus
 import logging
+import queue
 from typing import List, Optional
-from infinilm.llm.request import RequestStatus, InferenceRequest
+
+import janus
+
 from infinilm.llm.cache_manager import BlockManager, MambaCacheManager
+from infinilm.llm.request import InferenceRequest, RequestStatus
 
 logger = logging.getLogger(__name__)
 

--- a/python/infinilm/processors/__init__.py
+++ b/python/infinilm/processors/__init__.py
@@ -2,8 +2,10 @@ import importlib
 import json
 import pkgutil
 from pathlib import Path
+
 from transformers import AutoConfig
-from .processor import get_processor_class, InfinilmProcessor
+
+from .processor import InfinilmProcessor, get_processor_class
 
 # ---------------------------------------------------------------------------
 # Auto-discovery mechanism

--- a/python/infinilm/processors/baichuan_processor.py
+++ b/python/infinilm/processors/baichuan_processor.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+
 from .basic_llm_processor import BasicLLMProcessor
 from .processor import register_processor
 
@@ -53,7 +54,7 @@ class BaichuanProcessor(BasicLLMProcessor):
         This confirms that "<reserved_106>" encodes to [195] and "<reserved_107>" encodes
         to [196], while the naive "<reserved_195>" would be split into garbage tokens.
         """
-        if getattr(self.tokenizer, 'chat_template', None):
+        if getattr(self.tokenizer, "chat_template", None):
             return
 
         # Step 1: Read role token IDs from generation_config.json
@@ -87,4 +88,3 @@ class BaichuanProcessor(BasicLLMProcessor):
             "{%- endfor -%}"
         )
         self.tokenizer.chat_template = baichuan_template
-

--- a/python/infinilm/processors/basic_llm_processor.py
+++ b/python/infinilm/processors/basic_llm_processor.py
@@ -1,8 +1,9 @@
-from .processor import InfinilmProcessor, register_processor
 from transformers import AutoTokenizer
-from ..llm.static_scheduler import StaticSchedulerOutput
-from ..llm.scheduler import SchedulerOutput
 from typing_extensions import override
+
+from ..llm.scheduler import SchedulerOutput
+from ..llm.static_scheduler import StaticSchedulerOutput
+from .processor import InfinilmProcessor, register_processor
 
 
 @register_processor("default")
@@ -24,8 +25,6 @@ class BasicLLMProcessor(InfinilmProcessor):
         if return_tensors is None:
             return self.tokenizer(prompt, add_special_tokens=False)
         elif return_tensors == "infini":
-            import infinicore
-
             result = {}
             for key, tensor in self.tokenizer(
                 prompt, return_tensors="pt", add_special_tokens=False

--- a/python/infinilm/processors/chatglm_processor.py
+++ b/python/infinilm/processors/chatglm_processor.py
@@ -2,6 +2,7 @@
 
 import re
 import types
+
 from .basic_llm_processor import BasicLLMProcessor
 from .processor import register_processor
 
@@ -15,31 +16,32 @@ class ChatGLMProcessor(BasicLLMProcessor):
     @staticmethod
     def _fix_tokenizer_decode(tokenizer):
         """Fix ChatGLM tokenizer: patch convert_tokens_to_string.
-        
+
         ChatGLM uses SentencePiece which encodes spaces as ▁ (U+2581).
         Its convert_tokens_to_string calls self.tokenizer.decode_tokens(tokens),
         which strips ▁ when decoding tokens incrementally, losing inter-word spaces.
-        
+
         Fix: replace convert_tokens_to_string to:
         1. Join tokens + replace ▁ → space (the only thing decode_tokens gets wrong)
         2. Handle byte fallback: consecutive <0xHH> sequences → UTF-8 chars
-        
-        This keeps decode()'s other logic (skip_special_tokens, 
+
+        This keeps decode()'s other logic (skip_special_tokens,
         clean_up_tokenization_spaces, etc.) intact.
-        
+
         ▁ (U+2581) and _ (U+005F) are different characters in SentencePiece,
         so this replacement will NOT affect real underscores.
         """
+
         def patched_convert_tokens_to_string(self_tok, tokens):
             # 1. Join tokens + replace ▁ (U+2581) with space
             text = "".join(tokens).replace("\u2581", " ")
-            
+
             # 2. Handle SentencePiece byte fallback: consecutive <0xHH> → UTF-8
             def byte_fallback_replace(match):
                 hex_strs = re.findall(r"<0x([0-9A-Fa-f]{2})>", match.group(0))
                 byte_values = bytes([int(h, 16) for h in hex_strs])
                 return byte_values.decode("utf-8", errors="replace")
-            
+
             text = re.sub(r"(<0x[0-9A-Fa-f]{2}>)+", byte_fallback_replace, text)
             return text
 

--- a/python/infinilm/processors/deepseek_processor.py
+++ b/python/infinilm/processors/deepseek_processor.py
@@ -1,9 +1,9 @@
-from .basic_llm_processor import BasicLLMProcessor
-from .processor import register_processor
-
 from typing import List, Optional, Union
 
 from transformers.models.llama import LlamaTokenizerFast
+
+from .basic_llm_processor import BasicLLMProcessor
+from .processor import register_processor
 
 
 class DeepseekTokenizerFast(LlamaTokenizerFast):

--- a/python/infinilm/processors/llama_processor.py
+++ b/python/infinilm/processors/llama_processor.py
@@ -1,6 +1,7 @@
+from tokenizers import decoders as _dec
+
 from .basic_llm_processor import BasicLLMProcessor
 from .processor import register_processor
-from tokenizers import decoders as _dec
 
 
 @register_processor("llama")

--- a/python/infinilm/processors/mamba_processor.py
+++ b/python/infinilm/processors/mamba_processor.py
@@ -17,13 +17,13 @@ class MambaProcessor(BasicLLMProcessor):
         normalized_conversation = []
         for message in conversation:
             if isinstance(message["content"], list):
-                assert (
-                    len(message["content"]) == 1
-                ), "Only one content item supported in list"
+                assert len(message["content"]) == 1, (
+                    "Only one content item supported in list"
+                )
                 content_item = message["content"][0]
-                assert (
-                    "type" in content_item and "text" in content_item
-                ), "Content dict must have 'type' and 'text' keys"
+                assert "type" in content_item and "text" in content_item, (
+                    "Content dict must have 'type' and 'text' keys"
+                )
                 normalized_conversation.append(
                     {"role": message["role"], "content": content_item["text"]}
                 )

--- a/python/infinilm/processors/minicpmv_processor.py
+++ b/python/infinilm/processors/minicpmv_processor.py
@@ -1,9 +1,7 @@
+from transformers import AutoConfig, AutoProcessor
 from typing_extensions import override
 
-from transformers import AutoConfig, AutoProcessor
-
-from .processor import InfinilmProcessor
-from .processor import register_processor
+from .processor import InfinilmProcessor, register_processor
 
 
 @register_processor("minicpmv")

--- a/python/infinilm/processors/qwen3_5_processor.py
+++ b/python/infinilm/processors/qwen3_5_processor.py
@@ -1,6 +1,5 @@
-from typing_extensions import override
-
 from transformers import AutoProcessor, AutoTokenizer
+from typing_extensions import override
 
 from ..llm.scheduler import SchedulerOutput
 from ..llm.static_scheduler import StaticSchedulerOutput

--- a/python/infinilm/processors/sentencepiece_processor.py
+++ b/python/infinilm/processors/sentencepiece_processor.py
@@ -1,5 +1,6 @@
 import re
 import types
+
 from .basic_llm_processor import BasicLLMProcessor
 from .processor import register_processor
 

--- a/python/infinilm/processors/videonsa_processor.py
+++ b/python/infinilm/processors/videonsa_processor.py
@@ -1,9 +1,8 @@
 import os
 
-from typing_extensions import override
-
 import torch
 from transformers import AutoConfig, AutoProcessor
+from typing_extensions import override
 
 from .processor import InfinilmProcessor, register_processor
 


### PR DESCRIPTION
<!--
Thanks for contributing to InfiniLM! Please read `CONTRIBUTING.md` before
opening a pull request and fill out every section below. Delete any section
that is genuinely not applicable (and note why), but do not delete the
"Checklist" section — it must be filled in for every PR.

The PR title MUST follow Conventional Commits, e.g.
  feat: support Llama 3 models
  fix: correct linear attention calculations
See: https://www.conventionalcommits.org/
-->

## Summary

<!--
A concise description of **what** this PR changes. Prefer bullet points over
prose. Reference files with backtick-fenced paths (e.g. `csrc/models/llama/*`).
-->

-
-

## Motivation

<!--
Explain **why** this change is needed. Link to any related issue, bug, or
discussion. If this is a performance change, include before/after numbers
(hardware, shape, dtype, and the measurement methodology).
-->

Closes #

## Type of Change

<!-- Tick one or more. -->

- [ ] `feat` — new feature / new model
- [ ] `fix` — bug fix
- [ ] `perf` — performance improvement (no behavioral change)
- [ ] `refactor` — code restructuring without behavior change
- [ ] `test` — adding or fixing tests only
- [ ] `docs` — documentation only
- [ ] `build` / `ci` — build system or CI configuration
- [ ] `chore` — tooling, formatting, or other non-code changes
- [ ] Breaking change

## Test Results of Involved Models on Supported Platforms (Please attach screenshots)

<!--
For now, provide the screenshots for involved tests performed on platforms supposed to support the changes.

Tests that might be involved:
Single request test: examples/test_infer.py
Offline performance: examples/bench.py
Sanity test: test/bench/test_benchmark.py
Service: python/infinilm/server/inference_server.py + scripts/test_perf.py

Model adaptations may involve all four tests, unless specifying partial support for vastly new structures and confirmed with admin.

Python-level changes may involve less tests depending on which files/features are modified. 

Framework-level and Python-level changes may affect different models. Test a few models that might be affected.
-->

## Benchmark / Performance Impact

<!--
Required for `perf` PRs; optional otherwise. Describe the benchmark harness,
shapes, dtypes, hardware, and include baseline vs. new numbers. If the PR is
not performance-sensitive, write "N/A".
-->

## Notes for Reviewers

<!--
Anything reviewers should focus on: subtle invariants, known trade-offs,
follow-up work intentionally left out of scope, etc.
-->

## CI / ChatOps

<!--
CI does not run automatically on pull requests. Trigger it manually from the
Actions tab (workflow: **CI**, branch: this PR's head branch), or ask a
maintainer to comment `/retest` or `/test` on this PR.
-->

---

## Checklist

> Every contributor **must** verify every item below before requesting
> review. Tick each box only after the check has actually been performed —
> do not tick speculatively. If an item truly does not apply, replace the
> checkbox with `N/A` and briefly explain why in an inline comment.

### Title, Branch, and Commits

- [ ] PR **title** follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(nvidia): …`, `fix(cuda/gemm): …`).
- [ ] Branch name follows `<type>/xxx-yyyy-zzzz` where `<type>` matches the PR title's Conventional Commits type and words are joined with hyphens (see `CONTRIBUTING.md` §Branches).
- [ ] Each **commit** message follows Conventional Commits.
- [ ] Small PR is a **single squashable commit**; or, for a large PR, every commit is meaningful, well-formed, and independently reviewable (see `CONTRIBUTING.md` §Pull Requests).
- [ ] No stray merge commits from `main` — the branch is rebased cleanly on top of the current `main`.
- [ ] No `fixup!` / `squash!` / `wip` commits remain.
- [ ] Existing PR/branch/commit that followed the legacy issue format.

### Scope and Design

- [ ] Changes are **minimal** — nothing unrelated to the stated motivation was added (`CONTRIBUTING.md` §Code/General).
- [ ] No dead code, commented-out blocks, debug prints, `printf`/`std::cout`/`print(...)` left behind, or `TODO` without an owner and issue link.
- [ ] No unrelated formatting churn that would obscure the diff.
- [ ] Public API changes (if any) are intentional, documented, and reflected in affected callers/tests.

### General Code Hygiene (applies to all languages)

- [ ] The code is self-explanatory; comments were added **only** where the *why* is non-obvious (`CONTRIBUTING.md` §Code/General).
- [ ] Every modified or added file **ends with a single trailing newline** (`CONTRIBUTING.md` §Code/General).
- [ ] No trailing whitespace, tab/space mixing, or stray BOMs.
- [ ] Identifiers in comments and error messages are wrapped in backticks (e.g. ``the `seqlens_k` tensor``) (`CONTRIBUTING.md` §Code/General).
- [ ] All comments and error messages are in **English** (`CONTRIBUTING.md` §Code/General).
- [ ] Comments and error messages are complete sentences — capitalized first letter, terminal punctuation — **unless** the language/framework convention says otherwise (`CONTRIBUTING.md` §Code/General; §Python).

### C++ Specific (if C++ files changed)

- [ ] Code follows the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) strictly.
- [ ] Error and warning message wording follows the [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html#error-and-warning-messages) (`CONTRIBUTING.md` §C++).
- [ ] Constructor **initializer list order matches member declaration order** (`CONTRIBUTING.md` §C++).
- [ ] No raw `new`/`delete`; RAII / smart pointers / existing allocators are used.
- [ ] Changed files are formatted by `scripts/format.py`.
- [ ] No changes/reference to `csrc/models/llama_legacy/`.

### Python Specific (if Python files changed)

- [ ] Code is [PEP 8](https://peps.python.org/pep-0008/) compliant.
- [ ] Comments are complete English sentences, starting with a capital letter and ending with punctuation; Markdown backticks are used for code references (`CONTRIBUTING.md` §Python).
- [ ] Docstrings (if any) follow [PEP 257](https://peps.python.org/pep-0257/) (`CONTRIBUTING.md` §Python).
- [ ] Changed files are formatted by `scripts/format.py`.
- [ ] No changes/reference to `python/infinilm/auto_config.py`.

### Testing

- [ ] For any platform that could not be tested, an explicit reason is given in the table and a reviewer with access has been tagged.
- [ ] Passed single request test (`examples/test_infer.py`), or specify the reason for skipping.
- [ ] Passed offline performance test (`examples/bench.py`), or specify the reason for skipping.
- [ ] Passed sanity test (`test/bench/test_benchmark.py`), or specify the reason for skipping.
- [ ] Passed service test (`python/infinilm/server/inference_server.py` + `scripts/test_perf.py`), or specify the reason for skipping.

### Build, CI, and Tooling

- [ ] The project builds cleanly from a fresh directory on at least one affected platform.
- [ ] CI has been triggered manually (Actions → **CI** on this branch), or `/retest` was requested.

### Documentation

- [ ] `README.md`, `CONTRIBUTING.md`, or inline docs updated when behavior, build flags, or developer workflow changed.
- [ ] Any user-visible breaking change is called out explicitly under "Motivation" **and** in the commit/PR title with a `!` or `BREAKING CHANGE:` footer.

### Security and Safety

- [ ] No secrets, access tokens, internal URLs, customer data, or personal hardware identifiers have been committed.
- [ ] Third-party code is license-compatible and attributed.
- [ ] No unsafe pointer arithmetic, uninitialized reads, or missing bounds checks were introduced.
