### PR TITLE
feat: Trim cached memory before DeepSeek V2 lm_head on large prefill

### DIFF
--- a/csrc/models/deepseek_v2/deepseek_v2_for_causal_lm.cpp
+++ b/csrc/models/deepseek_v2/deepseek_v2_for_causal_lm.cpp
@@ -2,6 +2,7 @@
 
 #include "../../global_state/global_state.hpp"
 #include "../models_registry.hpp"
+#include "infinicore/context/context.hpp"
 
 #include <stdexcept>
 #include <string>
@@ -49,6 +50,13 @@ DeepseekV2ForCausalLM::DeepseekV2ForCausalLM(std::shared_ptr<infinilm::config::M
 
 infinilm::InfinilmModel::Output DeepseekV2ForCausalLM::forward(const infinilm::InfinilmModel::Input &input) const {
     auto hidden_states = model_->forward(input);
+
+    const auto &hidden_shape = hidden_states->shape();
+    if (hidden_shape.size() >= 2 && hidden_shape[0] * hidden_shape[1] > 4096) {
+        // Release cached prefill temporaries so lm_head can allocate full logits for large batches.
+        infinicore::context::trimMemory();
+    }
+
     auto logits = lm_head_->forward(hidden_states);
     return {logits};
 }
@@ -77,10 +85,10 @@ std::shared_ptr<infinilm::config::ModelConfig> create_deepseek_v2_model_config(s
     auto &config_json = model_config->get_config_json();
     const size_t q_head_dim = config_json.at("qk_nope_head_dim").get<size_t>() + config_json.at("qk_rope_head_dim").get<size_t>();
     config_json["head_dim"] = q_head_dim;
-    
+
     const size_t qk_rope_head_dim = config_json.at("qk_rope_head_dim").get<size_t>();
     config_json["partial_rotary_factor"] = static_cast<double>(qk_rope_head_dim) / static_cast<double>(q_head_dim);
-    
+
     config_json["num_experts"] = config_json.value("n_routed_experts", 0);
     config_json["mlp_bias"] = false;
     if (!config_json.contains("attention_output_bias")) {


### PR DESCRIPTION


## Summary

大规模 DeepSeek V2 prefill 在 lm_head 计算完整 logits 之前，可能会在 InfiniCore allocator cache 中留下大量临时张量缓存。如果这些缓存块没有先归还给 runtime，后续 lm_head 的显存分配可能会失败。
因此，在大 hidden-state batch 进入 lm_head 前主动清理缓存显存。这个修改只限制在 DeepSeek V2 内部，避免修改全局 allocator 的 retry 行为。


## Motivation

<!--
Explain **why** this change is needed. Link to any related issue, bug, or
discussion. If this is a performance change, include before/after numbers
(hardware, shape, dtype, and the measurement methodology).
-->

Closes #

## Type of Change

<!-- Tick one or more. -->

- [x] `feat` — new feature / new model
- [ ] `fix` — bug fix
- [ ] `perf` — performance improvement (no behavioral change)
- [ ] `refactor` — code restructuring without behavior change
- [ ] `test` — adding or fixing tests only
- [ ] `docs` — documentation only
- [ ] `build` / `ci` — build system or CI configuration
- [ ] `chore` — tooling, formatting, or other non-code changes
- [ ] Breaking change

## Test Results of Involved Models on Supported Platforms (Please attach screenshots)

### Hygon
bs4 1024 1024
<img width="959" height="424" alt="hy_dsv2_4_1024_1024" src="https://github.com/user-attachments/assets/d5a7dbd7-6d7f-4107-aca3-b2649d6ee2e0" />

bs4 4096 4096
<img width="961" height="452" alt="hy_dsv2_4_4096_4096" src="https://github.com/user-attachments/assets/45cc250a-74a3-42bd-af8d-247d12255b9a" />

bs16 128 128
<img width="956" height="465" alt="hy_dsv2_16_128_128" src="https://github.com/user-attachments/assets/ef3b269c-0b5f-4036-9635-4dadddc5ff54" />

bs16 1024 1024

<img width="956" height="274" alt="hy_dsv2_16_1024_1024" src="https://github.com/user-attachments/assets/d7eaa69a-d2e1-4f28-a33e-8ba7e1f9126b" />

bs16 4096 4096
<img width="959" height="417" alt="hy_dsv2_16_4096_4096" src="https://github.com/user-attachments/assets/99d77b95-4d32-4c3d-a830-ba654703fb1e" />


Model adaptations may involve all four tests, unless specifying partial support for vastly new structures and confirmed with admin.

Python-level changes may involve less tests depending on which files/features are modified. 

Framework-level and Python-level changes may affect different models. Test a few models that might be affected.
-->

## Benchmark / Performance Impact

<!--
Required for `perf` PRs; optional otherwise. Describe the benchmark harness,
shapes, dtypes, hardware, and include baseline vs. new numbers. If the PR is
not performance-sensitive, write "N/A".
-->

## Notes for Reviewers

<!--
Anything reviewers should focus on: subtle invariants, known trade-offs,
follow-up work intentionally left out of scope, etc.
-->

## CI / ChatOps

<!--
CI does not run automatically on pull requests. Trigger it manually from the
Actions tab (workflow: **CI**, branch: this PR's head branch), or ask a
maintainer to comment `/retest` or `/test` on this PR.
-->

---

## Checklist

> Every contributor **must** verify every item below before requesting
> review. Tick each box only after the check has actually been performed —
> do not tick speculatively. If an item truly does not apply, replace the
> checkbox with `N/A` and briefly explain why in an inline comment.

### Title, Branch, and Commits

- [ ] PR **title** follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(nvidia): …`, `fix(cuda/gemm): …`).
- [ ] Branch name follows `<type>/xxx-yyyy-zzzz` where `<type>` matches the PR title's Conventional Commits type and words are joined with hyphens (see `CONTRIBUTING.md` §Branches).
- [ ] Each **commit** message follows Conventional Commits.
- [ ] Small PR is a **single squashable commit**; or, for a large PR, every commit is meaningful, well-formed, and independently reviewable (see `CONTRIBUTING.md` §Pull Requests).
- [ ] No stray merge commits from `main` — the branch is rebased cleanly on top of the current `main`.
- [ ] No `fixup!` / `squash!` / `wip` commits remain.
- [ ] Existing PR/branch/commit that followed the legacy issue format.

### Scope and Design

- [ ] Changes are **minimal** — nothing unrelated to the stated motivation was added (`CONTRIBUTING.md` §Code/General).
- [ ] No dead code, commented-out blocks, debug prints, `printf`/`std::cout`/`print(...)` left behind, or `TODO` without an owner and issue link.
- [ ] No unrelated formatting churn that would obscure the diff.
- [ ] Public API changes (if any) are intentional, documented, and reflected in affected callers/tests.

### General Code Hygiene (applies to all languages)

- [ ] The code is self-explanatory; comments were added **only** where the *why* is non-obvious (`CONTRIBUTING.md` §Code/General).
- [ ] Every modified or added file **ends with a single trailing newline** (`CONTRIBUTING.md` §Code/General).
- [ ] No trailing whitespace, tab/space mixing, or stray BOMs.
- [ ] Identifiers in comments and error messages are wrapped in backticks (e.g. ``the `seqlens_k` tensor``) (`CONTRIBUTING.md` §Code/General).
- [ ] All comments and error messages are in **English** (`CONTRIBUTING.md` §Code/General).
- [ ] Comments and error messages are complete sentences — capitalized first letter, terminal punctuation — **unless** the language/framework convention says otherwise (`CONTRIBUTING.md` §Code/General; §Python).

### C++ Specific (if C++ files changed)

- [ ] Code follows the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) strictly.
- [ ] Error and warning message wording follows the [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html#error-and-warning-messages) (`CONTRIBUTING.md` §C++).
- [ ] Constructor **initializer list order matches member declaration order** (`CONTRIBUTING.md` §C++).
- [ ] No raw `new`/`delete`; RAII / smart pointers / existing allocators are used.
- [ ] Changed files are formatted by `scripts/format.py`.
- [ ] No changes/reference to `csrc/models/llama_legacy/`.

### Python Specific (if Python files changed)

- [ ] Code is [PEP 8](https://peps.python.org/pep-0008/) compliant.
- [ ] Comments are complete English sentences, starting with a capital letter and ending with punctuation; Markdown backticks are used for code references (`CONTRIBUTING.md` §Python).
- [ ] Docstrings (if any) follow [PEP 257](https://peps.python.org/pep-0257/) (`CONTRIBUTING.md` §Python).
- [ ] Changed files are formatted by `scripts/format.py`.
- [ ] No changes/reference to `python/infinilm/auto_config.py`.

### Testing

- [ ] For any platform that could not be tested, an explicit reason is given in the table and a reviewer with access has been tagged.
- [ ] Passed single request test (`examples/test_infer.py`), or specify the reason for skipping.
- [ ] Passed offline performance test (`examples/bench.py`), or specify the reason for skipping.
- [ ] Passed sanity test (`test/bench/test_benchmark.py`), or specify the reason for skipping.
- [ ] Passed service test (`python/infinilm/server/inference_server.py` + `scripts/test_perf.py`), or specify the reason for skipping.

### Build, CI, and Tooling

- [ ] The project builds cleanly from a fresh directory on at least one affected platform.
- [ ] CI has been triggered manually (Actions → **CI** on this branch), or `/retest` was requested.

### Documentation

- [ ] `README.md`, `CONTRIBUTING.md`, or inline docs updated when behavior, build flags, or developer workflow changed.
- [ ] Any user-visible breaking change is called out explicitly under "Motivation" **and** in the commit/PR title with a `!` or `BREAKING CHANGE:` footer.

### Security and Safety

- [ ] No secrets, access tokens, internal URLs, customer data, or personal hardware identifiers have been committed.
- [ ] Third-party code is license-compatible and attributed.
- [ ] No unsafe pointer arithmetic, uninitialized reads, or missing bounds checks were introduced.
