### PR TITLE
[2026春季][T2-1-3]xuzheng567

### DIFF
--- a/csrc/models/qwen3_moe/qwen3_moe_experts.cpp
+++ b/csrc/models/qwen3_moe/qwen3_moe_experts.cpp
@@ -1,21 +1,54 @@
 #include "qwen3_moe_experts.hpp"
 
+#include "../../config/model_config.hpp"
+#include "../../global_state/global_state.hpp"
 #include "infinicore/ops.hpp"
 
+#include <optional>
 #include <string>
 
 namespace infinilm::models::qwen3_moe {
 
 Qwen3MoeExperts::Qwen3MoeExperts(std::shared_ptr<infinilm::config::ModelConfig> model_config,
                                  const infinicore::Device &device) {
+    const auto &dtype = model_config->get_dtype();
+    const auto &rank_info = infinilm::global_state::get_tensor_model_parallel_rank_info();
+    const int tp_rank = rank_info.tp_rank;
+    const int tp_size = rank_info.tp_size;
 
     num_experts_ = model_config->get<size_t>("num_experts");
     num_experts_per_tok_ = model_config->get<size_t>("num_experts_per_tok");
+    hidden_size_ = model_config->get<size_t>("hidden_size");
+    const size_t intermediate_size = model_config->get<size_t>("moe_intermediate_size");
 
     ASSERT((num_experts_ > 0) && (num_experts_per_tok_ > 0) && (num_experts_per_tok_ <= num_experts_));
+    ASSERT(intermediate_size % static_cast<size_t>(tp_size) == 0);
+    intermediate_size_per_partition_ = intermediate_size / static_cast<size_t>(tp_size);
 
-    for (size_t i = 0; i < num_experts_; ++i) {
-        experts_.push_back(this->register_module<Qwen3MoeMLP>(std::to_string(i), model_config, device));
+    INFINICORE_NN_PARAMETER_INIT(w1, ({num_experts_, 2 * intermediate_size_per_partition_, hidden_size_}, dtype, device));
+    INFINICORE_NN_PARAMETER_INIT(w2, ({num_experts_, hidden_size_, intermediate_size_per_partition_}, dtype, device));
+
+    for (size_t expert = 0; expert < num_experts_; ++expert) {
+        auto gate_weight = w1_
+                               ->narrow({{0, expert, 1}, {1, 0, intermediate_size_per_partition_}})
+                               ->squeeze(0);
+        auto up_weight = w1_
+                             ->narrow({{0, expert, 1}, {1, intermediate_size_per_partition_, intermediate_size_per_partition_}})
+                             ->squeeze(0);
+        auto down_weight = w2_
+                               ->narrow({{0, expert, 1}})
+                               ->squeeze(0);
+
+        const std::string prefix = std::to_string(expert) + ".";
+        this->register_parameter(
+            prefix + "gate_proj.weight",
+            infinicore::nn::Parameter(gate_weight, 0, tp_rank, tp_size));
+        this->register_parameter(
+            prefix + "up_proj.weight",
+            infinicore::nn::Parameter(up_weight, 0, tp_rank, tp_size));
+        this->register_parameter(
+            prefix + "down_proj.weight",
+            infinicore::nn::Parameter(down_weight, 1, tp_rank, tp_size));
     }
 }
 
@@ -23,42 +56,10 @@ infinicore::Tensor Qwen3MoeExperts::forward(const infinicore::Tensor &hidden_sta
                                             const infinicore::Tensor &top_k_index,
                                             const infinicore::Tensor &top_k_weights) const {
     ASSERT(hidden_states->ndim() == 2);
+    ASSERT(top_k_index->ndim() == 2 && top_k_weights->ndim() == 2);
 
-    auto top_k_weights_cpu = top_k_weights->to(infinicore::Device::Type::CPU);
-    auto top_k_index_cpu = top_k_index->to(infinicore::Device::Type::CPU);
-
-    int *top_k_index_ptr = reinterpret_cast<int *>(top_k_index_cpu->data());
-    float *top_k_weights_ptr = reinterpret_cast<float *>(top_k_weights_cpu->data());
-
-    size_t ntoken = hidden_states->shape()[0];
-    int index;
-    float score;
-
-    auto final_hidden_states = infinicore::Tensor::empty(hidden_states->shape(), hidden_states->dtype(), hidden_states->device());
-    for (size_t itok = 0; itok < ntoken; ++itok) {
-        auto hidden_states_i = hidden_states->narrow({{0, itok, 1}});
-        const size_t route_row = itok * num_experts_per_tok_;
-
-        infinicore::Tensor final_hidden_states_i;
-        for (size_t k = 0; k < num_experts_per_tok_; ++k) {
-            index = top_k_index_ptr[route_row + k];
-            score = top_k_weights_ptr[route_row + k];
-
-            ASSERT(index >= 0 && static_cast<size_t>(index) < num_experts_);
-
-            experts_[index]->set_alpha(score);
-            auto expert_out = experts_[index]->forward(hidden_states_i);
-
-            if (k == 0) {
-                final_hidden_states_i = expert_out;
-            } else {
-                infinicore::op::add_(final_hidden_states_i, final_hidden_states_i, expert_out);
-            }
-        }
-
-        final_hidden_states->narrow({{0, itok, 1}})->copy_from(final_hidden_states_i);
-    }
-    return final_hidden_states;
+    return infinicore::op::fused_moe(hidden_states, top_k_index, top_k_weights, w1_, w2_, std::nullopt, std::nullopt,
+                                     infinicore::op::FusedMoeActivation::Swiglu);
 }
 
 } // namespace infinilm::models::qwen3_moe

--- a/csrc/models/qwen3_moe/qwen3_moe_experts.hpp
+++ b/csrc/models/qwen3_moe/qwen3_moe_experts.hpp
@@ -1,15 +1,17 @@
 #pragma once
 
-#include "../../layers/moe/legacy/moe_mlp.hpp"
 #include "infinicore/nn/module.hpp"
+#include "infinicore/nn/parameter.hpp"
 #include "infinicore/tensor.hpp"
 
 #include <cstddef>
 #include <memory>
 
-namespace infinilm::models::qwen3_moe {
+namespace infinilm::config {
+class ModelConfig;
+}
 
-using Qwen3MoeMLP = infinilm::layers::moe::legacy::MoeMLP;
+namespace infinilm::models::qwen3_moe {
 
 class Qwen3MoeExperts : public infinicore::nn::Module {
 public:
@@ -21,9 +23,13 @@ public:
                                const infinicore::Tensor &top_k_weights) const;
 
 protected:
-    INFINICORE_NN_MODULE_VEC(Qwen3MoeMLP, experts);
+    INFINICORE_NN_PARAMETER(w1);
+    INFINICORE_NN_PARAMETER(w2);
+
     size_t num_experts_per_tok_{0};
     size_t num_experts_{0};
+    size_t hidden_size_{0};
+    size_t intermediate_size_per_partition_{0};
 };
 
 } // namespace infinilm::models::qwen3_moe

--- a/python/infinilm/modeling_utils.py
+++ b/python/infinilm/modeling_utils.py
@@ -59,8 +59,11 @@ def _is_internal_moe_packed_weight(key: str) -> bool:
     # InfiniLM registers packed MoE parameters internally. HF checkpoints
     # provide per-expert gate/up/down weights instead, so these packed tensors
     # are expected missing keys during non-strict checkpoint loading.
-    return key.endswith(".mlp.experts.w13_weight") or key.endswith(
-        ".mlp.experts.w2_weight"
+    return (
+        key.endswith(".mlp.experts.w13_weight")
+        or key.endswith(".mlp.experts.w2_weight")
+        or key.endswith(".mlp.experts.w1")
+        or key.endswith(".mlp.experts.w2")
     )
 
 


### PR DESCRIPTION
# 基本信息

赛题：T2-1-3（qwen3 MOE模块优化）

队名：你说得都

成员：xz

github：

https://github.com/xuzheng567/InfiniCore

https://github.com/xuzheng567/InfiniLM

# 开发说明

- InfiniCore：https://github.com/xuzheng567/InfiniCore/tree/2026-spring-xuzheng567-T2-1-3 
(https://github.com/InfiniTensor/InfiniCore/pull/1388)

添加fused moe算子以及相应测试脚本，使用cutlass进行优化加速。参照项目已有算子对多个硬件平台进行了适配尝试。

- InfiniLM：https://github.com/xuzheng567/InfiniLM/tree/2026-spring-xuzheng567-T2-1-3

在已有的qwen3模型模块中，使用新的fused moe算子，替换掉了原本需要和cpu进行交互的moe计算方式。原本还重写了topk router部分，但后来发现框架对这一部分进行了更新迭代，改用框架内的最新写法。替换之后模型中计算逻辑中无cpu\-gpu交互，可使用框架内自带的cuda graph功能进一步提速。

# 结果

## 推理性能测试

使用框架已有的bench\.py，在输入输出长度均为1024的情况下测试

更改前：

```Plain Text
python examples/bench.py --device=nvidia --model=Qwen3-30B-A3B-Instruct-2507/ --batch-size 1 --input-len 1024 --output-len 1024 --enable-paged-attn --attn=flash-attn
```

```Plain Text
Generation completed in 71862.08 ms
Batchsize=1  Per_Batch_Input_Len=1024  Per_Batch_New_Tokens=1024

Prefill TTFT: 22704.45 ms  Throughput: 45.1 tok/s

Decode  Avg ITL: 48.05 ms   Throughput: 20.81 tok/s
```

更改后：

**可使用cuda graph**

```Plain Text
python examples/bench.py --device=nvidia --model=Qwen3-30B-A3B-Instruct-2507/ --batch-size 1 --input-len 1024 --output-len 1024 --enable-paged-attn --attn=flash-attn --enable-graph
```

```Plain Text
Generation completed in 11150.65 ms
Batchsize=1  Per_Batch_Input_Len=1024  Per_Batch_New_Tokens=1024

Prefill TTFT: 107.94 ms  Throughput: 9486.74 tok/s

Decode  Avg ITL: 10.79 ms   Throughput: 92.64 tok/s
```

**Prefill吞吐提升210倍，Decode吞吐提升4\.45倍**

# 多平台适配

参照框架内已有的跨平台算子的格式，将fused moe算子适配了复用cuda代码的硬件平台：

|平台|
|---|
|ILUVATAR|
|QY|
|HYGON|
|ALI|
|METAX|
|MOORE|

时间原因，大部分国产平台未来得及验证。

[HONOR_CODE.md](https://github.com/user-attachments/files/29938853/HONOR_CODE.md)
[REFERENCE.md](https://github.com/user-attachments/files/29938856/REFERENCE.md)
