### PR TITLE
[2026春季][T2-1-1] goog00

### DIFF
--- a/csrc/models/ernie4_5_moe_vl/ernie4_5_moe_vl_attention.cpp
+++ b/csrc/models/ernie4_5_moe_vl/ernie4_5_moe_vl_attention.cpp
@@ -1,0 +1,267 @@
+#include "ernie4_5_moe_vl_attention.hpp"
+#include "../../global_state/global_state.hpp"
+#include "../../layers/attention/attention.hpp"
+#include "../../utils.hpp"
+#include "infinicore/ops.hpp"
+
+#include <cmath>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+namespace infinilm::models::ernie4_5_moe_vl {
+
+Ernie4_5_VLMoeAttention::Ernie4_5_VLMoeAttention(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+                                                 size_t layer_idx,
+                                                 const infinicore::Device &device) {
+    layer_idx_ = layer_idx;
+    hidden_size_ = model_config->get<size_t>("hidden_size");
+    head_dim_ = model_config->get<size_t>("head_dim"); // supplied by create_ernie4_5_moe_vl_model_config
+
+    const auto &dtype{model_config->get_dtype()};
+    size_t total_num_heads = model_config->get<size_t>("num_attention_heads");
+    size_t total_num_kv_heads = model_config->get<size_t>("num_key_value_heads");
+    bool use_bias = model_config->get_or<bool>("use_bias", false);
+
+    attention_backend_ = infinilm::global_state::get_infinilm_config().attention_backend;
+    const engine::distributed::RankInfo &rank_info = infinilm::global_state::get_tensor_model_parallel_rank_info();
+    int tp_rank = infinilm::global_state::get_tensor_model_parallel_rank();
+    int tp_size = infinilm::global_state::get_tensor_model_parallel_world_size();
+    if ((total_num_kv_heads < static_cast<size_t>(tp_size)) || (0 != (total_num_kv_heads % tp_size))) {
+        throw std::runtime_error("Ernie4_5_VLMoeAttention: num_key_value_heads must be divisible by tp_size");
+    }
+
+    num_attention_heads_ = total_num_heads / tp_size;
+    num_key_value_heads_ = total_num_kv_heads / tp_size;
+
+    auto quantization_method = model_config->get_quantization_method();
+    auto register_fn = [this](const std::string &n, infinicore::nn::Parameter p) { this->register_parameter(n, std::move(p)); };
+    qkv_proj_ = std::make_shared<layers::linear::QKVParallelLinear>(
+        hidden_size_, head_dim_, total_num_heads, total_num_kv_heads,
+        "q_proj", "k_proj", "v_proj", register_fn,
+        quantization_method, use_bias, dtype, device, rank_info);
+    o_proj_ = this->register_module<layers::linear::RowParallelLinear>(
+        "o_proj", total_num_heads * head_dim_, hidden_size_, quantization_method,
+        use_bias, dtype, device, tp_rank, tp_size, rank_info.comm);
+
+    // Base 1D RoPE. ERNIE-4.5-VL uses GPT-J / interleaved rotary (HF
+    // RopeEmbedding.apply_rotary: sin_pos=[θ0,θ0,θ1,θ1,...], rotate_half pairs
+    // adjacent dims (q0,q1),(q2,q3),...), NOT the framework-default GPT-NEOX
+    // (half-split). Used directly for text positions and reused (algo+theta+
+    // head_dim) when building the 3D-mrope tables.
+    // GPT-J/interleaved algo is set on the model config by
+    // Ernie4_5_VLMoeForConditionalGeneration before the text model is built;
+    // get_rope() picks it up from there.
+    rotary_emb_ = infinilm::layers::rotary_embedding::get_rope(model_config, device);
+    rope_algo_ = rotary_emb_->algo();
+    rope_theta_ = model_config->get<double>("rope_theta");
+    // 3D mrope sections (time,height,width) from rope_scaling.mrope_section, e.g.
+    // [22,22,20] summing to head_dim/2 = 64. Empty -> plain 1D rope.
+    // VERIFY(GPU): confirm axis order and that mrope_section matches HF
+    // modeling_ernie4_5_vl (Qwen2-VL-style section->axis assignment is assumed).
+    {
+        const auto &cfg = model_config->get_config_json();
+        if (cfg.contains("rope_scaling") && cfg["rope_scaling"].is_object()
+            && cfg["rope_scaling"].contains("mrope_section")) {
+            for (const auto &v : cfg["rope_scaling"]["mrope_section"]) {
+                mrope_section_.push_back(v.get<size_t>());
+            }
+        }
+    }
+
+    float scaling = 1.0f / std::sqrt(static_cast<float>(head_dim_));
+    attn_ = std::make_shared<infinilm::layers::attention::AttentionLayer>(
+        num_attention_heads_, head_dim_, scaling, num_key_value_heads_, layer_idx_,
+        kv_cache_k_scale_, kv_cache_v_scale_, attention_backend_);
+
+    infinilm::layers::attention::init_kv_cache_quant_params(register_fn, device, kv_cache_k_scale_, kv_cache_v_scale_);
+}
+
+std::tuple<infinicore::Tensor, infinicore::Tensor, infinicore::Tensor>
+Ernie4_5_VLMoeAttention::build_mrope_(const infinicore::Tensor &position_ids,
+                                      const infinicore::DataType &dtype,
+                                      const infinicore::Device &device) const {
+    // position_ids: [3, seq] int64 = (time, height, width).
+    auto pos_cpu = position_ids->to(infinicore::Device::cpu())->contiguous();
+    size_t seq = pos_cpu->shape()[1];
+    const auto *pp = reinterpret_cast<const int64_t *>(pos_cpu->data());
+
+    size_t cache_dim = head_dim_ / 2;
+
+    // Per-frequency axis assignment, matching HF RopeEmbedding.apply_rotary_3d
+    // (NOT a sequential mrope_section split): with freq_allocation = mrope_section
+    // last entry (=20), the low frequencies [0, cache_dim-freq_allocation) alternate
+    // height(even)/width(odd), and the high frequencies [.., cache_dim) are time.
+    //   pos rows: 0 = time, 1 = height, 2 = width  (from processor get_rope_index).
+    // For text (all 3 rows equal) the assignment is irrelevant; it only matters for
+    // image/video where the axes differ.
+    size_t freq_allocation = mrope_section_.empty() ? 0 : mrope_section_.back();
+    size_t split = (freq_allocation <= cache_dim) ? (cache_dim - freq_allocation) : cache_dim;
+    std::vector<size_t> axis_of(cache_dim, 0);
+    for (size_t j = 0; j < cache_dim; ++j) {
+        if (j < split) {
+            axis_of[j] = (j % 2 == 0) ? 1 /*height*/ : 2 /*width*/;
+        } else {
+            axis_of[j] = 0 /*time*/;
+        }
+    }
+
+    // GPT-J style inverse frequency theta^(-2j/head_dim); the rope algo only
+    // controls dimension pairing in the kernel (kept == rotary_emb_'s algo).
+    std::vector<float> sin_f(seq * cache_dim);
+    std::vector<float> cos_f(seq * cache_dim);
+    for (size_t j = 0; j < cache_dim; ++j) {
+        float inv_freq = 1.0f / std::pow(static_cast<float>(rope_theta_),
+                                         2.0f * static_cast<float>(j) / static_cast<float>(head_dim_));
+        size_t ax = axis_of[j];
+        for (size_t i = 0; i < seq; ++i) {
+            float p = static_cast<float>(pp[ax * seq + i]);
+            float angle = p * inv_freq;
+            sin_f[i * cache_dim + j] = std::sin(angle);
+            cos_f[i * cache_dim + j] = std::cos(angle);
+        }
+    }
+
+    auto to_table = [&](const std::vector<float> &f) -> infinicore::Tensor {
+        auto out = infinicore::Tensor::empty({seq, cache_dim}, dtype, device);
+        if (dtype == infinicore::DataType::F32) {
+            auto cpu = infinicore::Tensor::from_blob(const_cast<float *>(f.data()), {seq, cache_dim},
+                                                     infinicore::DataType::F32, infinicore::Device::cpu());
+            out->copy_from(cpu);
+        } else if (dtype == infinicore::DataType::BF16) {
+            std::vector<uint16_t> h(f.size());
+            for (size_t i = 0; i < f.size(); ++i) {
+                h[i] = f32_to_bf16(f[i]);
+            }
+            auto cpu = infinicore::Tensor::from_blob(h.data(), {seq, cache_dim},
+                                                     infinicore::DataType::BF16, infinicore::Device::cpu());
+            out->copy_from(cpu);
+        } else if (dtype == infinicore::DataType::F16) {
+            std::vector<uint16_t> h(f.size());
+            for (size_t i = 0; i < f.size(); ++i) {
+                h[i] = f32_to_f16(f[i]);
+            }
+            auto cpu = infinicore::Tensor::from_blob(h.data(), {seq, cache_dim},
+                                                     infinicore::DataType::F16, infinicore::Device::cpu());
+            out->copy_from(cpu);
+        } else {
+            throw std::runtime_error("build_mrope_: unsupported dtype for rope tables");
+        }
+        return out;
+    };
+
+    auto sin_tbl = to_table(sin_f);
+    auto cos_tbl = to_table(cos_f);
+
+    // Position index = arange(seq): row i of the table holds token i's rotation.
+    std::vector<int64_t> idx(seq);
+    for (size_t i = 0; i < seq; ++i) {
+        idx[i] = static_cast<int64_t>(i);
+    }
+    auto idx_cpu = infinicore::Tensor::from_blob(idx.data(), {seq}, infinicore::DataType::I64,
+                                                 infinicore::Device::cpu());
+    auto pos_index = idx_cpu->to(device);
+
+    return std::make_tuple(sin_tbl, cos_tbl, pos_index);
+}
+
+infinicore::Tensor Ernie4_5_VLMoeAttention::forward(const infinicore::Tensor &positions,
+                                                    const infinicore::Tensor &hidden_states) const {
+    if (::infinilm::backends::AttentionBackend::STATIC_ATTN == attention_backend_) {
+        return forward_static_(positions, hidden_states);
+    }
+    return forward_paged_(positions, hidden_states);
+}
+
+infinicore::Tensor Ernie4_5_VLMoeAttention::forward_static_(const infinicore::Tensor &position_ids,
+                                                            const infinicore::Tensor &hidden_states) const {
+    auto hidden_states_mutable = hidden_states;
+    auto shape = hidden_states->shape();
+    size_t batch_size = shape[0];
+    size_t seq_len = shape[1];
+
+    auto [q, k, v] = qkv_proj_->forward_split(hidden_states_mutable);
+
+    auto q_reshaped = q->view({batch_size, seq_len, num_attention_heads_, head_dim_});
+    auto k_reshaped = k->view({batch_size, seq_len, num_key_value_heads_, head_dim_});
+    auto v_reshaped = v->view({batch_size, seq_len, num_key_value_heads_, head_dim_});
+
+    // RoPE. position_ids is [3, seq] for 3D mrope (time,height,width), or 1D /
+    // [1, seq] for text. q_rope is a fresh contiguous buffer in the
+    // [batch, heads, seq, dim] layout StaticAttentionImpl expects (applying RoPE
+    // in place on the non-contiguous narrowed q_reshaped would leave incompatible
+    // strides).
+    auto pos_shape = position_ids->shape();
+    bool use_mrope = (pos_shape.size() == 2) && (pos_shape[0] == 3) && !mrope_section_.empty();
+
+    auto q_rope = infinicore::Tensor::empty(
+        {batch_size, num_attention_heads_, seq_len, head_dim_},
+        q_reshaped->dtype(), q_reshaped->device())->permute({0, 2, 1, 3});
+
+    if (use_mrope) {
+        auto [sin_tbl, cos_tbl, pos_index] =
+            build_mrope_(position_ids, q_reshaped->dtype(), q_reshaped->device());
+        infinicore::op::rope_(q_rope, q_reshaped, pos_index, sin_tbl, cos_tbl, rope_algo_);
+        infinicore::op::rope_(k_reshaped, k_reshaped, pos_index, sin_tbl, cos_tbl, rope_algo_);
+    } else {
+        infinicore::Tensor pos_ids_for_rope = position_ids;
+        if (pos_shape.size() == 2) {
+            auto pos_narrowed = position_ids->narrow({{0, 0, 1}});
+            pos_ids_for_rope = pos_narrowed->contiguous()->view({pos_shape[1]});
+        } else if (pos_shape.size() == 1) {
+            pos_ids_for_rope = position_ids->contiguous();
+        }
+        rotary_emb_->forward(q_rope, q_reshaped, pos_ids_for_rope);
+        rotary_emb_->forward(k_reshaped, pos_ids_for_rope, true);
+    }
+
+    auto attn_output = attn_->forward(q_rope, k_reshaped, v_reshaped);
+    return o_proj_->forward(attn_output);
+}
+
+infinicore::Tensor Ernie4_5_VLMoeAttention::forward_paged_(const infinicore::Tensor &position_ids,
+                                                           const infinicore::Tensor &hidden_states) const {
+    auto hidden_states_mutable = hidden_states;
+    auto shape = hidden_states->shape();
+    size_t batch_size = shape[0];
+    size_t seq_len = shape[1];
+    ASSERT_EQ(batch_size, 1);
+
+    auto [q, k, v] = qkv_proj_->forward_split(hidden_states_mutable);
+
+    // Make contiguous before view: q/k/v are narrow slices of the fused QKV output
+    // and therefore non-contiguous; view on a non-contiguous tensor can fail in paged
+    // attention backends that permute+view the result.
+    auto q_cont = q->contiguous();
+    auto k_cont = k->contiguous();
+    auto v_cont = v->contiguous();
+
+    auto q_reshaped = q_cont->view({seq_len, num_attention_heads_, head_dim_});
+    auto k_reshaped = k_cont->view({seq_len, num_key_value_heads_, head_dim_});
+    auto v_reshaped = v_cont->view({seq_len, num_key_value_heads_, head_dim_});
+
+    // RoPE (see forward_static_). 3D mrope when position_ids is [3, seq].
+    auto pos_shape = position_ids->shape();
+    bool use_mrope = (pos_shape.size() == 2) && (pos_shape[0] == 3) && !mrope_section_.empty();
+    if (use_mrope) {
+        auto [sin_tbl, cos_tbl, pos_index] =
+            build_mrope_(position_ids, q_reshaped->dtype(), q_reshaped->device());
+        infinicore::op::rope_(q_reshaped, q_reshaped, pos_index, sin_tbl, cos_tbl, rope_algo_);
+        infinicore::op::rope_(k_reshaped, k_reshaped, pos_index, sin_tbl, cos_tbl, rope_algo_);
+    } else {
+        infinicore::Tensor pos_ids_for_rope = position_ids;
+        if (pos_shape.size() == 2) {
+            auto pos_narrowed = position_ids->narrow({{0, 0, 1}});
+            pos_ids_for_rope = pos_narrowed->view({pos_shape[1]});
+        } else if (pos_shape.size() == 1) {
+            pos_ids_for_rope = position_ids;
+        }
+        rotary_emb_->forward(q_reshaped, pos_ids_for_rope, true);
+        rotary_emb_->forward(k_reshaped, pos_ids_for_rope, true);
+    }
+
+    auto attn_output = attn_->forward(q_reshaped, k_reshaped, v_reshaped);
+    return o_proj_->forward(attn_output);
+}
+
+} // namespace infinilm::models::ernie4_5_moe_vl

--- a/csrc/models/ernie4_5_moe_vl/ernie4_5_moe_vl_attention.cpp
+++ b/csrc/models/ernie4_5_moe_vl/ernie4_5_moe_vl_attention.cpp
@@ -111,8 +111,7 @@ Ernie4_5_VLMoeAttention::build_mrope_(const infinicore::Tensor &position_ids,
     std::vector<float> sin_f(seq * cache_dim);
     std::vector<float> cos_f(seq * cache_dim);
     for (size_t j = 0; j < cache_dim; ++j) {
-        float inv_freq = 1.0f / std::pow(static_cast<float>(rope_theta_),
-                                         2.0f * static_cast<float>(j) / static_cast<float>(head_dim_));
+        float inv_freq = 1.0f / std::pow(static_cast<float>(rope_theta_), 2.0f * static_cast<float>(j) / static_cast<float>(head_dim_));
         size_t ax = axis_of[j];
         for (size_t i = 0; i < seq; ++i) {
             float p = static_cast<float>(pp[ax * seq + i]);
@@ -195,12 +194,12 @@ infinicore::Tensor Ernie4_5_VLMoeAttention::forward_static_(const infinicore::Te
     bool use_mrope = (pos_shape.size() == 2) && (pos_shape[0] == 3) && !mrope_section_.empty();
 
     auto q_rope = infinicore::Tensor::empty(
-        {batch_size, num_attention_heads_, seq_len, head_dim_},
-        q_reshaped->dtype(), q_reshaped->device())->permute({0, 2, 1, 3});
+                      {batch_size, num_attention_heads_, seq_len, head_dim_},
+                      q_reshaped->dtype(), q_reshaped->device())
+                      ->permute({0, 2, 1, 3});
 
     if (use_mrope) {
-        auto [sin_tbl, cos_tbl, pos_index] =
-            build_mrope_(position_ids, q_reshaped->dtype(), q_reshaped->device());
+        auto [sin_tbl, cos_tbl, pos_index] = build_mrope_(position_ids, q_reshaped->dtype(), q_reshaped->device());
         infinicore::op::rope_(q_rope, q_reshaped, pos_index, sin_tbl, cos_tbl, rope_algo_);
         infinicore::op::rope_(k_reshaped, k_reshaped, pos_index, sin_tbl, cos_tbl, rope_algo_);
     } else {
@@ -244,8 +243,7 @@ infinicore::Tensor Ernie4_5_VLMoeAttention::forward_paged_(const infinicore::Ten
     auto pos_shape = position_ids->shape();
     bool use_mrope = (pos_shape.size() == 2) && (pos_shape[0] == 3) && !mrope_section_.empty();
     if (use_mrope) {
-        auto [sin_tbl, cos_tbl, pos_index] =
-            build_mrope_(position_ids, q_reshaped->dtype(), q_reshaped->device());
+        auto [sin_tbl, cos_tbl, pos_index] = build_mrope_(position_ids, q_reshaped->dtype(), q_reshaped->device());
         infinicore::op::rope_(q_reshaped, q_reshaped, pos_index, sin_tbl, cos_tbl, rope_algo_);
         infinicore::op::rope_(k_reshaped, k_reshaped, pos_index, sin_tbl, cos_tbl, rope_algo_);
     } else {

--- a/csrc/models/ernie4_5_moe_vl/ernie4_5_moe_vl_attention.hpp
+++ b/csrc/models/ernie4_5_moe_vl/ernie4_5_moe_vl_attention.hpp
@@ -1,0 +1,73 @@
+#pragma once
+
+#include "../../layers/common_modules.hpp"
+
+#include <tuple>
+#include <vector>
+
+namespace infinilm::models::ernie4_5_moe_vl {
+
+// Text-side self-attention for ERNIE-4.5-VL-MoE.
+//
+// Differences vs. the generic `infinilm::layers::attention::Attention`:
+//   - No q_norm / k_norm (ERNIE-4.5 attention has no QK-RMSNorm).
+//   - 3D RoPE (mrope): position_ids carry [time, height, width]; rotation uses
+//     `rope_scaling.mrope_section = [22, 22, 20]`.
+//   - use_bias = false for all projections (config: "use_bias": false).
+//
+// GQA: num_attention_heads = 20, num_key_value_heads = 4, head_dim = 128.
+class Ernie4_5_VLMoeAttention : public infinicore::nn::Module {
+public:
+    Ernie4_5_VLMoeAttention(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+                            size_t layer_idx,
+                            const infinicore::Device &device);
+
+    infinicore::Tensor forward(const infinicore::Tensor &positions,
+                               const infinicore::Tensor &hidden_states) const;
+
+    size_t layer_idx() const { return layer_idx_; }
+    size_t num_heads() const { return num_attention_heads_; }
+    size_t num_kv_heads() const { return num_key_value_heads_; }
+    size_t head_dim() const { return head_dim_; }
+    size_t hidden_size() const { return hidden_size_; }
+
+private:
+    infinicore::Tensor forward_static_(const infinicore::Tensor &positions,
+                                       const infinicore::Tensor &hidden_states) const;
+
+    infinicore::Tensor forward_paged_(const infinicore::Tensor &positions,
+                                      const infinicore::Tensor &hidden_states) const;
+
+    // Build per-token 3D-mrope sin/cos tables [seq, head_dim/2] plus a [seq]
+    // position index (arange), so op::rope can be reused: each table row already
+    // encodes the multi-axis (time,height,width) rotation for that token.
+    std::tuple<infinicore::Tensor, infinicore::Tensor, infinicore::Tensor>
+    build_mrope_(const infinicore::Tensor &position_ids,
+                 const infinicore::DataType &dtype,
+                 const infinicore::Device &device) const;
+
+protected:
+    std::shared_ptr<infinilm::layers::linear::QKVParallelLinear> qkv_proj_;
+    std::shared_ptr<infinilm::layers::linear::RowParallelLinear> o_proj_;
+    std::shared_ptr<infinicore::nn::RoPE> rotary_emb_;
+
+    std::shared_ptr<infinilm::layers::attention::AttentionLayer> attn_;
+    ::infinilm::backends::AttentionBackend attention_backend_;
+    size_t layer_idx_;
+    size_t num_attention_heads_;
+    size_t num_key_value_heads_;
+    size_t hidden_size_;
+    size_t head_dim_;
+
+    // 3D mrope (rope_scaling.mrope_section, e.g. [22,22,20] summing to head_dim/2).
+    // Empty -> plain 1D rope via rotary_emb_.
+    std::vector<size_t> mrope_section_;
+    double rope_theta_{0.0};
+    infinicore::nn::RoPE::Algo rope_algo_{infinicore::nn::RoPE::Algo::GPT_NEOX};
+
+    // For off-line kv cache quantization.
+    INFINICORE_NN_PARAMETER(kv_cache_k_scale);
+    INFINICORE_NN_PARAMETER(kv_cache_v_scale);
+};
+
+} // namespace infinilm::models::ernie4_5_moe_vl

--- a/csrc/models/ernie4_5_moe_vl/ernie4_5_moe_vl_decoder_layer.cpp
+++ b/csrc/models/ernie4_5_moe_vl/ernie4_5_moe_vl_decoder_layer.cpp
@@ -1,0 +1,66 @@
+#include "ernie4_5_moe_vl_decoder_layer.hpp"
+
+#include "infinicore/context/context.hpp"
+
+namespace infinilm::models::ernie4_5_moe_vl {
+
+bool Ernie4_5_VLMoeDecoderLayer::compute_is_moe_layer(
+    const std::shared_ptr<infinilm::config::ModelConfig> &model_config,
+    size_t layer_idx) {
+    // moe_layer_start_index = [1, 1], moe_layer_end_index = [29, 28],
+    // moe_layer_interval = 1. Index 0 of each array is the text branch which
+    // drives the (shared) layer schedule; layers in [start, end) at the given
+    // interval are MoE. With 28 layers this makes layer 0 dense and 1..27 MoE.
+    auto start = model_config->get_ref("moe_layer_start_index");
+    auto interval = model_config->get_or<size_t>("moe_layer_interval", 1);
+    size_t start_idx = start[0];
+    if (layer_idx < start_idx) {
+        return false;
+    }
+    return ((layer_idx - start_idx) % interval) == 0;
+}
+
+Ernie4_5_VLMoeDecoderLayer::Ernie4_5_VLMoeDecoderLayer(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+                                                       size_t layer_idx,
+                                                       const infinicore::Device &device)
+    : layer_idx_(layer_idx) {
+    const auto &dtype{model_config->get_dtype()};
+    size_t hidden_size = model_config->get<size_t>("hidden_size");
+    double rms_norm_eps = model_config->get<double>("rms_norm_eps");
+
+    INFINICORE_NN_MODULE_INIT(input_layernorm, hidden_size, rms_norm_eps, dtype, device);
+    INFINICORE_NN_MODULE_INIT(post_attention_layernorm, hidden_size, rms_norm_eps, dtype, device);
+    INFINICORE_NN_MODULE_INIT(self_attn, model_config, layer_idx, device);
+
+    is_moe_layer_ = compute_is_moe_layer(model_config, layer_idx);
+    if (is_moe_layer_) {
+        moe_block_ = this->register_module<Ernie4_5_VLMoeSparseMoeBlock>("mlp", model_config, device);
+    } else {
+        dense_mlp_ = this->register_module<infinilm::layers::mlp::MLP>("mlp", model_config, device);
+    }
+}
+
+std::tuple<infinicore::Tensor, infinicore::Tensor>
+Ernie4_5_VLMoeDecoderLayer::forward(const infinicore::Tensor &positions,
+                                    infinicore::Tensor &hidden_states,
+                                    infinicore::Tensor &residual,
+                                    const infinicore::Tensor &token_type_ids) {
+    input_layernorm_->forward_inplace(hidden_states, residual);
+    hidden_states = self_attn_->forward(positions, hidden_states);
+    // Drain the MetaX command queue. Ops are enqueued host-side and only submitted
+    // on a sync; a large prefill (a video's 2448 tokens) otherwise piles up enough
+    // work to block the enqueue and deadlock (GPU idle, no progress). Small prefills
+    // are fast enough that the extra syncs are cheap.
+    infinicore::context::syncStream();
+    post_attention_layernorm_->forward_inplace(hidden_states, residual);
+
+    if (is_moe_layer_) {
+        hidden_states = moe_block_->forward(hidden_states, token_type_ids);
+    } else {
+        hidden_states = dense_mlp_->forward(hidden_states);
+    }
+    infinicore::context::syncStream();
+    return std::make_tuple(hidden_states, residual);
+}
+
+} // namespace infinilm::models::ernie4_5_moe_vl

--- a/csrc/models/ernie4_5_moe_vl/ernie4_5_moe_vl_decoder_layer.hpp
+++ b/csrc/models/ernie4_5_moe_vl/ernie4_5_moe_vl_decoder_layer.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "ernie4_5_moe_vl_attention.hpp"
+#include "ernie4_5_moe_vl_moe.hpp"
+
+#include "../../layers/mlp/mlp.hpp"
+#include "infinicore/nn/module.hpp"
+#include "infinicore/nn/rmsnorm.hpp"
+
+#include <memory>
+#include <tuple>
+
+namespace infinilm::models::ernie4_5_moe_vl {
+
+// One transformer block. Layers are heterogeneous:
+//   - layer 0 is dense (regular SwiGLU MLP), per moe_layer_start_index = [1, 1].
+//   - layers 1..27 are modality-specific MoE blocks.
+// forward takes token_type_ids (used only by MoE layers to split text/vision routing).
+class Ernie4_5_VLMoeDecoderLayer : public infinicore::nn::Module {
+public:
+    Ernie4_5_VLMoeDecoderLayer(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+                               size_t layer_idx,
+                               const infinicore::Device &device);
+
+    std::tuple<infinicore::Tensor, infinicore::Tensor>
+    forward(const infinicore::Tensor &positions,
+            infinicore::Tensor &hidden_states,
+            infinicore::Tensor &residual,
+            const infinicore::Tensor &token_type_ids);
+
+    size_t layer_idx() const { return layer_idx_; }
+    bool is_moe_layer() const { return is_moe_layer_; }
+
+    static bool compute_is_moe_layer(const std::shared_ptr<infinilm::config::ModelConfig> &model_config,
+                                     size_t layer_idx);
+
+protected:
+    INFINICORE_NN_MODULE(infinicore::nn::RMSNorm, input_layernorm);
+    INFINICORE_NN_MODULE(infinicore::nn::RMSNorm, post_attention_layernorm);
+    INFINICORE_NN_MODULE(Ernie4_5_VLMoeAttention, self_attn);
+
+    // Exactly one of these is registered as "mlp" depending on is_moe_layer_.
+    std::shared_ptr<infinilm::layers::mlp::MLP> dense_mlp_;
+    std::shared_ptr<Ernie4_5_VLMoeSparseMoeBlock> moe_block_;
+
+    size_t layer_idx_;
+    bool is_moe_layer_;
+};
+
+} // namespace infinilm::models::ernie4_5_moe_vl

--- a/csrc/models/ernie4_5_moe_vl/ernie4_5_moe_vl_for_conditional_generation.cpp
+++ b/csrc/models/ernie4_5_moe_vl/ernie4_5_moe_vl_for_conditional_generation.cpp
@@ -1,0 +1,199 @@
+#include "ernie4_5_moe_vl_for_conditional_generation.hpp"
+
+#include "../../global_state/global_state.hpp"
+#include "../models_registry.hpp"
+#include "infinicore/ops.hpp"
+
+#include <algorithm>
+#include <cstring>
+#include <stdexcept>
+#include <vector>
+
+namespace infinilm::models::ernie4_5_moe_vl {
+
+Ernie4_5_VLMoeForConditionalGeneration::Ernie4_5_VLMoeForConditionalGeneration(
+    std::shared_ptr<infinilm::config::ModelConfig> model_config,
+    const infinicore::Device &device) {
+    model_config_ = model_config;
+    compute_device_ = device;
+
+    // ERNIE-4.5-VL uses GPT-J / interleaved rotary (not the framework-default
+    // GPT-NEOX half-split). The shared get_rope() reads the algorithm from the
+    // config, so set it once here before the text model (and its RoPE) is built.
+    model_config->set_rope_algo(infinicore::nn::RoPE::Algo::GPT_J);
+
+    const auto &dtype{model_config->get_dtype()};
+    size_t hidden_size = model_config->get<size_t>("hidden_size");
+    size_t vocab_size = model_config->get<size_t>("vocab_size");
+
+    im_patch_id_ = model_config->get_or<int64_t>("im_patch_id", 100295);
+    image_start_token_id_ = model_config->get_or<int64_t>("image_start_token_id", 101304);
+    image_end_token_id_ = model_config->get_or<int64_t>("image_end_token_id", 101305);
+    video_start_token_id_ = model_config->get_or<int64_t>("video_start_token_id", 101306);
+    video_end_token_id_ = model_config->get_or<int64_t>("video_end_token_id", 101307);
+
+    INFINICORE_NN_MODULE_INIT(model, model_config, device);
+
+    // Vision tower + adapter in one module registered as "visual" to match HF
+    // checkpoint prefix. visual.merger.* holds the resampler weights.
+    INFINICORE_NN_MODULE_INIT(visual, model_config, device);
+
+    // tie_word_embeddings = true: weights are shared with model.embed_tokens and
+    // copied in by the loader. The module is still created to own the logits proj.
+    INFINICORE_NN_MODULE_INIT(lm_head, hidden_size, vocab_size, false, dtype, device);
+}
+
+infinicore::Tensor Ernie4_5_VLMoeForConditionalGeneration::derive_token_type_ids(
+    const infinicore::Tensor &input_ids) const {
+    // 0 = text, 1 = vision. Vision tokens are the image patch placeholder and any
+    // token inside an image/video span.
+    auto ids_cpu = input_ids->to(infinicore::Device::cpu());
+    auto shape = ids_cpu->shape();
+    size_t numel = ids_cpu->numel();
+    const auto *ids = reinterpret_cast<const int64_t *>(ids_cpu->data());
+
+    // Build on CPU and write EVERY element explicitly. Tensor::zeros(I64) is not
+    // reliable here (it does not actually clear the buffer), so a zeros-then-set-1
+    // construction leaves the text (0) entries full of garbage, which randomly
+    // misclassifies text tokens as vision and routes them through the wrong expert
+    // set -> non-deterministic output. Allocate with empty() and assign all slots.
+    // Keep the result on CPU: the MoE dispatch is the only consumer and reads it on
+    // the host; round-tripping this I64 tensor through MetaX device memory is both
+    // wasteful and an additional corruption risk.
+    auto token_type = infinicore::Tensor::empty(shape, infinicore::DataType::I64, infinicore::Device::cpu());
+    auto *tt = reinterpret_cast<int64_t *>(token_type->data());
+    // HF marks the entire contiguous span [START .. END] -- including the
+    // IMAGE/VIDEO_START and _END marker tokens, not just the inner placeholders --
+    // as the vision modality (token_type=1). Routing the markers through text
+    // experts (placeholder-only classification) perturbs the MoE output and diverges
+    // from HF. Track the span and mark start/end inclusive.
+    bool in_vision = false;
+    for (size_t i = 0; i < numel; ++i) {
+        if (ids[i] == image_start_token_id_ || ids[i] == video_start_token_id_) {
+            in_vision = true;
+        }
+        tt[i] = (in_vision || ids[i] == im_patch_id_) ? 1 : 0;
+        if (ids[i] == image_end_token_id_ || ids[i] == video_end_token_id_) {
+            in_vision = false;
+        }
+    }
+    return token_type;
+}
+
+infinicore::Tensor Ernie4_5_VLMoeForConditionalGeneration::merge_vision_embeddings(
+    const infinicore::Tensor &inputs_embeds,
+    const infinicore::Tensor &vision_embeds,
+    const infinicore::Tensor &input_ids) const {
+    // Scatter vision_embeds[0..V) into inputs_embeds at the V positions where
+    // input_ids == im_patch_id, preserving order. Mirrors minicpmv replace_embeddings
+    // but keyed on the patch id rather than explicit bounds.
+    auto out = infinicore::Tensor::empty(inputs_embeds->shape(), inputs_embeds->dtype(), inputs_embeds->device());
+    out->copy_from(inputs_embeds);
+
+    ASSERT_EQ(inputs_embeds->size(0), 1); // batch == 1 for prefill
+    auto ids_cpu = input_ids->to(infinicore::Device::cpu());
+    const auto *ids = reinterpret_cast<const int64_t *>(ids_cpu->data());
+    size_t seq_len = ids_cpu->numel();
+
+    auto out_slice = out->squeeze(0); // [seq, hidden]
+    size_t v = 0;
+    size_t vision_len = vision_embeds->size(0);
+    for (size_t i = 0; i < seq_len && v < vision_len; ++i) {
+        if (ids[i] == im_patch_id_) {
+            auto patch = vision_embeds->narrow({{0, v, 1}});
+            out_slice->narrow({{0, i, 1}})->copy_from(patch);
+            ++v;
+        }
+    }
+    return out;
+}
+
+InfinilmModel::Output Ernie4_5_VLMoeForConditionalGeneration::forward(const Input &input) const {
+    if (!input.input_ids.has_value()) {
+        throw std::runtime_error("Ernie4_5_VLMoeForConditionalGeneration: input_ids is required");
+    }
+    auto input_ids = input.input_ids.value();
+
+    // Multimodal prefill: pixel_values present and processing a full prompt.
+    if (input.pixel_values.has_value() && input_ids->size(1) > 1) {
+        if (!input.tgt_sizes.has_value()) {
+            throw std::runtime_error("Ernie4_5_VLMoeForConditionalGeneration: grid_thw (tgt_sizes) required for multimodal input");
+        }
+        auto pixel_values = input.pixel_values.value();
+        auto grid_thw = input.tgt_sizes.value();
+
+        // pixel_values arrives as a CPU tensor (built via from_numpy). Small images
+        // work through the implicit host-mapped access, but a video's ~21.5MB buffer
+        // can't be handled that way. Stage it to the module's compute device.
+        // NOTE 1: use compute_device_, not nn::Module::device_ (default-constructed
+        //   /garbage for this parent module -- moving to it crashes the GEMM).
+        // NOTE 2: a single large pageable host->device copy hangs the MetaX runtime,
+        //   so copy in row chunks to keep each transfer small.
+        if (pixel_values->device() != compute_device_) {
+            size_t rows = pixel_values->shape()[0];
+            auto dev = infinicore::Tensor::empty(pixel_values->shape(), pixel_values->dtype(),
+                                                 compute_device_);
+            constexpr size_t H2D_ROWS = 1024;
+            for (size_t s = 0; s < rows; s += H2D_ROWS) {
+                size_t n = std::min(H2D_ROWS, rows - s);
+                dev->narrow({{0, s, n}})->copy_from(pixel_values->narrow({{0, s, n}}));
+            }
+            pixel_values = dev;
+        }
+
+        // visual_ forward: ViT blocks -> merger -> [num_merged_tokens, text_hidden].
+        auto vision_embeds = visual_->forward(pixel_values, grid_thw);
+
+        auto inputs_embeds = model_->embed_tokens(input_ids);
+        auto merged = merge_vision_embeddings(inputs_embeds, vision_embeds, input_ids);
+        auto token_type_ids = derive_token_type_ids(input_ids);
+
+        auto position_ids = input.position_ids.value();
+        auto hidden_states = model_->forward_embeds(merged, position_ids, token_type_ids);
+        auto logits = lm_head_->forward(hidden_states);
+        return {logits};
+    }
+
+    // Text-only path (also the decode path for multimodal: vision already in cache).
+    auto hidden_states = model_->forward(input);
+    auto logits = lm_head_->forward(hidden_states);
+    return {logits};
+}
+
+void Ernie4_5_VLMoeForConditionalGeneration::reset_cache(const cache::CacheConfig *cache_config) {
+    if (nullptr == cache_config) {
+        InfinilmModel::reset_cache(nullptr);
+        return;
+    }
+    cache_config_ = cache_config->unique_copy();
+
+    auto &kv_cache_vec = infinilm::global_state::get_forward_context().kv_cache_vec;
+    kv_cache_vec.clear();
+    const backends::AttentionBackend attention_backend = infinilm::global_state::get_infinilm_config().attention_backend;
+    kv_cache_vec = std::move(default_allocate_kv_cache_tensors(cache_config, model_config_, attention_backend));
+}
+
+std::shared_ptr<infinilm::config::ModelConfig> create_ernie4_5_moe_vl_model_config(
+    std::shared_ptr<infinilm::config::ModelConfig> model_config) {
+    const std::string &model_type = model_config->get<std::string>("model_type");
+    if ("ernie4_5_moe_vl" != model_type) {
+        throw std::runtime_error("create_ernie4_5_moe_vl_model_config: model_type is not ernie4_5_moe_vl");
+    }
+
+    nlohmann::json &config_json = model_config->get_config_json();
+    if (!config_json.contains("head_dim")) {
+        size_t head_dim = model_config->get<size_t>("hidden_size")
+                        / model_config->get<size_t>("num_attention_heads");
+        config_json["head_dim"] = head_dim; // 2560 / 20 = 128
+    }
+    return model_config;
+}
+
+} // namespace infinilm::models::ernie4_5_moe_vl
+
+namespace {
+INFINILM_REGISTER_CAUSAL_LM_MODEL(
+    ernie4_5_moe_vl,
+    infinilm::models::ernie4_5_moe_vl::Ernie4_5_VLMoeForConditionalGeneration,
+    infinilm::models::ernie4_5_moe_vl::create_ernie4_5_moe_vl_model_config);
+} // namespace

--- a/csrc/models/ernie4_5_moe_vl/ernie4_5_moe_vl_for_conditional_generation.hpp
+++ b/csrc/models/ernie4_5_moe_vl/ernie4_5_moe_vl_for_conditional_generation.hpp
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "ernie4_5_moe_vl_text_model.hpp"
+#include "ernie4_5_moe_vl_vision.hpp"
+
+#include "../infinilm_model.hpp"
+#include "../../layers/linear/linear.hpp"
+
+namespace infinilm::models::ernie4_5_moe_vl {
+
+// Top-level: Ernie4_5_VLMoeForConditionalGeneration.
+// Assembles the text MoE backbone + vision tower + lm_head.
+// Module layout matches HF checkpoint prefixes:
+//   model.*       - text MoE backbone
+//   visual.*      - vision tower (visual.blocks.*, visual.patch_embed.*)
+//   visual.merger.* - spatial/temporal adapter (inside vision tower)
+//   lm_head.*     - output projection (weights tied to model.embed_tokens)
+class Ernie4_5_VLMoeForConditionalGeneration : public InfinilmModel {
+public:
+    Ernie4_5_VLMoeForConditionalGeneration(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+                                           const infinicore::Device &device);
+
+    Output forward(const Input &input) const override;
+
+    void reset_cache(const cache::CacheConfig *cache_config) override;
+
+private:
+    // Replace im_patch_id placeholder positions in inputs_embeds with vision_embeds.
+    infinicore::Tensor merge_vision_embeddings(const infinicore::Tensor &inputs_embeds,
+                                               const infinicore::Tensor &vision_embeds,
+                                               const infinicore::Tensor &input_ids) const;
+
+    // Derive per-token modality ids (0=text, 1=vision) from input_ids, using the
+    // image/video token ids from config. Avoids adding token_type_ids to the
+    // framework-level Input struct.
+    infinicore::Tensor derive_token_type_ids(const infinicore::Tensor &input_ids) const;
+
+    // The module's compute device. nn::Module::device_ is default-constructed and
+    // never set for parent modules (only leaf weights get the device via their
+    // constructors), so we stash the ctor's device here to stage pixel_values onto
+    // the GPU in forward().
+    infinicore::Device compute_device_;
+
+    int64_t im_patch_id_{0};
+    int64_t image_start_token_id_{0};
+    int64_t image_end_token_id_{0};
+    int64_t video_start_token_id_{0};
+    int64_t video_end_token_id_{0};
+
+    INFINICORE_NN_MODULE(Ernie4_5_VLMoeModel, model);
+    // Registered as "visual" to match HF checkpoint prefix visual.*
+    INFINICORE_NN_MODULE(Ernie4_5_VisionTransformer, visual);
+    INFINICORE_NN_MODULE(infinilm::layers::linear::ReplicatedLinear, lm_head);
+};
+
+std::shared_ptr<infinilm::config::ModelConfig> create_ernie4_5_moe_vl_model_config(
+    std::shared_ptr<infinilm::config::ModelConfig> model_config);
+
+} // namespace infinilm::models::ernie4_5_moe_vl

--- a/csrc/models/ernie4_5_moe_vl/ernie4_5_moe_vl_for_conditional_generation.hpp
+++ b/csrc/models/ernie4_5_moe_vl/ernie4_5_moe_vl_for_conditional_generation.hpp
@@ -3,8 +3,8 @@
 #include "ernie4_5_moe_vl_text_model.hpp"
 #include "ernie4_5_moe_vl_vision.hpp"
 
-#include "../infinilm_model.hpp"
 #include "../../layers/linear/linear.hpp"
+#include "../infinilm_model.hpp"
 
 namespace infinilm::models::ernie4_5_moe_vl {
 

--- a/csrc/models/ernie4_5_moe_vl/ernie4_5_moe_vl_moe.cpp
+++ b/csrc/models/ernie4_5_moe_vl/ernie4_5_moe_vl_moe.cpp
@@ -88,7 +88,7 @@ Ernie4_5_VLMoeGate::forward(const infinicore::Tensor &hidden_states,
     ASSERT(hidden_states->ndim() == 2);
     size_t ntoken = hidden_states->shape()[0];
 
-    auto gate_weight = (modality == 0) ? weight_ : weight_1_;  // [num_experts, hidden]
+    auto gate_weight = (modality == 0) ? weight_ : weight_1_; // [num_experts, hidden]
     auto router_logits = infinicore::op::linear(
         const_cast<infinicore::Tensor &>(hidden_states), gate_weight, std::nullopt, 1.0f);
     size_t num_experts = router_logits->shape()[1];
@@ -175,13 +175,13 @@ Ernie4_5_VLMoeGate::forward(const infinicore::Tensor &hidden_states,
 // Ernie4_5_VLMoeExpertList
 // ---------------------------------------------------------------------------
 Ernie4_5_VLMoeExpertList::Ernie4_5_VLMoeExpertList(size_t num_experts_text,
-                                                    size_t num_experts_vision,
-                                                    size_t hidden_size,
-                                                    size_t inter_text,
-                                                    size_t inter_vision,
-                                                    bool use_bias,
-                                                    const infinicore::DataType &dtype,
-                                                    const infinicore::Device &device) {
+                                                   size_t num_experts_vision,
+                                                   size_t hidden_size,
+                                                   size_t inter_text,
+                                                   size_t inter_vision,
+                                                   bool use_bias,
+                                                   const infinicore::DataType &dtype,
+                                                   const infinicore::Device &device) {
     // Text experts: indices [0, num_experts_text) -> weight paths experts.0.*, experts.1.*, ...
     for (size_t i = 0; i < num_experts_text; ++i) {
         experts.push_back(this->register_module<Ernie4_5_VLMoeMLP>(
@@ -203,8 +203,8 @@ Ernie4_5_VLMoeSparseMoeBlock::Ernie4_5_VLMoeSparseMoeBlock(std::shared_ptr<infin
     size_t hidden_size = model_config->get<size_t>("hidden_size");
     bool use_bias = model_config->get_or<bool>("use_bias", false);
 
-    const auto &num_experts = model_config->get_ref("moe_num_experts");          // [64, 64]
-    const auto &intermediate = model_config->get_ref("moe_intermediate_size");    // [1536, 512]
+    const auto &num_experts = model_config->get_ref("moe_num_experts");        // [64, 64]
+    const auto &intermediate = model_config->get_ref("moe_intermediate_size"); // [1536, 512]
     num_experts_text_ = num_experts[0].get<size_t>();
     num_experts_vision_ = num_experts[1].get<size_t>();
     size_t inter_text = intermediate[0].get<size_t>();
@@ -228,7 +228,7 @@ Ernie4_5_VLMoeSparseMoeBlock::Ernie4_5_VLMoeSparseMoeBlock(std::shared_ptr<infin
 infinicore::Tensor Ernie4_5_VLMoeSparseMoeBlock::forward(const infinicore::Tensor &hidden_states,
                                                          const infinicore::Tensor &token_type_ids) const {
     ASSERT(hidden_states->ndim() == 3);
-    auto shape = hidden_states->shape();  // [batch, seq, hidden]
+    auto shape = hidden_states->shape(); // [batch, seq, hidden]
     size_t hidden = shape[2];
     size_t ntoken = shape[0] * shape[1];
     auto flat = hidden_states->view({ntoken, hidden});
@@ -257,8 +257,8 @@ infinicore::Tensor Ernie4_5_VLMoeSparseMoeBlock::forward(const infinicore::Tenso
 
     // 3) Per-modality batch gate + per-token expert dispatch.
     auto dispatch_modality = [&](const std::vector<size_t> &idxs,
-                                  size_t modality,
-                                  size_t expert_offset) {
+                                 size_t modality,
+                                 size_t expert_offset) {
         if (idxs.empty()) {
             return;
         }
@@ -281,7 +281,7 @@ infinicore::Tensor Ernie4_5_VLMoeSparseMoeBlock::forward(const infinicore::Tenso
         const auto *i_ptr = reinterpret_cast<const int32_t *>(i_cpu->data());
 
         for (size_t i = 0; i < n; ++i) {
-            auto token = gathered->narrow({{0, i, 1}});  // [1, hidden]
+            auto token = gathered->narrow({{0, i, 1}}); // [1, hidden]
             infinicore::Tensor expert_sum;
             for (size_t k = 0; k < moe_k_; ++k) {
                 size_t local_idx = static_cast<size_t>(i_ptr[i * moe_k_ + k]);
@@ -300,8 +300,8 @@ infinicore::Tensor Ernie4_5_VLMoeSparseMoeBlock::forward(const infinicore::Tenso
         }
     };
 
-    dispatch_modality(text_idxs, 0, 0);                          // text experts [0 .. num_experts_text_)
-    dispatch_modality(vision_idxs, 1, num_experts_text_);        // vision experts [num_experts_text_ .. total)
+    dispatch_modality(text_idxs, 0, 0);                   // text experts [0 .. num_experts_text_)
+    dispatch_modality(vision_idxs, 1, num_experts_text_); // vision experts [num_experts_text_ .. total)
 
     return final_states->view(shape);
 }

--- a/csrc/models/ernie4_5_moe_vl/ernie4_5_moe_vl_moe.cpp
+++ b/csrc/models/ernie4_5_moe_vl/ernie4_5_moe_vl_moe.cpp
@@ -1,0 +1,309 @@
+#include "ernie4_5_moe_vl_moe.hpp"
+#include "../../global_state/global_state.hpp"
+#include "../../utils.hpp"
+#include "infinicore/ops.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+namespace infinilm::models::ernie4_5_moe_vl {
+
+// ---------------------------------------------------------------------------
+// Ernie4_5_VLMoeMLP
+// ---------------------------------------------------------------------------
+Ernie4_5_VLMoeMLP::Ernie4_5_VLMoeMLP(size_t hidden_size,
+                                     size_t intermediate_size,
+                                     bool use_bias,
+                                     const infinicore::DataType &dtype,
+                                     const infinicore::Device &device)
+    : hidden_size_(hidden_size), intermediate_size_(intermediate_size), use_bias_(use_bias) {
+
+    const engine::distributed::RankInfo &rank_info = infinilm::global_state::get_tensor_model_parallel_rank_info();
+    int tp_rank = rank_info.tp_rank;
+    int tp_size = rank_info.tp_size;
+
+    gate_proj_ = this->register_module<layers::linear::ColumnParallelLinear>(
+        "gate_proj", hidden_size_, intermediate_size_, use_bias_, dtype, device, tp_rank, tp_size);
+    up_proj_ = this->register_module<layers::linear::ColumnParallelLinear>(
+        "up_proj", hidden_size_, intermediate_size_, use_bias_, dtype, device, tp_rank, tp_size);
+    down_proj_ = this->register_module<layers::linear::RowParallelLinear>(
+        "down_proj", intermediate_size_, hidden_size_, use_bias_, dtype, device, tp_rank, tp_size, rank_info.comm);
+}
+
+infinicore::Tensor Ernie4_5_VLMoeMLP::forward(const infinicore::Tensor &hidden_states) const {
+    auto x = hidden_states;
+    auto gate = gate_proj_->forward(x);
+    auto up = up_proj_->forward(x);
+    auto intermediate = infinicore::op::swiglu(up, gate);
+    return down_proj_->forward(intermediate);
+}
+
+// ---------------------------------------------------------------------------
+// Ernie4_5_VLMoeStatics (aux-free correction bias)
+// ---------------------------------------------------------------------------
+Ernie4_5_VLMoeStatics::Ernie4_5_VLMoeStatics(size_t num_modalities,
+                                             size_t num_experts,
+                                             const infinicore::Device &device)
+    : num_modalities_(num_modalities), num_experts_(num_experts) {
+    // Bias is stored in fp32 in the checkpoint (load as F32).
+    INFINICORE_NN_PARAMETER_INIT(e_score_correction_bias, ({num_modalities_, num_experts_}, infinicore::DataType::F32, device));
+}
+
+infinicore::Tensor Ernie4_5_VLMoeStatics::bias_for_modality(size_t modality) const {
+    if (modality >= num_modalities_) {
+        throw std::runtime_error("Ernie4_5_VLMoeStatics: modality out of range");
+    }
+    return e_score_correction_bias_->narrow({{0, modality, 1}})->squeeze(0);
+}
+
+// ---------------------------------------------------------------------------
+// Ernie4_5_VLMoeGate
+// ---------------------------------------------------------------------------
+Ernie4_5_VLMoeGate::Ernie4_5_VLMoeGate(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+                                       const infinicore::Device &device) {
+    const auto &dtype{model_config->get_dtype()};
+    size_t hidden_size = model_config->get<size_t>("hidden_size");
+
+    // moe_num_experts = [text, vision]; moe_k = 6.
+    const auto &num_experts = model_config->get_ref("moe_num_experts");
+    size_t num_experts_text = num_experts[0].get<size_t>();
+    size_t num_experts_vision = num_experts[1].get<size_t>();
+    moe_k_ = model_config->get<size_t>("moe_k");
+
+    // Gate weights: checkpoint stores [hidden, num_experts]; the framework loader
+    // transposes linear weights to [out, in], so declare [num_experts, hidden] and
+    // use op::linear (x @ W^T) as usual.
+    INFINICORE_NN_PARAMETER_INIT(weight, ({num_experts_text, hidden_size}, dtype, device));
+    INFINICORE_NN_PARAMETER_INIT(weight_1, ({num_experts_vision, hidden_size}, dtype, device));
+}
+
+std::tuple<infinicore::Tensor, infinicore::Tensor>
+Ernie4_5_VLMoeGate::forward(const infinicore::Tensor &hidden_states,
+                            size_t modality,
+                            const std::optional<infinicore::Tensor> &correction_bias) const {
+    // hidden_states: [num_tokens, hidden_size]
+    ASSERT(hidden_states->ndim() == 2);
+    size_t ntoken = hidden_states->shape()[0];
+
+    auto gate_weight = (modality == 0) ? weight_ : weight_1_;  // [num_experts, hidden]
+    auto router_logits = infinicore::op::linear(
+        const_cast<infinicore::Tensor &>(hidden_states), gate_weight, std::nullopt, 1.0f);
+    size_t num_experts = router_logits->shape()[1];
+
+    // ERNIE-4.5-VL aux-free routing (matches HF modeling_ernie4_5_vl
+    // top_k_weight_and_expert, non-group path; gate.act = softmax):
+    //   prob        = softmax(router_logits)                  # over all experts
+    //   selection   = top-k of (prob + correction_bias)       # bias affects choice only
+    //   combine wts = prob[selected]                          # raw softmax prob, bias excluded
+    //   (NO renormalization of the selected weights, and no routed_scaling_factor)
+    //
+    // Computed on CPU because (a) there is no GPU softmax-topk-with-bias op, and
+    // (b) the infiniop `topkrouter` fused kernel is hardcoded to DeepSeek's 256
+    // experts + 8-group routing (returns BAD_PARAM for ERNIE's 64 experts and
+    // applies group logic ERNIE does not use). num_experts=64 is tiny so the CPU
+    // cost is negligible; a GPU softmax+topk path is a P2 optimization.
+    auto logits_cpu = router_logits->to(infinicore::Device::cpu())->contiguous();
+    auto dtype = logits_cpu->dtype();
+    const void *raw = logits_cpu->data();
+    auto read_logit = [&](size_t flat) -> float {
+        if (dtype == infinicore::DataType::BF16) {
+            return bf16_to_f32(reinterpret_cast<const uint16_t *>(raw)[flat]);
+        } else if (dtype == infinicore::DataType::F16) {
+            return f16_to_f32(reinterpret_cast<const uint16_t *>(raw)[flat]);
+        }
+        return reinterpret_cast<const float *>(raw)[flat];
+    };
+
+    std::vector<float> bias(num_experts, 0.0f);
+    if (correction_bias.has_value()) {
+        auto bias_cpu = correction_bias.value()->to(infinicore::Device::cpu())->contiguous();
+        const float *bp = reinterpret_cast<const float *>(bias_cpu->data());
+        for (size_t e = 0; e < num_experts; ++e) {
+            bias[e] = bp[e];
+        }
+    }
+
+    auto scores_cpu = infinicore::Tensor::empty({ntoken, moe_k_}, infinicore::DataType::F32, infinicore::Device::cpu());
+    auto indices_cpu = infinicore::Tensor::empty({ntoken, moe_k_}, infinicore::DataType::I32, infinicore::Device::cpu());
+    auto *sc = reinterpret_cast<float *>(scores_cpu->data());
+    auto *ic = reinterpret_cast<int32_t *>(indices_cpu->data());
+
+    std::vector<float> logit_t(num_experts);
+    std::vector<float> prob(num_experts);
+    std::vector<std::pair<float, size_t>> choice(num_experts);
+    for (size_t t = 0; t < ntoken; ++t) {
+        // softmax over all experts (numerically stable).
+        float maxv = read_logit(t * num_experts);
+        for (size_t e = 0; e < num_experts; ++e) {
+            logit_t[e] = read_logit(t * num_experts + e);
+            if (logit_t[e] > maxv) {
+                maxv = logit_t[e];
+            }
+        }
+        float denom = 0.0f;
+        for (size_t e = 0; e < num_experts; ++e) {
+            prob[e] = std::exp(logit_t[e] - maxv);
+            denom += prob[e];
+        }
+        for (size_t e = 0; e < num_experts; ++e) {
+            prob[e] /= denom;
+            // Bias affects selection only (aux-free load balancing).
+            choice[e] = {prob[e] + bias[e], e};
+        }
+        std::partial_sort(
+            choice.begin(), choice.begin() + moe_k_, choice.end(),
+            [](const std::pair<float, size_t> &a, const std::pair<float, size_t> &b) {
+                return a.first > b.first;
+            });
+        // Combine weights are the raw softmax probabilities at the selected
+        // experts (bias excluded); HF does not renormalize them.
+        for (size_t k = 0; k < moe_k_; ++k) {
+            size_t e = choice[k].second;
+            ic[t * moe_k_ + k] = static_cast<int32_t>(e);
+            sc[t * moe_k_ + k] = prob[e];
+        }
+    }
+
+    return std::make_tuple(scores_cpu->to(hidden_states->device()),
+                           indices_cpu->to(hidden_states->device()));
+}
+
+// ---------------------------------------------------------------------------
+// Ernie4_5_VLMoeExpertList
+// ---------------------------------------------------------------------------
+Ernie4_5_VLMoeExpertList::Ernie4_5_VLMoeExpertList(size_t num_experts_text,
+                                                    size_t num_experts_vision,
+                                                    size_t hidden_size,
+                                                    size_t inter_text,
+                                                    size_t inter_vision,
+                                                    bool use_bias,
+                                                    const infinicore::DataType &dtype,
+                                                    const infinicore::Device &device) {
+    // Text experts: indices [0, num_experts_text) -> weight paths experts.0.*, experts.1.*, ...
+    for (size_t i = 0; i < num_experts_text; ++i) {
+        experts.push_back(this->register_module<Ernie4_5_VLMoeMLP>(
+            std::to_string(i), hidden_size, inter_text, use_bias, dtype, device));
+    }
+    // Vision experts: indices [num_experts_text, total) -> weight paths experts.64.*, ...
+    for (size_t i = 0; i < num_experts_vision; ++i) {
+        experts.push_back(this->register_module<Ernie4_5_VLMoeMLP>(
+            std::to_string(num_experts_text + i), hidden_size, inter_vision, use_bias, dtype, device));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Ernie4_5_VLMoeSparseMoeBlock
+// ---------------------------------------------------------------------------
+Ernie4_5_VLMoeSparseMoeBlock::Ernie4_5_VLMoeSparseMoeBlock(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+                                                           const infinicore::Device &device) {
+    const auto &dtype{model_config->get_dtype()};
+    size_t hidden_size = model_config->get<size_t>("hidden_size");
+    bool use_bias = model_config->get_or<bool>("use_bias", false);
+
+    const auto &num_experts = model_config->get_ref("moe_num_experts");          // [64, 64]
+    const auto &intermediate = model_config->get_ref("moe_intermediate_size");    // [1536, 512]
+    num_experts_text_ = num_experts[0].get<size_t>();
+    num_experts_vision_ = num_experts[1].get<size_t>();
+    size_t inter_text = intermediate[0].get<size_t>();
+    size_t inter_vision = intermediate[1].get<size_t>();
+    moe_k_ = model_config->get<size_t>("moe_k");
+    size_t num_shared = model_config->get_or<size_t>("moe_num_shared_experts", 2);
+
+    INFINICORE_NN_MODULE_INIT(gate, model_config, device);
+    INFINICORE_NN_MODULE_INIT(moe_statics, /*num_modalities=*/2, num_experts_text_, device);
+
+    // Registered as "experts" so weight paths are mlp.experts.N.*
+    // Text experts [0..num_text), vision experts [num_text..total).
+    INFINICORE_NN_MODULE_INIT(experts, num_experts_text_, num_experts_vision_,
+                              hidden_size, inter_text, inter_vision, use_bias, dtype, device);
+
+    // Shared experts: one fused MLP with intermediate = num_shared * inter_text.
+    // TODO(ernie-vl): confirm shared-expert layout/weight names against checkpoint.
+    INFINICORE_NN_MODULE_INIT(shared_experts, hidden_size, num_shared * inter_text, use_bias, dtype, device);
+}
+
+infinicore::Tensor Ernie4_5_VLMoeSparseMoeBlock::forward(const infinicore::Tensor &hidden_states,
+                                                         const infinicore::Tensor &token_type_ids) const {
+    ASSERT(hidden_states->ndim() == 3);
+    auto shape = hidden_states->shape();  // [batch, seq, hidden]
+    size_t hidden = shape[2];
+    size_t ntoken = shape[0] * shape[1];
+    auto flat = hidden_states->view({ntoken, hidden});
+
+    // 1) Shared experts: every token passes through (residual contribution).
+    auto shared_out = shared_experts_->forward(flat);
+
+    // Output starts as shared_out; routed expert outputs are added on top.
+    auto final_states = infinicore::Tensor::empty(flat->shape(), flat->dtype(), flat->device());
+    final_states->copy_from(shared_out);
+
+    // 2) Read per-token modality on CPU and group token indices.
+    auto tt_cpu = token_type_ids->to(infinicore::Device::cpu())->contiguous();
+    const auto *tt_data = reinterpret_cast<const int64_t *>(tt_cpu->data());
+
+    std::vector<size_t> text_idxs;
+    std::vector<size_t> vision_idxs;
+    text_idxs.reserve(ntoken);
+    for (size_t i = 0; i < ntoken; ++i) {
+        if (tt_data[i] == 0) {
+            text_idxs.push_back(i);
+        } else {
+            vision_idxs.push_back(i);
+        }
+    }
+
+    // 3) Per-modality batch gate + per-token expert dispatch.
+    auto dispatch_modality = [&](const std::vector<size_t> &idxs,
+                                  size_t modality,
+                                  size_t expert_offset) {
+        if (idxs.empty()) {
+            return;
+        }
+        size_t n = idxs.size();
+
+        // Gather hidden states for this modality. CPU loop with narrow+copy_from is
+        // not the fastest path, but keeps the implementation simple and correct.
+        auto gathered = infinicore::Tensor::empty({n, hidden}, flat->dtype(), flat->device());
+        for (size_t i = 0; i < n; ++i) {
+            gathered->narrow({{0, i, 1}})->copy_from(flat->narrow({{0, idxs[i], 1}}));
+        }
+
+        // Batch gate forward for this modality; correction_bias row selects the
+        // modality's aux-free load-balancing bias for top-k selection.
+        auto bias = moe_statics_->bias_for_modality(modality);
+        auto [weights, indices] = gate_->forward(gathered, modality, bias);
+        auto w_cpu = weights->to(infinicore::Device::cpu())->contiguous();
+        auto i_cpu = indices->to(infinicore::Device::cpu())->contiguous();
+        const auto *w_ptr = reinterpret_cast<const float *>(w_cpu->data());
+        const auto *i_ptr = reinterpret_cast<const int32_t *>(i_cpu->data());
+
+        for (size_t i = 0; i < n; ++i) {
+            auto token = gathered->narrow({{0, i, 1}});  // [1, hidden]
+            infinicore::Tensor expert_sum;
+            for (size_t k = 0; k < moe_k_; ++k) {
+                size_t local_idx = static_cast<size_t>(i_ptr[i * moe_k_ + k]);
+                size_t global_idx = expert_offset + local_idx;
+                ASSERT(global_idx < experts_->experts.size());
+                experts_->experts[global_idx]->set_alpha(w_ptr[i * moe_k_ + k]);
+                auto out = experts_->experts[global_idx]->forward(token);
+                if (k == 0) {
+                    expert_sum = out;
+                } else {
+                    infinicore::op::add_(expert_sum, expert_sum, out);
+                }
+            }
+            auto target = final_states->narrow({{0, idxs[i], 1}});
+            infinicore::op::add_(target, target, expert_sum);
+        }
+    };
+
+    dispatch_modality(text_idxs, 0, 0);                          // text experts [0 .. num_experts_text_)
+    dispatch_modality(vision_idxs, 1, num_experts_text_);        // vision experts [num_experts_text_ .. total)
+
+    return final_states->view(shape);
+}
+
+} // namespace infinilm::models::ernie4_5_moe_vl

--- a/csrc/models/ernie4_5_moe_vl/ernie4_5_moe_vl_moe.hpp
+++ b/csrc/models/ernie4_5_moe_vl/ernie4_5_moe_vl_moe.hpp
@@ -77,8 +77,8 @@ public:
             const std::optional<infinicore::Tensor> &correction_bias) const;
 
 protected:
-    INFINICORE_NN_PARAMETER(weight);    // text gate   (mlp.gate.weight)
-    INFINICORE_NN_PARAMETER(weight_1);  // vision gate (mlp.gate.weight_1)
+    INFINICORE_NN_PARAMETER(weight);   // text gate   (mlp.gate.weight)
+    INFINICORE_NN_PARAMETER(weight_1); // vision gate (mlp.gate.weight_1)
 
     size_t moe_k_{0};
 };
@@ -90,13 +90,13 @@ protected:
 class Ernie4_5_VLMoeExpertList : public infinicore::nn::Module {
 public:
     Ernie4_5_VLMoeExpertList(size_t num_experts_text,
-                              size_t num_experts_vision,
-                              size_t hidden_size,
-                              size_t inter_text,
-                              size_t inter_vision,
-                              bool use_bias,
-                              const infinicore::DataType &dtype,
-                              const infinicore::Device &device);
+                             size_t num_experts_vision,
+                             size_t hidden_size,
+                             size_t inter_text,
+                             size_t inter_vision,
+                             bool use_bias,
+                             const infinicore::DataType &dtype,
+                             const infinicore::Device &device);
 
     // Direct access for dispatch in SparseMoeBlock.
     std::vector<std::shared_ptr<Ernie4_5_VLMoeMLP>> experts;

--- a/csrc/models/ernie4_5_moe_vl/ernie4_5_moe_vl_moe.hpp
+++ b/csrc/models/ernie4_5_moe_vl/ernie4_5_moe_vl_moe.hpp
@@ -1,0 +1,130 @@
+#pragma once
+
+#include "../../config/model_config.hpp"
+#include "../../layers/common_modules.hpp"
+#include "../../layers/linear/linear.hpp"
+#include "infinicore/nn/module.hpp"
+
+#include <memory>
+#include <tuple>
+#include <vector>
+
+namespace infinilm::models::ernie4_5_moe_vl {
+
+// SwiGLU expert / shared FFN with an *explicit* intermediate size, because
+// ERNIE-4.5-VL uses different intermediate sizes per modality
+// (config "moe_intermediate_size": [1536, 512]) and for shared experts.
+// Mirrors infinilm::layers::MoeMLP but parameterized instead of config-read.
+class Ernie4_5_VLMoeMLP : public infinicore::nn::Module {
+public:
+    Ernie4_5_VLMoeMLP(size_t hidden_size,
+                      size_t intermediate_size,
+                      bool use_bias,
+                      const infinicore::DataType &dtype,
+                      const infinicore::Device &device);
+
+    infinicore::Tensor forward(const infinicore::Tensor &hidden_states) const;
+
+    // Scales the down_proj output, used to fold the routing weight into the
+    // expert output (same trick as qwen3_moe).
+    void set_alpha(float alpha) { down_proj_->set_alpha(alpha); }
+
+protected:
+    std::shared_ptr<infinilm::layers::linear::ColumnParallelLinear> gate_proj_;
+    std::shared_ptr<infinilm::layers::linear::ColumnParallelLinear> up_proj_;
+    std::shared_ptr<infinilm::layers::linear::RowParallelLinear> down_proj_;
+
+    size_t hidden_size_;
+    size_t intermediate_size_;
+    bool use_bias_;
+};
+
+// Aux-loss-free load-balancing bias (config "moe_use_aux_free": true).
+// Weight name: mlp.moe_statics.e_score_correction_bias, shape
+// [num_modalities, num_experts]. Added to scores ONLY for top-k selection,
+// not for the combine weights (DeepSeek-V3 style).
+class Ernie4_5_VLMoeStatics : public infinicore::nn::Module {
+public:
+    Ernie4_5_VLMoeStatics(size_t num_modalities,
+                          size_t num_experts,
+                          const infinicore::Device &device);
+
+    // Returns the correction bias row for the given modality (0 = text, 1 = vision).
+    infinicore::Tensor bias_for_modality(size_t modality) const;
+
+protected:
+    INFINICORE_NN_PARAMETER(e_score_correction_bias);
+    size_t num_modalities_{0};
+    size_t num_experts_{0};
+};
+
+// Router gate. ERNIE-4.5-VL keeps a separate routing projection per modality:
+//   mlp.gate.weight     -> text experts   [num_experts_text, hidden]
+//   mlp.gate.weight_1   -> vision experts [num_experts_vision, hidden]   (name TBD)
+// Selection uses scores + e_score_correction_bias; combine weights use raw scores,
+// optionally renormalized over the top-k (config: norm via "moe_..." flag).
+class Ernie4_5_VLMoeGate : public infinicore::nn::Module {
+public:
+    Ernie4_5_VLMoeGate(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+                       const infinicore::Device &device);
+
+    // hidden_states: [num_tokens, hidden]; modality picks which gate weight to use.
+    // correction_bias: row from Ernie4_5_VLMoeStatics for aux-free selection.
+    // Returns (topk_weights [num_tokens, k], topk_indices [num_tokens, k]).
+    std::tuple<infinicore::Tensor, infinicore::Tensor>
+    forward(const infinicore::Tensor &hidden_states,
+            size_t modality,
+            const std::optional<infinicore::Tensor> &correction_bias) const;
+
+protected:
+    INFINICORE_NN_PARAMETER(weight);    // text gate   (mlp.gate.weight)
+    INFINICORE_NN_PARAMETER(weight_1);  // vision gate (mlp.gate.weight_1)
+
+    size_t moe_k_{0};
+};
+
+// Thin container for the routed expert list. Registered as "experts" in the
+// SparseMoeBlock so individual expert weights load at mlp.experts.N.* — matching
+// the HF checkpoint layout where experts is an nn.ModuleList.
+// Text experts occupy indices [0, num_text) and vision experts [num_text, total).
+class Ernie4_5_VLMoeExpertList : public infinicore::nn::Module {
+public:
+    Ernie4_5_VLMoeExpertList(size_t num_experts_text,
+                              size_t num_experts_vision,
+                              size_t hidden_size,
+                              size_t inter_text,
+                              size_t inter_vision,
+                              bool use_bias,
+                              const infinicore::DataType &dtype,
+                              const infinicore::Device &device);
+
+    // Direct access for dispatch in SparseMoeBlock.
+    std::vector<std::shared_ptr<Ernie4_5_VLMoeMLP>> experts;
+};
+
+// The full sparse MoE block for one decoder layer.
+// forward routes each token to its modality's experts (text vs. vision) using
+// token_type_ids, runs top-k routed experts, adds shared-expert output.
+class Ernie4_5_VLMoeSparseMoeBlock : public infinicore::nn::Module {
+public:
+    Ernie4_5_VLMoeSparseMoeBlock(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+                                 const infinicore::Device &device);
+
+    // hidden_states: [batch, seq, hidden]; token_type_ids: [batch, seq] (0=text, 1=vision).
+    infinicore::Tensor forward(const infinicore::Tensor &hidden_states,
+                               const infinicore::Tensor &token_type_ids) const;
+
+protected:
+    INFINICORE_NN_MODULE(Ernie4_5_VLMoeGate, gate);
+    INFINICORE_NN_MODULE(Ernie4_5_VLMoeStatics, moe_statics);
+    // Registered as "experts" -> weight paths mlp.experts.N.*
+    INFINICORE_NN_MODULE(Ernie4_5_VLMoeExpertList, experts);
+    // 2 shared experts fused into one MLP (intermediate = num_shared * inter_text).
+    INFINICORE_NN_MODULE(Ernie4_5_VLMoeMLP, shared_experts);
+
+    size_t num_experts_text_{0};
+    size_t num_experts_vision_{0};
+    size_t moe_k_{0};
+};
+
+} // namespace infinilm::models::ernie4_5_moe_vl

--- a/csrc/models/ernie4_5_moe_vl/ernie4_5_moe_vl_resampler.cpp
+++ b/csrc/models/ernie4_5_moe_vl/ernie4_5_moe_vl_resampler.cpp
@@ -1,0 +1,120 @@
+#include "ernie4_5_moe_vl_resampler.hpp"
+
+#include "../../utils.hpp"
+#include "infinicore/ops.hpp"
+
+#include <cstdint>
+#include <vector>
+
+namespace infinilm::models::ernie4_5_moe_vl {
+
+Ernie4_5_VLResampler::Ernie4_5_VLResampler(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+                                           const infinicore::Device &device) {
+    const auto &dtype{model_config->get_dtype()};
+
+    pixel_hidden_size_ = model_config->get<size_t>("pixel_hidden_size");      // 1280
+    text_hidden_size_ = model_config->get<size_t>("hidden_size");             // 2560
+    spatial_conv_size_ = model_config->get_or<size_t>("spatial_conv_size", 2);
+    temporal_conv_size_ = model_config->get_or<size_t>("temporal_conv_size", 2);
+
+    size_t spatial_dim = pixel_hidden_size_ * spatial_conv_size_ * spatial_conv_size_;  // 5120
+    size_t temporal_dim = spatial_dim * temporal_conv_size_;                            // 10240
+    double layer_norm_eps = 1e-6;   // spatial/temporal Sequential LayerNorms
+    double after_norm_eps = 1e-5;   // HF after_norm RMSNorm uses eps=1e-5
+
+    // spatial_linear: Linear(5120,5120) -> act -> Linear(5120,5120) -> LayerNorm(5120)
+    spatial_linear_0_ = this->register_module<infinicore::nn::Linear>(
+        "spatial_linear.0", spatial_dim, spatial_dim, true, dtype, device);
+    spatial_linear_2_ = this->register_module<infinicore::nn::Linear>(
+        "spatial_linear.2", spatial_dim, spatial_dim, true, dtype, device);
+    spatial_linear_3_ = this->register_module<infinicore::nn::LayerNorm>(
+        "spatial_linear.3", spatial_dim, layer_norm_eps, dtype, device);
+
+    // temporal_linear: Linear(10240,5120) -> act -> Linear(5120,5120) -> LayerNorm(5120)
+    temporal_linear_0_ = this->register_module<infinicore::nn::Linear>(
+        "temporal_linear.0", temporal_dim, spatial_dim, true, dtype, device);
+    temporal_linear_2_ = this->register_module<infinicore::nn::Linear>(
+        "temporal_linear.2", spatial_dim, spatial_dim, true, dtype, device);
+    temporal_linear_3_ = this->register_module<infinicore::nn::LayerNorm>(
+        "temporal_linear.3", spatial_dim, layer_norm_eps, dtype, device);
+
+    INFINICORE_NN_MODULE_INIT(mlp, spatial_dim, text_hidden_size_, true, dtype, device);
+    INFINICORE_NN_MODULE_INIT(after_norm, text_hidden_size_, after_norm_eps, dtype, device);
+}
+
+infinicore::Tensor Ernie4_5_VLResampler::forward(const infinicore::Tensor &x,
+                                                 const infinicore::Tensor &grid_thw) const {
+    // Input:  x [num_patches, pixel_hidden_size]
+    // Output: [num_merged_tokens, text_hidden_size]
+    ASSERT(x->ndim() == 2);
+    size_t num_patches = x->shape()[0];
+    size_t spatial_block = spatial_conv_size_ * spatial_conv_size_;
+    size_t spatial_dim = pixel_hidden_size_ * spatial_block;
+
+    ASSERT_EQ(num_patches % spatial_block, 0);
+    size_t num_spatial_merged = num_patches / spatial_block;
+
+    auto merged_spatial = x->view({num_spatial_merged, spatial_dim});
+
+    // spatial_linear Sequential: Linear -> act -> Linear -> LayerNorm
+    // TODO(ernie-vl): activation type (gelu vs quick_gelu) is a guess; verify.
+    auto h = spatial_linear_0_->forward(merged_spatial);
+    h = infinicore::op::gelu(h);
+    h = spatial_linear_2_->forward(h);
+    h = spatial_linear_3_->forward(h);
+    auto x_spatial = h;  // [num_spatial_merged, spatial_dim]
+
+    // Temporal merge. ERNIE applies temporal_linear for BOTH images and video
+    // (use_temporal_conv=true) -- HF fwd_placeholder gathers two interleaved
+    // "timesteps" of spatial tokens and concatenates them on the feature axis to
+    // [n_out, 2*spatial_dim], then temporal_linear projects back to spatial_dim.
+    // timestep_1 = frames 0,2,4,...; timestep_2 = frames 1,3,5,... (for t==1 both
+    // are the single frame, i.e. the spatial features are duplicated). Indices are
+    // computed per media from grid_thw on CPU.
+    auto thw_cpu = grid_thw->to(infinicore::Device::cpu())->contiguous();
+    const auto *g = reinterpret_cast<const int64_t *>(thw_cpu->data());
+    size_t num_media = grid_thw->shape()[0];
+
+    std::vector<size_t> idx1;
+    std::vector<size_t> idx2;
+    size_t base = 0;
+    for (size_t i = 0; i < num_media; ++i) {
+        int64_t t = g[i * 3 + 0];
+        int64_t hh = g[i * 3 + 1];
+        int64_t ww = g[i * 3 + 2];
+        size_t ss = static_cast<size_t>(hh * ww) / spatial_block;  // spatial tokens / frame
+        for (int64_t to = 0; to < t; to += 2) {
+            for (size_t s = 0; s < ss; ++s) {
+                idx1.push_back(base + static_cast<size_t>(to) * ss + s);
+            }
+        }
+        for (int64_t to = (t > 1 ? 1 : 0); to < t; to += 2) {
+            for (size_t s = 0; s < ss; ++s) {
+                idx2.push_back(base + static_cast<size_t>(to) * ss + s);
+            }
+        }
+        base += static_cast<size_t>(t) * ss;
+    }
+    ASSERT_EQ(idx1.size(), idx2.size());
+    size_t n_out = idx1.size();
+    size_t temporal_dim = spatial_dim * temporal_conv_size_;  // 10240
+
+    auto x_temporal_in = infinicore::Tensor::empty(
+        {n_out, temporal_dim}, x_spatial->dtype(), x_spatial->device());
+    for (size_t r = 0; r < n_out; ++r) {
+        auto dst = x_temporal_in->narrow({{0, r, 1}});  // [1, temporal_dim]
+        dst->narrow({{1, 0, spatial_dim}})->copy_from(x_spatial->narrow({{0, idx1[r], 1}}));
+        dst->narrow({{1, spatial_dim, spatial_dim}})->copy_from(x_spatial->narrow({{0, idx2[r], 1}}));
+    }
+
+    // temporal_linear Sequential: Linear -> gelu -> Linear -> LayerNorm
+    auto tt = temporal_linear_0_->forward(x_temporal_in);
+    tt = infinicore::op::gelu(tt);
+    tt = temporal_linear_2_->forward(tt);
+    tt = temporal_linear_3_->forward(tt);
+
+    auto projected = mlp_->forward(tt);  // -> [num_merged_tokens, text_hidden_size]
+    return after_norm_->forward(projected);  // RMSNorm (HF uses RMSNorm here)
+}
+
+} // namespace infinilm::models::ernie4_5_moe_vl

--- a/csrc/models/ernie4_5_moe_vl/ernie4_5_moe_vl_resampler.cpp
+++ b/csrc/models/ernie4_5_moe_vl/ernie4_5_moe_vl_resampler.cpp
@@ -12,15 +12,15 @@ Ernie4_5_VLResampler::Ernie4_5_VLResampler(std::shared_ptr<infinilm::config::Mod
                                            const infinicore::Device &device) {
     const auto &dtype{model_config->get_dtype()};
 
-    pixel_hidden_size_ = model_config->get<size_t>("pixel_hidden_size");      // 1280
-    text_hidden_size_ = model_config->get<size_t>("hidden_size");             // 2560
+    pixel_hidden_size_ = model_config->get<size_t>("pixel_hidden_size"); // 1280
+    text_hidden_size_ = model_config->get<size_t>("hidden_size");        // 2560
     spatial_conv_size_ = model_config->get_or<size_t>("spatial_conv_size", 2);
     temporal_conv_size_ = model_config->get_or<size_t>("temporal_conv_size", 2);
 
-    size_t spatial_dim = pixel_hidden_size_ * spatial_conv_size_ * spatial_conv_size_;  // 5120
-    size_t temporal_dim = spatial_dim * temporal_conv_size_;                            // 10240
-    double layer_norm_eps = 1e-6;   // spatial/temporal Sequential LayerNorms
-    double after_norm_eps = 1e-5;   // HF after_norm RMSNorm uses eps=1e-5
+    size_t spatial_dim = pixel_hidden_size_ * spatial_conv_size_ * spatial_conv_size_; // 5120
+    size_t temporal_dim = spatial_dim * temporal_conv_size_;                           // 10240
+    double layer_norm_eps = 1e-6;                                                      // spatial/temporal Sequential LayerNorms
+    double after_norm_eps = 1e-5;                                                      // HF after_norm RMSNorm uses eps=1e-5
 
     // spatial_linear: Linear(5120,5120) -> act -> Linear(5120,5120) -> LayerNorm(5120)
     spatial_linear_0_ = this->register_module<infinicore::nn::Linear>(
@@ -62,7 +62,7 @@ infinicore::Tensor Ernie4_5_VLResampler::forward(const infinicore::Tensor &x,
     h = infinicore::op::gelu(h);
     h = spatial_linear_2_->forward(h);
     h = spatial_linear_3_->forward(h);
-    auto x_spatial = h;  // [num_spatial_merged, spatial_dim]
+    auto x_spatial = h; // [num_spatial_merged, spatial_dim]
 
     // Temporal merge. ERNIE applies temporal_linear for BOTH images and video
     // (use_temporal_conv=true) -- HF fwd_placeholder gathers two interleaved
@@ -82,7 +82,7 @@ infinicore::Tensor Ernie4_5_VLResampler::forward(const infinicore::Tensor &x,
         int64_t t = g[i * 3 + 0];
         int64_t hh = g[i * 3 + 1];
         int64_t ww = g[i * 3 + 2];
-        size_t ss = static_cast<size_t>(hh * ww) / spatial_block;  // spatial tokens / frame
+        size_t ss = static_cast<size_t>(hh * ww) / spatial_block; // spatial tokens / frame
         for (int64_t to = 0; to < t; to += 2) {
             for (size_t s = 0; s < ss; ++s) {
                 idx1.push_back(base + static_cast<size_t>(to) * ss + s);
@@ -97,12 +97,12 @@ infinicore::Tensor Ernie4_5_VLResampler::forward(const infinicore::Tensor &x,
     }
     ASSERT_EQ(idx1.size(), idx2.size());
     size_t n_out = idx1.size();
-    size_t temporal_dim = spatial_dim * temporal_conv_size_;  // 10240
+    size_t temporal_dim = spatial_dim * temporal_conv_size_; // 10240
 
     auto x_temporal_in = infinicore::Tensor::empty(
         {n_out, temporal_dim}, x_spatial->dtype(), x_spatial->device());
     for (size_t r = 0; r < n_out; ++r) {
-        auto dst = x_temporal_in->narrow({{0, r, 1}});  // [1, temporal_dim]
+        auto dst = x_temporal_in->narrow({{0, r, 1}}); // [1, temporal_dim]
         dst->narrow({{1, 0, spatial_dim}})->copy_from(x_spatial->narrow({{0, idx1[r], 1}}));
         dst->narrow({{1, spatial_dim, spatial_dim}})->copy_from(x_spatial->narrow({{0, idx2[r], 1}}));
     }
@@ -113,8 +113,8 @@ infinicore::Tensor Ernie4_5_VLResampler::forward(const infinicore::Tensor &x,
     tt = temporal_linear_2_->forward(tt);
     tt = temporal_linear_3_->forward(tt);
 
-    auto projected = mlp_->forward(tt);  // -> [num_merged_tokens, text_hidden_size]
-    return after_norm_->forward(projected);  // RMSNorm (HF uses RMSNorm here)
+    auto projected = mlp_->forward(tt);     // -> [num_merged_tokens, text_hidden_size]
+    return after_norm_->forward(projected); // RMSNorm (HF uses RMSNorm here)
 }
 
 } // namespace infinilm::models::ernie4_5_moe_vl

--- a/csrc/models/ernie4_5_moe_vl/ernie4_5_moe_vl_resampler.hpp
+++ b/csrc/models/ernie4_5_moe_vl/ernie4_5_moe_vl_resampler.hpp
@@ -1,0 +1,58 @@
+#pragma once
+
+#include "../../config/model_config.hpp"
+#include "infinicore/nn/layer_norm.hpp"
+#include "infinicore/nn/linear.hpp"
+#include "infinicore/nn/module.hpp"
+#include "infinicore/nn/rmsnorm.hpp"
+#include "infinicore/tensor.hpp"
+
+#include <memory>
+
+namespace infinilm::models::ernie4_5_moe_vl {
+
+// Multimodal adapter: VariableResolutionResamplerModel.
+// Merges variable-resolution vision patches into the text embedding space:
+//   - spatial merge: spatial_conv_size x spatial_conv_size (2x2) neighboring
+//     patches are concatenated  -> dim *= 4.
+//   - temporal merge (video): temporal_conv_size (2) frames are merged.
+//   - projection: -> text hidden_size (2560).
+// config: pixel_hidden_size 1280, spatial_conv_size 2, temporal_conv_size 2.
+//
+// Checkpoint layout under model.resampler_model.* (remapped to visual.merger.*):
+//   spatial_linear  : Sequential([0]Linear(5120,5120) -> [1]act -> [2]Linear(5120,5120) -> [3]LayerNorm(5120))
+//   temporal_linear : Sequential([0]Linear(10240,5120) -> [1]act -> [2]Linear(5120,5120) -> [3]LayerNorm(5120))
+//   mlp             : Linear(5120, 2560)
+//   after_norm      : RMSNorm(2560), weight-only (HF uses RMSNorm here, not LayerNorm)
+class Ernie4_5_VLResampler : public infinicore::nn::Module {
+public:
+    Ernie4_5_VLResampler(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+                         const infinicore::Device &device);
+
+    // x: vision features [num_patches, pixel_hidden_size].
+    // grid_thw: [num_media, 3] = (t, h, w) patch grid, drives the spatial/temporal
+    // merge bookkeeping. Returns [num_merged_tokens, text_hidden_size].
+    infinicore::Tensor forward(const infinicore::Tensor &x,
+                               const infinicore::Tensor &grid_thw) const;
+
+protected:
+    size_t pixel_hidden_size_{0};
+    size_t text_hidden_size_{0};
+    size_t spatial_conv_size_{0};
+    size_t temporal_conv_size_{0};
+
+    // spatial_linear Sequential members (registered as "spatial_linear.{0,2,3}")
+    std::shared_ptr<infinicore::nn::Linear> spatial_linear_0_;
+    std::shared_ptr<infinicore::nn::Linear> spatial_linear_2_;
+    std::shared_ptr<infinicore::nn::LayerNorm> spatial_linear_3_;
+
+    // temporal_linear Sequential members (registered as "temporal_linear.{0,2,3}")
+    std::shared_ptr<infinicore::nn::Linear> temporal_linear_0_;
+    std::shared_ptr<infinicore::nn::Linear> temporal_linear_2_;
+    std::shared_ptr<infinicore::nn::LayerNorm> temporal_linear_3_;
+
+    INFINICORE_NN_MODULE(infinicore::nn::Linear, mlp);
+    INFINICORE_NN_MODULE(infinicore::nn::RMSNorm, after_norm);
+};
+
+} // namespace infinilm::models::ernie4_5_moe_vl

--- a/csrc/models/ernie4_5_moe_vl/ernie4_5_moe_vl_text_model.cpp
+++ b/csrc/models/ernie4_5_moe_vl/ernie4_5_moe_vl_text_model.cpp
@@ -1,0 +1,77 @@
+#include "ernie4_5_moe_vl_text_model.hpp"
+
+#include "infinicore/context/context.hpp"
+#include "infinicore/ops.hpp"
+
+#include <cstdint>
+#include <vector>
+
+namespace infinilm::models::ernie4_5_moe_vl {
+
+Ernie4_5_VLMoeModel::Ernie4_5_VLMoeModel(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+                                         const infinicore::Device &device) {
+    const auto &dtype{model_config->get_dtype()};
+    size_t vocab_size = model_config->get<size_t>("vocab_size");
+    size_t hidden_size = model_config->get<size_t>("hidden_size");
+    size_t num_hidden_layers = model_config->get<size_t>("num_hidden_layers");
+    double rms_norm_eps = model_config->get<double>("rms_norm_eps");
+
+    embed_tokens_ = this->register_module<infinicore::nn::Embedding>(
+        "embed_tokens", vocab_size, hidden_size, std::nullopt, dtype, device);
+
+    layers_.reserve(num_hidden_layers);
+    for (size_t i = 0; i < num_hidden_layers; ++i) {
+        layers_.push_back(this->register_module<Ernie4_5_VLMoeDecoderLayer>(
+            "layers." + std::to_string(i), model_config, i, device));
+    }
+
+    norm_ = this->register_module<infinicore::nn::RMSNorm>("norm", hidden_size, rms_norm_eps, dtype, device);
+}
+
+infinicore::Tensor Ernie4_5_VLMoeModel::embed_tokens(const infinicore::Tensor &input_ids) const {
+    return embed_tokens_->forward(input_ids);
+}
+
+infinicore::Tensor Ernie4_5_VLMoeModel::forward(const infinilm::InfinilmModel::Input &input) const {
+    auto input_ids = input.input_ids.value();
+    auto positions = input.position_ids.value();
+    auto hidden_states = embed_tokens_->forward(input_ids);
+
+    // Text-only path: all tokens are text modality (token_type 0). Build the zero
+    // tensor explicitly on CPU then move to device -- Tensor::zeros(I64) on the MetaX
+    // backend does not reliably clear device memory, which left token_type garbage and
+    // routed every token through the vision experts/gate.
+    std::vector<int64_t> tt_zero(input_ids->numel(), 0);
+    auto token_type_ids = infinicore::Tensor::from_blob(
+                              tt_zero.data(), input_ids->shape(),
+                              infinicore::DataType::I64, infinicore::Device::cpu())
+                              ->to(hidden_states->device());
+
+    infinicore::Tensor residual;
+    for (size_t i = 0; i < layers_.size(); ++i) {
+        layers_.at(i)->forward(positions, hidden_states, residual, token_type_ids);
+        // Drain the command queue each layer. A large prefill (e.g. a video's 2448
+        // tokens through the MoE) otherwise piles up enough async work to deadlock
+        // the MetaX command queue; a per-layer sync keeps it bounded.
+        infinicore::context::syncStream();
+    }
+    norm_->forward_inplace(hidden_states, residual);
+    return hidden_states;
+}
+
+infinicore::Tensor Ernie4_5_VLMoeModel::forward_embeds(const infinicore::Tensor &inputs_embeds,
+                                                       const infinicore::Tensor &position_ids,
+                                                       const infinicore::Tensor &token_type_ids) const {
+    auto hidden_states = inputs_embeds;
+    infinicore::Tensor residual;
+    for (size_t i = 0; i < layers_.size(); ++i) {
+        layers_.at(i)->forward(position_ids, hidden_states, residual, token_type_ids);
+        // Per-layer command-queue drain (see forward()): a video's large prefill
+        // deadlocks the MetaX queue without it.
+        infinicore::context::syncStream();
+    }
+    norm_->forward_inplace(hidden_states, residual);
+    return hidden_states;
+}
+
+} // namespace infinilm::models::ernie4_5_moe_vl

--- a/csrc/models/ernie4_5_moe_vl/ernie4_5_moe_vl_text_model.hpp
+++ b/csrc/models/ernie4_5_moe_vl/ernie4_5_moe_vl_text_model.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "ernie4_5_moe_vl_decoder_layer.hpp"
+
+#include "../../config/model_config.hpp"
+#include "../infinilm_model.hpp"
+#include "infinicore/nn/embedding.hpp"
+#include "infinicore/nn/rmsnorm.hpp"
+#include "infinicore/tensor.hpp"
+
+#include <memory>
+#include <vector>
+
+namespace infinilm::models::ernie4_5_moe_vl {
+
+// Text backbone: token embedding + heterogeneous decoder layers + final RMSNorm.
+// Cannot reuse layers::causal_lm_templates::TextModel because the decoder layer
+// forward needs token_type_ids (for modality-specific MoE routing).
+class Ernie4_5_VLMoeModel : public infinicore::nn::Module {
+public:
+    Ernie4_5_VLMoeModel(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+                        const infinicore::Device &device);
+
+    // Standard text-only entry: derives token_type_ids = all-text.
+    infinicore::Tensor forward(const infinilm::InfinilmModel::Input &input) const;
+
+    // Multimodal entry: caller supplies merged embeddings + 3D position_ids +
+    // per-token modality ids (0=text, 1=vision).
+    infinicore::Tensor forward_embeds(const infinicore::Tensor &inputs_embeds,
+                                      const infinicore::Tensor &position_ids,
+                                      const infinicore::Tensor &token_type_ids) const;
+
+    infinicore::Tensor embed_tokens(const infinicore::Tensor &input_ids) const;
+
+protected:
+    INFINICORE_NN_MODULE(infinicore::nn::Embedding, embed_tokens);
+    INFINICORE_NN_MODULE_VEC(Ernie4_5_VLMoeDecoderLayer, layers);
+    INFINICORE_NN_MODULE(infinicore::nn::RMSNorm, norm);
+};
+
+} // namespace infinilm::models::ernie4_5_moe_vl

--- a/csrc/models/ernie4_5_moe_vl/ernie4_5_moe_vl_vision.cpp
+++ b/csrc/models/ernie4_5_moe_vl/ernie4_5_moe_vl_vision.cpp
@@ -29,7 +29,9 @@ infinicore::Tensor Ernie4_5_VisionPatchEmbed::forward(const infinicore::Tensor &
     // [num_patches, C, pH, pW] -> [num_patches, C*pH*pW] -> [num_patches, embed_dim]
     size_t num_patches = pixel_values->shape()[0];
     size_t flat_size = 1;
-    for (size_t i = 1; i < pixel_values->ndim(); ++i) flat_size *= pixel_values->shape()[i];
+    for (size_t i = 1; i < pixel_values->ndim(); ++i) {
+        flat_size *= pixel_values->shape()[i];
+    }
     auto flat = const_cast<infinicore::Tensor &>(pixel_values)->view({num_patches, flat_size});
     return proj_->forward(flat);
 }
@@ -62,7 +64,7 @@ infinicore::Tensor Ernie4_5_VisionAttention::forward(const infinicore::Tensor &h
     auto qkv_out = qkv_->forward(const_cast<infinicore::Tensor &>(hidden_states));
     auto qkv_view = qkv_out->view({num_patches, 3, num_heads_, head_dim_});
 
-    auto q = qkv_view->narrow({{1, 0, 1}})->squeeze(1)->contiguous();  // [N, H, D]
+    auto q = qkv_view->narrow({{1, 0, 1}})->squeeze(1)->contiguous(); // [N, H, D]
     auto k = qkv_view->narrow({{1, 1, 1}})->squeeze(1)->contiguous();
     auto v = qkv_view->narrow({{1, 2, 1}})->squeeze(1)->contiguous();
 
@@ -82,15 +84,15 @@ infinicore::Tensor Ernie4_5_VisionAttention::forward(const infinicore::Tensor &h
             continue;
         }
         size_t n = e - s;
-        auto qs = q->narrow({{0, s, n}})->permute({1, 0, 2})->contiguous();  // [H, n, D]
-        auto ks = k->narrow({{0, s, n}})->permute({1, 0, 2})->contiguous();  // [H, n, D]
-        auto vs = v->narrow({{0, s, n}})->permute({1, 0, 2})->contiguous();  // [H, n, D]
-        auto ks_t = ks->permute({0, 2, 1});                                  // [H, D, n]
+        auto qs = q->narrow({{0, s, n}})->permute({1, 0, 2})->contiguous(); // [H, n, D]
+        auto ks = k->narrow({{0, s, n}})->permute({1, 0, 2})->contiguous(); // [H, n, D]
+        auto vs = v->narrow({{0, s, n}})->permute({1, 0, 2})->contiguous(); // [H, n, D]
+        auto ks_t = ks->permute({0, 2, 1});                                 // [H, D, n]
 
-        auto scores = infinicore::op::matmul(qs, ks_t, scale_);              // [H, n, n]
-        auto probs = infinicore::op::softmax(scores, -1);                    // [H, n, n]
-        auto out_seg = infinicore::op::matmul(probs, vs);                    // [H, n, D]
-        out_seg = out_seg->permute({1, 0, 2})->contiguous();                 // [n, H, D]
+        auto scores = infinicore::op::matmul(qs, ks_t, scale_); // [H, n, n]
+        auto probs = infinicore::op::softmax(scores, -1);       // [H, n, n]
+        auto out_seg = infinicore::op::matmul(probs, vs);       // [H, n, D]
+        out_seg = out_seg->permute({1, 0, 2})->contiguous();    // [n, H, D]
         out->narrow({{0, s, n}})->copy_from(out_seg);
     }
 
@@ -221,8 +223,7 @@ Ernie4_5_VisionTransformer::build_rope_(const infinicore::Tensor &grid_thw,
     std::vector<float> cos_f(num_patches * cache_dim);
     for (size_t k = 0; k < half; ++k) {
         // VisionRotaryEmbedding inv_freq over dim=cache_dim: theta^(-2k/cache_dim).
-        float inv_freq = 1.0f / std::pow(static_cast<float>(rope_theta_vision_),
-                                         2.0f * static_cast<float>(k) / static_cast<float>(cache_dim));
+        float inv_freq = 1.0f / std::pow(static_cast<float>(rope_theta_vision_), 2.0f * static_cast<float>(k) / static_cast<float>(cache_dim));
         for (size_t i = 0; i < num_patches; ++i) {
             float ah = static_cast<float>(hpos[i]) * inv_freq; // first half: height
             float aw = static_cast<float>(wpos[i]) * inv_freq; // second half: width

--- a/csrc/models/ernie4_5_moe_vl/ernie4_5_moe_vl_vision.cpp
+++ b/csrc/models/ernie4_5_moe_vl/ernie4_5_moe_vl_vision.cpp
@@ -1,0 +1,327 @@
+#include "ernie4_5_moe_vl_vision.hpp"
+
+#include "../../utils.hpp"
+#include "infinicore/ops.hpp"
+
+#include <cmath>
+#include <stdexcept>
+#include <tuple>
+#include <vector>
+
+namespace infinilm::models::ernie4_5_moe_vl {
+
+// ---------------------------------------------------------------------------
+// Patch embedding (visual.patch_embed.*)
+// proj is nn::Linear([1280, 588]); input is flattened from [N, C, pH, pW].
+// ---------------------------------------------------------------------------
+Ernie4_5_VisionPatchEmbed::Ernie4_5_VisionPatchEmbed(const nlohmann::json &vision_config,
+                                                     const infinicore::DataType &dtype,
+                                                     const infinicore::Device &device) {
+    size_t in_channels = vision_config.value("in_channels", 3);
+    size_t embed_dim = vision_config.value("embed_dim", 1280);
+    size_t patch_size = vision_config.value("patch_size", 14);
+    size_t in_features = in_channels * patch_size * patch_size;
+    // Checkpoint has no patch_embed.proj.bias -> nn.Linear(bias=False).
+    INFINICORE_NN_MODULE_INIT(proj, in_features, embed_dim, false, dtype, device);
+}
+
+infinicore::Tensor Ernie4_5_VisionPatchEmbed::forward(const infinicore::Tensor &pixel_values) const {
+    // [num_patches, C, pH, pW] -> [num_patches, C*pH*pW] -> [num_patches, embed_dim]
+    size_t num_patches = pixel_values->shape()[0];
+    size_t flat_size = 1;
+    for (size_t i = 1; i < pixel_values->ndim(); ++i) flat_size *= pixel_values->shape()[i];
+    auto flat = const_cast<infinicore::Tensor &>(pixel_values)->view({num_patches, flat_size});
+    return proj_->forward(flat);
+}
+
+// ---------------------------------------------------------------------------
+// Attention (2D rope, block-diagonal over images)
+// ---------------------------------------------------------------------------
+Ernie4_5_VisionAttention::Ernie4_5_VisionAttention(const nlohmann::json &vision_config,
+                                                   const infinicore::DataType &dtype,
+                                                   const infinicore::Device &device)
+    : embed_dim_(vision_config.value("embed_dim", 1280)),
+      num_heads_(vision_config.value("num_heads", 16)),
+      head_dim_(embed_dim_ / num_heads_),
+      scale_(1.0f / std::sqrt(static_cast<float>(head_dim_))) {
+    INFINICORE_NN_MODULE_INIT(qkv, embed_dim_, embed_dim_ * 3, true, dtype, device);
+    INFINICORE_NN_MODULE_INIT(proj, embed_dim_, embed_dim_, true, dtype, device);
+}
+
+infinicore::Tensor Ernie4_5_VisionAttention::forward(const infinicore::Tensor &hidden_states,
+                                                     const infinicore::Tensor &sin_tbl,
+                                                     const infinicore::Tensor &cos_tbl,
+                                                     const infinicore::Tensor &pos_index,
+                                                     const std::vector<int64_t> &cu_seqlens) const {
+    // Input: hidden_states [num_patches, embed_dim] (batchless; cu_seqlens encodes
+    // per-frame segmentation). Output: [num_patches, embed_dim].
+    ASSERT(hidden_states->ndim() == 2);
+    size_t num_patches = hidden_states->shape()[0];
+
+    // Fused QKV projection: out [num_patches, embed_dim * 3].
+    auto qkv_out = qkv_->forward(const_cast<infinicore::Tensor &>(hidden_states));
+    auto qkv_view = qkv_out->view({num_patches, 3, num_heads_, head_dim_});
+
+    auto q = qkv_view->narrow({{1, 0, 1}})->squeeze(1)->contiguous();  // [N, H, D]
+    auto k = qkv_view->narrow({{1, 1, 1}})->squeeze(1)->contiguous();
+    auto v = qkv_view->narrow({{1, 2, 1}})->squeeze(1)->contiguous();
+
+    // 2D rope (NEOX rotate_half) over head_dim, per patch position. sin/cos tables
+    // already encode (height,width) coords in their two halves.
+    infinicore::op::rope_(q, q, pos_index, sin_tbl, cos_tbl, infinicore::nn::RoPE::Algo::GPT_NEOX);
+    infinicore::op::rope_(k, k, pos_index, sin_tbl, cos_tbl, infinicore::nn::RoPE::Algo::GPT_NEOX);
+
+    // Block-diagonal attention (attn_sep=true): scaled dot-product runs
+    // independently within each frame's patch span [s,e). A single image is one
+    // segment, so this reduces to plain full attention.
+    auto out = infinicore::Tensor::empty({num_patches, num_heads_, head_dim_}, q->dtype(), q->device());
+    for (size_t seg = 0; seg + 1 < cu_seqlens.size(); ++seg) {
+        size_t s = static_cast<size_t>(cu_seqlens[seg]);
+        size_t e = static_cast<size_t>(cu_seqlens[seg + 1]);
+        if (e <= s) {
+            continue;
+        }
+        size_t n = e - s;
+        auto qs = q->narrow({{0, s, n}})->permute({1, 0, 2})->contiguous();  // [H, n, D]
+        auto ks = k->narrow({{0, s, n}})->permute({1, 0, 2})->contiguous();  // [H, n, D]
+        auto vs = v->narrow({{0, s, n}})->permute({1, 0, 2})->contiguous();  // [H, n, D]
+        auto ks_t = ks->permute({0, 2, 1});                                  // [H, D, n]
+
+        auto scores = infinicore::op::matmul(qs, ks_t, scale_);              // [H, n, n]
+        auto probs = infinicore::op::softmax(scores, -1);                    // [H, n, n]
+        auto out_seg = infinicore::op::matmul(probs, vs);                    // [H, n, D]
+        out_seg = out_seg->permute({1, 0, 2})->contiguous();                 // [n, H, D]
+        out->narrow({{0, s, n}})->copy_from(out_seg);
+    }
+
+    auto out_flat = out->view({num_patches, embed_dim_});
+    return proj_->forward(out_flat);
+}
+
+// ---------------------------------------------------------------------------
+// MLP (quick_gelu)
+// ---------------------------------------------------------------------------
+Ernie4_5_VisionMLP::Ernie4_5_VisionMLP(const nlohmann::json &vision_config,
+                                       const infinicore::DataType &dtype,
+                                       const infinicore::Device &device) {
+    size_t embed_dim = vision_config.value("embed_dim", 1280);
+    size_t mlp_ratio = vision_config.value("mlp_ratio", 4);
+    size_t intermediate = embed_dim * mlp_ratio;
+    INFINICORE_NN_MODULE_INIT(fc1, embed_dim, intermediate, true, dtype, device);
+    INFINICORE_NN_MODULE_INIT(fc2, intermediate, embed_dim, true, dtype, device);
+}
+
+infinicore::Tensor Ernie4_5_VisionMLP::forward(const infinicore::Tensor &hidden_states) const {
+    auto x = fc1_->forward(const_cast<infinicore::Tensor &>(hidden_states));
+    // TODO(ernie-vl): quick_gelu(x) = x * sigmoid(1.702 * x). Confirm whether
+    // infinicore::op exposes quick_gelu directly; otherwise compose from sigmoid.
+    x = infinicore::op::quick_gelu(x);
+    return fc2_->forward(x);
+}
+
+// ---------------------------------------------------------------------------
+// Block
+// ---------------------------------------------------------------------------
+Ernie4_5_VisionBlock::Ernie4_5_VisionBlock(const nlohmann::json &vision_config,
+                                           const infinicore::DataType &dtype,
+                                           const infinicore::Device &device) {
+    size_t embed_dim = vision_config.value("embed_dim", 1280);
+    float layer_norm_eps = vision_config.value("layer_norm_eps", 1e-6f);
+    INFINICORE_NN_MODULE_INIT(norm1, embed_dim, layer_norm_eps, dtype, device);
+    INFINICORE_NN_MODULE_INIT(attn, vision_config, dtype, device);
+    INFINICORE_NN_MODULE_INIT(norm2, embed_dim, layer_norm_eps, dtype, device);
+    INFINICORE_NN_MODULE_INIT(mlp, vision_config, dtype, device);
+}
+
+infinicore::Tensor Ernie4_5_VisionBlock::forward(const infinicore::Tensor &hidden_states,
+                                                 const infinicore::Tensor &sin_tbl,
+                                                 const infinicore::Tensor &cos_tbl,
+                                                 const infinicore::Tensor &pos_index,
+                                                 const std::vector<int64_t> &cu_seqlens) const {
+    auto h = const_cast<infinicore::Tensor &>(hidden_states);
+    auto normed = norm1_->forward(h);
+    auto attn_out = attn_->forward(normed, sin_tbl, cos_tbl, pos_index, cu_seqlens);
+    h = infinicore::op::add(h, attn_out);
+
+    auto normed2 = norm2_->forward(h);
+    auto mlp_out = mlp_->forward(normed2);
+    return infinicore::op::add(h, mlp_out);
+}
+
+// ---------------------------------------------------------------------------
+// Transformer
+// ---------------------------------------------------------------------------
+Ernie4_5_VisionTransformer::Ernie4_5_VisionTransformer(
+    std::shared_ptr<infinilm::config::ModelConfig> model_config,
+    const infinicore::Device &device) {
+    const nlohmann::json &vision_config = model_config->get_config_json().at("vision_config");
+    const auto &dtype = model_config->get_dtype();
+
+    embed_dim_ = vision_config.value("embed_dim", 1280);
+    num_heads_ = vision_config.value("num_heads", 16);
+    head_dim_ = embed_dim_ / num_heads_;
+    spatial_merge_size_ = vision_config.value("spatial_merge_size", 2);
+    // VERIFY(GPU): vision 2D-rope base frequency; Qwen2-VL uses 10000. Confirm
+    // against HF DFNRope config (key may differ).
+    rope_theta_vision_ = vision_config.value("rope_theta", 10000.0);
+
+    INFINICORE_NN_MODULE_INIT(patch_embed, vision_config, dtype, device);
+
+    size_t depth = vision_config.value("depth", 32);
+    blocks_.reserve(depth);
+    for (size_t i = 0; i < depth; ++i) {
+        blocks_.push_back(this->register_module<Ernie4_5_VisionBlock>(
+            "blocks." + std::to_string(i), vision_config, dtype, device));
+    }
+
+    // Post-transformer LayerNorm (visual.norm1.*) applied before the merger.
+    float layer_norm_eps = vision_config.value("layer_norm_eps", 1e-6f);
+    INFINICORE_NN_MODULE_INIT(norm1, embed_dim_, layer_norm_eps, dtype, device);
+
+    // Adapter: registered as "merger" to match HF checkpoint prefix visual.merger.*
+    INFINICORE_NN_MODULE_INIT(merger, model_config, device);
+}
+
+std::tuple<infinicore::Tensor, infinicore::Tensor, infinicore::Tensor>
+Ernie4_5_VisionTransformer::build_rope_(const infinicore::Tensor &grid_thw,
+                                        const infinicore::DataType &dtype,
+                                        const infinicore::Device &device) const {
+    // grid_thw: [num_img, 3] = (t, h, w) in patch units (int64). For each patch
+    // compute its (h_coord, w_coord) in the merge-block order the processor emits:
+    // for each (hb, wb) block, the m*m patches in (mh, mw) order; coord = block*m+sub.
+    auto thw = grid_thw->to(infinicore::Device::cpu())->contiguous();
+    const auto *g = reinterpret_cast<const int64_t *>(thw->data());
+    size_t num_img = thw->shape()[0];
+    int64_t m = static_cast<int64_t>(spatial_merge_size_);
+
+    std::vector<int64_t> hpos;
+    std::vector<int64_t> wpos;
+    for (size_t im = 0; im < num_img; ++im) {
+        int64_t t = g[im * 3 + 0];
+        int64_t h = g[im * 3 + 1];
+        int64_t w = g[im * 3 + 2];
+        for (int64_t frame = 0; frame < t; ++frame) {
+            for (int64_t hb = 0; hb < h / m; ++hb) {
+                for (int64_t wb = 0; wb < w / m; ++wb) {
+                    for (int64_t mh = 0; mh < m; ++mh) {
+                        for (int64_t mw = 0; mw < m; ++mw) {
+                            hpos.push_back(hb * m + mh);
+                            wpos.push_back(wb * m + mw);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    size_t num_patches = hpos.size();
+
+    size_t cache_dim = head_dim_ / 2; // 40 for head_dim 80
+    size_t half = cache_dim / 2;      // 20 freqs per axis (height / width)
+    std::vector<float> sin_f(num_patches * cache_dim);
+    std::vector<float> cos_f(num_patches * cache_dim);
+    for (size_t k = 0; k < half; ++k) {
+        // VisionRotaryEmbedding inv_freq over dim=cache_dim: theta^(-2k/cache_dim).
+        float inv_freq = 1.0f / std::pow(static_cast<float>(rope_theta_vision_),
+                                         2.0f * static_cast<float>(k) / static_cast<float>(cache_dim));
+        for (size_t i = 0; i < num_patches; ++i) {
+            float ah = static_cast<float>(hpos[i]) * inv_freq; // first half: height
+            float aw = static_cast<float>(wpos[i]) * inv_freq; // second half: width
+            sin_f[i * cache_dim + k] = std::sin(ah);
+            cos_f[i * cache_dim + k] = std::cos(ah);
+            sin_f[i * cache_dim + half + k] = std::sin(aw);
+            cos_f[i * cache_dim + half + k] = std::cos(aw);
+        }
+    }
+
+    auto to_table = [&](const std::vector<float> &f) -> infinicore::Tensor {
+        auto out = infinicore::Tensor::empty({num_patches, cache_dim}, dtype, device);
+        if (dtype == infinicore::DataType::F32) {
+            auto cpu = infinicore::Tensor::from_blob(const_cast<float *>(f.data()), {num_patches, cache_dim},
+                                                     infinicore::DataType::F32, infinicore::Device::cpu());
+            out->copy_from(cpu);
+        } else if (dtype == infinicore::DataType::BF16) {
+            std::vector<uint16_t> hbuf(f.size());
+            for (size_t i = 0; i < f.size(); ++i) {
+                hbuf[i] = f32_to_bf16(f[i]);
+            }
+            auto cpu = infinicore::Tensor::from_blob(hbuf.data(), {num_patches, cache_dim},
+                                                     infinicore::DataType::BF16, infinicore::Device::cpu());
+            out->copy_from(cpu);
+        } else if (dtype == infinicore::DataType::F16) {
+            std::vector<uint16_t> hbuf(f.size());
+            for (size_t i = 0; i < f.size(); ++i) {
+                hbuf[i] = f32_to_f16(f[i]);
+            }
+            auto cpu = infinicore::Tensor::from_blob(hbuf.data(), {num_patches, cache_dim},
+                                                     infinicore::DataType::F16, infinicore::Device::cpu());
+            out->copy_from(cpu);
+        } else {
+            throw std::runtime_error("build_rope_: unsupported dtype for vision rope tables");
+        }
+        return out;
+    };
+
+    auto sin_tbl = to_table(sin_f);
+    auto cos_tbl = to_table(cos_f);
+
+    std::vector<int64_t> idx(num_patches);
+    for (size_t i = 0; i < num_patches; ++i) {
+        idx[i] = static_cast<int64_t>(i);
+    }
+    auto idx_cpu = infinicore::Tensor::from_blob(idx.data(), {num_patches}, infinicore::DataType::I64,
+                                                 infinicore::Device::cpu());
+    auto pos_index = idx_cpu->to(device);
+
+    return std::make_tuple(sin_tbl, cos_tbl, pos_index);
+}
+
+std::vector<int64_t>
+Ernie4_5_VisionTransformer::build_cu_seqlens_(const infinicore::Tensor &grid_thw) const {
+    // Per-frame attention segments (Qwen2-VL style): each frame's h*w patches form
+    // one block-diagonal segment. Boundaries are a cumulative sum [0, ...].
+    auto thw = grid_thw->to(infinicore::Device::cpu())->contiguous();
+    const auto *g = reinterpret_cast<const int64_t *>(thw->data());
+    size_t num_img = thw->shape()[0];
+
+    std::vector<int64_t> cu;
+    cu.push_back(0);
+    int64_t acc = 0;
+    for (size_t im = 0; im < num_img; ++im) {
+        int64_t t = g[im * 3 + 0];
+        int64_t h = g[im * 3 + 1];
+        int64_t w = g[im * 3 + 2];
+        for (int64_t frame = 0; frame < t; ++frame) {
+            acc += h * w;
+            cu.push_back(acc);
+        }
+    }
+    return cu;
+}
+
+infinicore::Tensor Ernie4_5_VisionTransformer::forward(const infinicore::Tensor &pixel_values,
+                                                       const infinicore::Tensor &grid_thw) const {
+    // pixel_values: [num_patches, in_channels, patch, patch] (NCHW per-patch view)
+    //   produced by the processor's patchify step.
+    // grid_thw: [num_images, 3] = (t, h_in_patches, w_in_patches), CPU side.
+    //
+    // Linear patch embedding: [num_patches, C*pH*pW] -> [num_patches, embed_dim].
+    auto patch_out = patch_embed_->forward(pixel_values);
+    ASSERT(patch_out->ndim() == 2);
+    auto hidden = patch_out;
+
+    // 2. 2D-rope tables + per-frame attention segments from the patch grid.
+    auto [sin_tbl, cos_tbl, pos_index] = build_rope_(grid_thw, hidden->dtype(), hidden->device());
+    auto cu_seqlens = build_cu_seqlens_(grid_thw);
+
+    for (size_t bi = 0; bi < blocks_.size(); ++bi) {
+        hidden = blocks_[bi]->forward(hidden, sin_tbl, cos_tbl, pos_index, cu_seqlens);
+    }
+
+    // 3. Post-transformer LayerNorm (visual.norm1).
+    hidden = norm1_->forward(hidden);
+
+    // 4. Spatial+temporal merge and projection -> [num_merged_tokens, text_hidden_size].
+    return merger_->forward(hidden, grid_thw);
+}
+
+} // namespace infinilm::models::ernie4_5_moe_vl

--- a/csrc/models/ernie4_5_moe_vl/ernie4_5_moe_vl_vision.hpp
+++ b/csrc/models/ernie4_5_moe_vl/ernie4_5_moe_vl_vision.hpp
@@ -1,0 +1,145 @@
+#pragma once
+
+#include "ernie4_5_moe_vl_resampler.hpp"
+
+#include "../../config/model_config.hpp"
+#include "infinicore/nn/layer_norm.hpp"
+#include "infinicore/nn/linear.hpp"
+#include "infinicore/nn/module.hpp"
+#include "infinicore/tensor.hpp"
+#include <nlohmann/json.hpp>
+
+#include <optional>
+#include <tuple>
+#include <vector>
+
+namespace infinilm::models::ernie4_5_moe_vl {
+
+// Vision tower: DFNRopeVisionTransformer.
+// config.vision_config: depth 32, embed_dim 1280, num_heads 16 (head_dim 80),
+// patch_size 14, spatial_merge_size 2, mlp_ratio 4, hidden_act "quick_gelu",
+// attn_sep true. Uses 2D rotary position embedding (NaViT-style, variable
+// resolution), not learned positional embeddings.
+
+// Linear patch embedding: flatten [num_patches, C, pH, pW] -> [num_patches, C*pH*pW],
+// then project via nn::Linear. Weight shape [embed_dim, in_channels*patch_size^2] = [1280, 588].
+// "proj" submodule matches checkpoint path visual.patch_embed.proj.{weight,bias}.
+class Ernie4_5_VisionPatchEmbed : public infinicore::nn::Module {
+public:
+    Ernie4_5_VisionPatchEmbed(const nlohmann::json &vision_config,
+                              const infinicore::DataType &dtype,
+                              const infinicore::Device &device);
+
+    infinicore::Tensor forward(const infinicore::Tensor &pixel_values) const;
+
+private:
+    INFINICORE_NN_MODULE(infinicore::nn::Linear, proj);
+};
+
+// Self-attention with 2D RoPE. qkv is a single fused projection.
+class Ernie4_5_VisionAttention : public infinicore::nn::Module {
+public:
+    Ernie4_5_VisionAttention(const nlohmann::json &vision_config,
+                             const infinicore::DataType &dtype,
+                             const infinicore::Device &device);
+
+    // sin_tbl/cos_tbl: precomputed 2D-rope tables [num_patches, head_dim/2].
+    // pos_index: [num_patches] arange selecting the table row per patch.
+    // cu_seqlens: per-image patch boundaries [num_img+1] for block-diagonal
+    // attention (attn_sep) — attention runs independently within each segment.
+    infinicore::Tensor forward(const infinicore::Tensor &hidden_states,
+                               const infinicore::Tensor &sin_tbl,
+                               const infinicore::Tensor &cos_tbl,
+                               const infinicore::Tensor &pos_index,
+                               const std::vector<int64_t> &cu_seqlens) const;
+
+private:
+    size_t embed_dim_;
+    size_t num_heads_;
+    size_t head_dim_;
+    float scale_;
+
+    INFINICORE_NN_MODULE(infinicore::nn::Linear, qkv);
+    INFINICORE_NN_MODULE(infinicore::nn::Linear, proj);
+};
+
+// MLP with quick_gelu: fc2(quick_gelu(fc1(x))), quick_gelu(x)=x*sigmoid(1.702*x).
+class Ernie4_5_VisionMLP : public infinicore::nn::Module {
+public:
+    Ernie4_5_VisionMLP(const nlohmann::json &vision_config,
+                       const infinicore::DataType &dtype,
+                       const infinicore::Device &device);
+
+    infinicore::Tensor forward(const infinicore::Tensor &hidden_states) const;
+
+private:
+    INFINICORE_NN_MODULE(infinicore::nn::Linear, fc1);
+    INFINICORE_NN_MODULE(infinicore::nn::Linear, fc2);
+};
+
+// One ViT block: norm1 -> attn -> residual -> norm2 -> mlp -> residual.
+class Ernie4_5_VisionBlock : public infinicore::nn::Module {
+public:
+    Ernie4_5_VisionBlock(const nlohmann::json &vision_config,
+                         const infinicore::DataType &dtype,
+                         const infinicore::Device &device);
+
+    infinicore::Tensor forward(const infinicore::Tensor &hidden_states,
+                               const infinicore::Tensor &sin_tbl,
+                               const infinicore::Tensor &cos_tbl,
+                               const infinicore::Tensor &pos_index,
+                               const std::vector<int64_t> &cu_seqlens) const;
+
+private:
+    INFINICORE_NN_MODULE(infinicore::nn::LayerNorm, norm1);
+    INFINICORE_NN_MODULE(Ernie4_5_VisionAttention, attn);
+    INFINICORE_NN_MODULE(infinicore::nn::LayerNorm, norm2);
+    INFINICORE_NN_MODULE(Ernie4_5_VisionMLP, mlp);
+};
+
+// Full vision transformer + adapter. Registered as "visual" in the top-level
+// model to match the HF checkpoint prefix. Includes:
+//   - patch embedding (visual.patch_embed.*)
+//   - 32 ViT blocks (visual.blocks.*)
+//   - VariableResolutionResampler adapter (visual.merger.*)
+// Output: merged tokens [num_merged, text_hidden_size] ready for cross-modal fusion.
+class Ernie4_5_VisionTransformer : public infinicore::nn::Module {
+public:
+    // Takes full model_config so both vision_config and text hidden_size
+    // (needed by the merger projection) are accessible.
+    Ernie4_5_VisionTransformer(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+                               const infinicore::Device &device);
+
+    // pixel_values: flattened patches [num_patches, C, p, p];
+    // grid_thw: [num_media, 3] = (t, h, w) in patch units.
+    // Returns [num_merged_tokens, text_hidden_size].
+    infinicore::Tensor forward(const infinicore::Tensor &pixel_values,
+                               const infinicore::Tensor &grid_thw) const;
+
+private:
+    // Build DFNRope 2D-rope tables [num_patches, head_dim/2] (height freqs ++ width
+    // freqs) and a [num_patches] arange index. Each patch's (h,w) grid coordinate
+    // drives the two halves; reused via op::rope (NEOX rotate_half).
+    std::tuple<infinicore::Tensor, infinicore::Tensor, infinicore::Tensor>
+    build_rope_(const infinicore::Tensor &grid_thw,
+                const infinicore::DataType &dtype,
+                const infinicore::Device &device) const;
+
+    // Per-image patch boundaries [num_img+1] (host) for block-diagonal attention.
+    std::vector<int64_t> build_cu_seqlens_(const infinicore::Tensor &grid_thw) const;
+
+    size_t embed_dim_;
+    size_t num_heads_;
+    size_t head_dim_;
+    size_t spatial_merge_size_;
+    double rope_theta_vision_{10000.0};
+
+    INFINICORE_NN_MODULE(Ernie4_5_VisionPatchEmbed, patch_embed);
+    INFINICORE_NN_MODULE_VEC(Ernie4_5_VisionBlock, blocks);
+    // Post-transformer LayerNorm: visual.norm1.weight / visual.norm1.bias
+    INFINICORE_NN_MODULE(infinicore::nn::LayerNorm, norm1);
+    // Registered as "merger" to match HF: visual.merger.*
+    INFINICORE_NN_MODULE(Ernie4_5_VLResampler, merger);
+};
+
+} // namespace infinilm::models::ernie4_5_moe_vl

--- a/python/infinilm/modeling_utils.py
+++ b/python/infinilm/modeling_utils.py
@@ -709,11 +709,11 @@ def _remap_ernie4_5_vl(state_dict, config=None):
     """Remap ERNIE-4.5-VL model weights to InfiniLM format.
     Handle MoE gate weight transpose, dtype conversion, and parameter name mapping issues."""
     import torch
-    
+
     result = {}
     for key, tensor in state_dict.items():
         new_key = key  # 默认保持键不变
-        
+
         # Handle MoE gate weight transpose issue. Checkpoint stores the gate as
         # [hidden, num_experts]; InfiniLM's op::linear expects [num_experts, hidden].
         # NOTE: .t() returns a non-contiguous (stride-swapped) view; from_torch reads
@@ -727,15 +727,17 @@ def _remap_ernie4_5_vl(state_dict, config=None):
             # Ensure consistent dtype (convert to bfloat16 as expected by the model)
             if tensor.dtype != torch.bfloat16:
                 tensor = tensor.to(torch.bfloat16)
-        
+
         # Vision encoder: map vision_model.* to visual.* (C++ registration name)
         # and its layer-norm submodule names to norm1/norm2. Other submodule names
         # (attn/qkv/proj/mlp/fc1/fc2) already match, so they pass through unchanged.
         elif key.startswith("vision_model."):
-            new_key = (key.replace("vision_model.", "visual.")
-                          .replace(".ln_1.", ".norm1.")   # LayerNorm in attention block
-                          .replace(".ln_2.", ".norm2.")   # LayerNorm in mlp block
-                          .replace(".ln.", ".norm1."))     # general layer-norm fallback
+            new_key = (
+                key.replace("vision_model.", "visual.")
+                .replace(".ln_1.", ".norm1.")  # LayerNorm in attention block
+                .replace(".ln_2.", ".norm2.")  # LayerNorm in mlp block
+                .replace(".ln.", ".norm1.")
+            )  # general layer-norm fallback
 
         # Map resampler (lives under model.resampler_model.* in HF) -> visual.merger.*
         elif key.startswith("model.resampler_model."):
@@ -747,13 +749,13 @@ def _remap_ernie4_5_vl(state_dict, config=None):
         # Standard dtype handling for tensors that need dtype conversion
         if tensor.dtype == torch.float32:
             # Check if this is a weight or bias that should be converted to bfloat16
-            if new_key.endswith(('.weight', '.bias')):
+            if new_key.endswith((".weight", ".bias")):
                 # Convert to expected dtype if needed
                 if config and config.get("torch_dtype") == "bfloat16":
                     tensor = tensor.to(torch.bfloat16)
-                elif hasattr(config, 'get') and config.get('dtype') == 'bfloat16':
+                elif hasattr(config, "get") and config.get("dtype") == "bfloat16":
                     tensor = tensor.to(torch.bfloat16)
-        
+
         result[new_key] = tensor
 
     # after_norm in the ERNIE-4.5-VL resampler is an RMSNorm (weight-only) in the
@@ -809,5 +811,4 @@ _WEIGHT_REMAPPER = {
     "videonsa": _remap_videonsa,
     "qwen3_5": _remap_qwen3_5,
     "ernie4_5_moe_vl": _remap_ernie4_5_vl,  # Add ERNIE-4.5-VL mapping
-}
 }

--- a/python/infinilm/modeling_utils.py
+++ b/python/infinilm/modeling_utils.py
@@ -705,6 +705,63 @@ def _remap_videonsa(state_dict, config=None):
     return state_dict
 
 
+def _remap_ernie4_5_vl(state_dict, config=None):
+    """Remap ERNIE-4.5-VL model weights to InfiniLM format.
+    Handle MoE gate weight transpose, dtype conversion, and parameter name mapping issues."""
+    import torch
+    
+    result = {}
+    for key, tensor in state_dict.items():
+        new_key = key  # 默认保持键不变
+        
+        # Handle MoE gate weight transpose issue. Checkpoint stores the gate as
+        # [hidden, num_experts]; InfiniLM's op::linear expects [num_experts, hidden].
+        # NOTE: .t() returns a non-contiguous (stride-swapped) view; from_torch reads
+        # the raw contiguous buffer, so it MUST be materialized with .contiguous() or
+        # the weight is loaded scrambled (routing then picks the wrong experts).
+        if ".mlp.gate.weight" in key:
+            expected_shape = tensor.shape
+            if expected_shape[0] > expected_shape[1]:  # e.g., [2560, 64] -> [64, 2560]
+                tensor = tensor.t().contiguous()
+
+            # Ensure consistent dtype (convert to bfloat16 as expected by the model)
+            if tensor.dtype != torch.bfloat16:
+                tensor = tensor.to(torch.bfloat16)
+        
+        # Vision encoder: map vision_model.* to visual.* (C++ registration name)
+        # and its layer-norm submodule names to norm1/norm2. Other submodule names
+        # (attn/qkv/proj/mlp/fc1/fc2) already match, so they pass through unchanged.
+        elif key.startswith("vision_model."):
+            new_key = (key.replace("vision_model.", "visual.")
+                          .replace(".ln_1.", ".norm1.")   # LayerNorm in attention block
+                          .replace(".ln_2.", ".norm2.")   # LayerNorm in mlp block
+                          .replace(".ln.", ".norm1."))     # general layer-norm fallback
+
+        # Map resampler (lives under model.resampler_model.* in HF) -> visual.merger.*
+        elif key.startswith("model.resampler_model."):
+            new_key = key.replace("model.resampler_model.", "visual.merger.", 1)
+
+        # Text model (language_model.* / model.*) submodule names already match
+        # InfiniLM, so new_key stays equal to key (handled by the default above).
+
+        # Standard dtype handling for tensors that need dtype conversion
+        if tensor.dtype == torch.float32:
+            # Check if this is a weight or bias that should be converted to bfloat16
+            if new_key.endswith(('.weight', '.bias')):
+                # Convert to expected dtype if needed
+                if config and config.get("torch_dtype") == "bfloat16":
+                    tensor = tensor.to(torch.bfloat16)
+                elif hasattr(config, 'get') and config.get('dtype') == 'bfloat16':
+                    tensor = tensor.to(torch.bfloat16)
+        
+        result[new_key] = tensor
+
+    # after_norm in the ERNIE-4.5-VL resampler is an RMSNorm (weight-only) in the
+    # checkpoint -- it maps directly to infinicore::nn::RMSNorm, no bias needed.
+
+    return result
+
+
 # Model type → remap function mapping
 def _remap_qwen3_5(state_dict, config):
     """Apply Qwen3.5-specific load-time weight fixes."""
@@ -751,4 +808,6 @@ _WEIGHT_REMAPPER = {
     "mamba": _remap_mamba,
     "videonsa": _remap_videonsa,
     "qwen3_5": _remap_qwen3_5,
+    "ernie4_5_moe_vl": _remap_ernie4_5_vl,  # Add ERNIE-4.5-VL mapping
+}
 }

--- a/python/infinilm/multimodal/multimodal.py
+++ b/python/infinilm/multimodal/multimodal.py
@@ -1,4 +1,5 @@
 from typing import List, Union
+
 from PIL import Image
 
 

--- a/python/infinilm/multimodal/multimodal.py
+++ b/python/infinilm/multimodal/multimodal.py
@@ -52,8 +52,14 @@ def resolve_multimodal_inputs(messages: Union[List[dict], dict]):
                     video_urls.append(
                         f"predecoded_video:{len(video_urls)}:{len(video)}"
                     )
+            elif item.get("type") == "video":
+                # Pass the source path through; the processor decodes, samples
+                # frames, burns timestamps, and patchifies (see
+                # Ernie4_5_VLMoeProcessor._decode_and_sample_frames).
+                videos.append(item["video_url"])
+
             else:  # TODO support audio
-                raise NotImplementedError("Only image/video input is supported for now")
+                raise NotImplementedError("Only image and video inputs are supported")
 
     return {
         "images": images,

--- a/python/infinilm/processors/ernie4_5_moe_vl_processor.py
+++ b/python/infinilm/processors/ernie4_5_moe_vl_processor.py
@@ -209,7 +209,11 @@ class Ernie4_5_VLMoeProcessor(BasicLLMProcessor):
         images = list(images or [])
         videos = list(videos or [])
         pattern = re.compile(
-            "(" + re.escape(self.IMAGE_SENTINEL) + "|" + re.escape(self.VIDEO_SENTINEL) + ")"
+            "("
+            + re.escape(self.IMAGE_SENTINEL)
+            + "|"
+            + re.escape(self.VIDEO_SENTINEL)
+            + ")"
         )
         ids = []
         pixel_list = []
@@ -350,9 +354,7 @@ class Ernie4_5_VLMoeProcessor(BasicLLMProcessor):
         arr = (arr - mean) / std
         return arr.transpose(2, 0, 1)  # HWC -> CHW
 
-    _FONT_URL = (
-        "https://paddlenlp.bj.bcebos.com/vision-language-models/materials/Roboto-Regular.ttf"
-    )
+    _FONT_URL = "https://paddlenlp.bj.bcebos.com/vision-language-models/materials/Roboto-Regular.ttf"
 
     def _font_path(self):
         """Path to Roboto-Regular.ttf (the font HF burns timestamps with). Cached
@@ -401,7 +403,9 @@ class Ernie4_5_VLMoeProcessor(BasicLLMProcessor):
         if target_frames > 0:
             acc = min(target_frames, vlen)
             intervals = np.linspace(0, vlen, acc + 1).astype(int)
-            return [int(intervals[i]) for i in range(acc)]  # leading = interval left edge
+            return [
+                int(intervals[i]) for i in range(acc)
+            ]  # leading = interval left edge
         delta = 1.0 / target_fps
         duration = float(vlen) / input_fps
         frame_seconds = np.arange(0, duration, delta)
@@ -459,7 +463,9 @@ class Ernie4_5_VLMoeProcessor(BasicLLMProcessor):
         t = len(frames)
         w0, h0 = frames[0].size  # PIL size is (W, H)
         factor = self.patch_size * self.spatial_merge_size
-        rh, rw = smart_resize(h0, w0, factor, self.video_min_pixels, self.video_max_pixels)
+        rh, rw = smart_resize(
+            h0, w0, factor, self.video_min_pixels, self.video_max_pixels
+        )
         ph, pw = rh // self.patch_size, rw // self.patch_size
 
         patch_list = []
@@ -555,9 +561,15 @@ class Ernie4_5_VLMoeProcessor(BasicLLMProcessor):
             # from_numpy (not from_list(.tolist())): a video has ~19200*588 = 11.3M
             # elements, and materializing that as a nested Python list is slow and
             # memory-heavy for no benefit (from_list just rebuilds a numpy array).
-            pv2d = np.ascontiguousarray(pi["pixel_values"]).reshape(pi["pixel_values"].shape[0], -1)
-            base["pixel_values"] = infinicore.from_numpy(pv2d, dtype=self._infini_dtype())
-            base["tgt_sizes"] = infinicore.from_list(grid_thw.tolist(), dtype=infinicore.int64)
+            pv2d = np.ascontiguousarray(pi["pixel_values"]).reshape(
+                pi["pixel_values"].shape[0], -1
+            )
+            base["pixel_values"] = infinicore.from_numpy(
+                pv2d, dtype=self._infini_dtype()
+            )
+            base["tgt_sizes"] = infinicore.from_list(
+                grid_thw.tolist(), dtype=infinicore.int64
+            )
         else:
             pos = req.get_total_length() - 1
             pos_slice = [[row[pos]] for row in pos3d]

--- a/python/infinilm/processors/ernie4_5_moe_vl_processor.py
+++ b/python/infinilm/processors/ernie4_5_moe_vl_processor.py
@@ -1,0 +1,578 @@
+"""Processor for ERNIE-4.5-VL-28B-A3B (model_type: ernie4_5_moe_vl).
+
+Handles the three input modalities required by the task:
+  1. text -> text
+  2. image + text -> text
+  3. video + text -> text
+
+Inherits from BasicLLMProcessor for the text-only path (build_model_inputs,
+tokenization, chat template defaults). Multimodal extensions are layered on top.
+
+NOTE on third-party deps: the tokenizer is loaded via transformers.AutoTokenizer
+(a standard component, same as BasicLLMProcessor). The multimodal *adaptation*
+logic (patchify, placeholder expansion, 3D/mrope position ids) must be implemented
+here and must NOT call into a third-party model's forward/processing internals;
+transformers may only be used as a reference in the correctness test.
+"""
+
+import json
+import os
+from typing import Optional
+
+from .basic_llm_processor import BasicLLMProcessor
+from .processor import register_processor
+
+
+def _conversation_is_text_only(conversation) -> bool:
+    """Return True if no message contains a non-text content item."""
+    for message in conversation:
+        content = message.get("content")
+        if isinstance(content, list):
+            for item in content:
+                # Anything other than {"type": "text", ...} is multimodal.
+                if isinstance(item, dict) and item.get("type", "text") != "text":
+                    return False
+    return True
+
+
+# ----------------------------------------------------------------------
+# Geometry / timestamp helpers -- byte-for-byte mirrors of the HF processor
+# (processing_ernie4_5_vl.py) so our independent pipeline lands on the same
+# grid_thw, placeholder counts, and burned-in timestamp pixels.
+# ----------------------------------------------------------------------
+def _round_by_factor(number, factor):
+    return round(number / factor) * factor
+
+
+def _floor_by_factor(number, factor):
+    import math
+
+    return math.floor(number / factor) * factor
+
+
+def _ceil_by_factor(number, factor):
+    import math
+
+    return math.ceil(number / factor) * factor
+
+
+def smart_resize(height, width, factor, min_pixels, max_pixels):
+    """Round H/W to a multiple of `factor` while keeping H*W within
+    [min_pixels, max_pixels] and the aspect ratio as close as possible.
+    Returns (h_bar, w_bar), both multiples of factor."""
+    import math
+
+    MAX_RATIO = 200
+    if max(height, width) / min(height, width) > MAX_RATIO:
+        if height > width:
+            new_width = max(factor, _round_by_factor(width, factor))
+            new_height = _floor_by_factor(new_width * MAX_RATIO, factor)
+        else:
+            new_height = max(factor, _round_by_factor(height, factor))
+            new_width = _floor_by_factor(new_height * MAX_RATIO, factor)
+        height, width = new_height, new_width
+
+    h_bar = max(factor, _round_by_factor(height, factor))
+    w_bar = max(factor, _round_by_factor(width, factor))
+    if h_bar * w_bar > max_pixels:
+        beta = math.sqrt((height * width) / max_pixels)
+        h_bar = _floor_by_factor(height / beta, factor)
+        w_bar = _floor_by_factor(width / beta, factor)
+    elif h_bar * w_bar < min_pixels:
+        beta = math.sqrt(min_pixels / (height * width))
+        h_bar = _ceil_by_factor(height * beta, factor)
+        w_bar = _ceil_by_factor(width * beta, factor)
+    return h_bar, w_bar
+
+
+def _timestamp_converting(t):
+    """seconds -> 'HH:MM:SS.ss' (mirror of HF timestamp_converting)."""
+    hours = 0
+    while t >= 3600:
+        hours += 1
+        t -= 3600
+    mins = 0
+    while t >= 60:
+        mins += 1
+        t -= 60
+    return f"{int(hours):02d}:{int(mins):02d}:{t:05.02f}"
+
+
+@register_processor("ernie4_5_moe_vl")
+class Ernie4_5_VLMoeProcessor(BasicLLMProcessor):
+    def __init__(self, model_dir_path: str):
+        # Tokenizer setup via parent (transformers AutoTokenizer with trust_remote_code).
+        # Uses the Ernie4_5_VLTokenizer class declared in tokenizer_config.json's
+        # auto_map, defined in processing_ernie4_5_vl.py in the model dir.
+        super().__init__(model_dir_path)
+
+        with open(os.path.join(model_dir_path, "config.json")) as f:
+            cfg = json.load(f)
+
+        # Model compute dtype (pixel_values must match the vision weights).
+        self._config_dtype = cfg.get("torch_dtype", "bfloat16")
+
+        # Special token ids for vision placeholders / span markers.
+        self.im_patch_id = cfg.get("im_patch_id", 100295)
+        self.image_start_token_id = cfg.get("image_start_token_id", 101304)
+        self.image_end_token_id = cfg.get("image_end_token_id", 101305)
+        self.video_start_token_id = cfg.get("video_start_token_id", 101306)
+        self.video_end_token_id = cfg.get("video_end_token_id", 101307)
+
+        # Vision / resampler geometry.
+        vision_cfg = cfg.get("vision_config", {})
+        self.patch_size = vision_cfg.get("patch_size", 14)
+        self.spatial_merge_size = vision_cfg.get("spatial_merge_size", 2)
+        self.temporal_conv_size = cfg.get("temporal_conv_size", 2)
+        self.spatial_conv_size = cfg.get("spatial_conv_size", 2)
+
+        # Video frame-sampling + pixel-budget config. Mirrors the HF processor
+        # (processing_ernie4_5_vl.py) defaults; read from preprocessor_config.json
+        # when present, else fall back to the shipped defaults.
+        pp = {}
+        pp_path = os.path.join(model_dir_path, "preprocessor_config.json")
+        if os.path.exists(pp_path):
+            with open(pp_path) as f:
+                pp = json.load(f)
+        self.video_fps = pp.get("fps", 2)
+        self.video_min_frames = pp.get("min_frames", 16)
+        self.video_max_frames = pp.get("max_frames", 180)
+        self.video_min_pixels = pp.get("video_min_pixels", 234416)
+        self.video_max_pixels = pp.get("video_max_pixels", 937664)
+
+    # Placeholder markers the tokenizer chat template emits for each media item
+    # (its render_content macro renders " Picture N:<|IMAGE_START|><|image@placeholder
+    # |><|IMAGE_END|>" / the video equivalent). __call__ splits the rendered prompt on
+    # these and splices the per-image patch-placeholder token run in their place.
+    IMAGE_SENTINEL = "<|IMAGE_START|><|image@placeholder|><|IMAGE_END|>"
+    VIDEO_SENTINEL = "<|VIDEO_START|><|video@placeholder|><|VIDEO_END|>"
+
+    # ------------------------------------------------------------------
+    # Chat template: defer to the tokenizer's template for BOTH text and multimodal.
+    # The template's render_content macro turns image/video content items into the
+    # markers above (with the "Picture N:" / "Video N:" prefixes ERNIE was trained
+    # with), so we pass the conversation through unchanged -- flattening it to a
+    # custom sentinel string (the previous approach) bypassed that macro and dropped
+    # the "Picture N:" prefix, which corrupted the multimodal prompt. __call__ then
+    # expands each marker into image_start + im_patch * N + image_end token ids.
+    # tokenize=False: the LLM pipeline tokenizes via __call__.
+    # ------------------------------------------------------------------
+    def apply_chat_template(
+        self,
+        conversation,
+        add_generation_prompt: bool = False,
+        tokenize: bool = True,
+        **kwargs,
+    ):
+        if _conversation_is_text_only(conversation):
+            return super().apply_chat_template(
+                conversation,
+                add_generation_prompt=add_generation_prompt,
+                tokenize=tokenize,
+                **kwargs,
+            )
+
+        return self.tokenizer.apply_chat_template(
+            conversation=conversation,
+            add_generation_prompt=add_generation_prompt,
+            tokenize=False,
+            **kwargs,
+        )
+
+    # ------------------------------------------------------------------
+    # Text-only entry: defer to BasicLLMProcessor.__call__ unless multimodal.
+    # ------------------------------------------------------------------
+    def __call__(
+        self,
+        prompt: str,
+        images: Optional[list] = None,
+        videos: Optional[list] = None,
+        audios: Optional[list] = None,
+        return_tensors: str = None,
+        **kwargs,
+    ) -> dict:
+        # Pure text path — same as BasicLLMProcessor (drives the text correctness test).
+        if not images and not videos:
+            return super().__call__(prompt, return_tensors=return_tensors, **kwargs)
+
+        # Multimodal path: walk the rendered prompt in order, replacing each
+        # image/video sentinel with its start + im_patch*N + end run and appending
+        # that media's patches + grid row. Ordering media by sentinel position keeps
+        # grid_thw / pixel_values in the same order the C++ tower + resampler +
+        # merge_vision_embeddings consume them (they scatter vision tokens onto the
+        # im_patch positions left-to-right). Image and video both use im_patch_id as
+        # the placeholder (HF video_patch_id falls back to image_patch_id).
+        import re
+
+        import numpy as np
+
+        images = list(images or [])
+        videos = list(videos or [])
+        pattern = re.compile(
+            "(" + re.escape(self.IMAGE_SENTINEL) + "|" + re.escape(self.VIDEO_SENTINEL) + ")"
+        )
+        ids = []
+        pixel_list = []
+        grid_list = []
+        img_i = vid_i = 0
+        for part in pattern.split(prompt):
+            if part == self.IMAGE_SENTINEL:
+                patches, grid, count = self._preprocess_one_image(images[img_i])
+                img_i += 1
+                pixel_list.append(patches)
+                grid_list.append(grid)
+                ids.append(self.image_start_token_id)
+                ids.extend([self.im_patch_id] * count)
+                ids.append(self.image_end_token_id)
+            elif part == self.VIDEO_SENTINEL:
+                patches, grid, count = self._preprocess_one_video(videos[vid_i])
+                vid_i += 1
+                pixel_list.append(patches)
+                grid_list.append(grid)
+                ids.append(self.video_start_token_id)
+                ids.extend([self.im_patch_id] * count)
+                ids.append(self.video_end_token_id)
+            elif part:
+                ids.extend(self.tokenizer(part, add_special_tokens=False)["input_ids"])
+
+        if img_i != len(images) or vid_i != len(videos):
+            raise ValueError(
+                f"sentinel/media mismatch: images {img_i}/{len(images)}, "
+                f"videos {vid_i}/{len(videos)}"
+            )
+
+        return {
+            "input_ids": self._wrap_input_ids(ids, return_tensors),
+            "pixel_values": np.concatenate(pixel_list, axis=0),
+            "grid_thw": np.asarray(grid_list, dtype=np.int64),
+        }
+
+    def _preprocess_one_image(self, image_input):
+        """Normalize + patchify a single image. Returns (patches [n,3,p,p],
+        grid_row [1,h,w], placeholder_count). count = (h*w)//spatial_block is the
+        number of vision tokens the resampler emits for a t==1 media, so the C++
+        merge_vision_embeddings scatters them 1:1 onto the im_patch positions."""
+        block = self.spatial_conv_size * self.spatial_conv_size
+        pil = self._load_image(image_input)
+        chw = self._normalize_image(pil)
+        patches, h, w = self._patchify_frame(chw)
+        return patches, [1, h, w], (h * w) // block
+
+    @staticmethod
+    def _wrap_input_ids(ids, return_tensors):
+        if return_tensors == "pt":
+            import torch
+
+            return torch.tensor([ids], dtype=torch.long)
+        return ids
+
+    # ------------------------------------------------------------------
+    # Multimodal preprocessing.
+    # ------------------------------------------------------------------
+    # CLIP-style normalization (used by most large vision encoders, including
+    # ERNIE-VL's DFNRope ViT). Confirm against the checkpoint's preprocessor_config
+    # if accuracy is off.
+    _IMAGE_MEAN = (0.48145466, 0.4578275, 0.40821073)
+    _IMAGE_STD = (0.26862954, 0.26130258, 0.27577711)
+
+    def _patchify_frame(self, np_chw):
+        """Take a [3, H, W] float32 array (already normalized) and emit
+        patches in spatial-merge-friendly order along with the patch grid.
+
+        Returns: (patches [num_patches, 3, patch, patch], h_grid, w_grid).
+        The patches are laid out so every spatial_merge x spatial_merge block
+        of consecutive entries forms one 2x2 spatial group — matches the
+        resampler's view() contract.
+        """
+        import numpy as np
+
+        _, H, W = np_chw.shape
+        p = self.patch_size
+        m = self.spatial_merge_size
+        assert H % (p * m) == 0 and W % (p * m) == 0, (
+            f"image size {(H, W)} must be a multiple of patch*merge={p * m}"
+        )
+
+        h = H // p
+        w = W // p
+        # [3, h*p, w*p] -> [3, h, p, w, p] -> [h, w, 3, p, p]
+        x = np_chw.reshape(3, h, p, w, p).transpose(1, 3, 0, 2, 4)
+        # Group neighbouring 2x2 patches: [h/m, m, w/m, m, 3, p, p]
+        x = x.reshape(h // m, m, w // m, m, 3, p, p)
+        # Reorder so each spatial group is contiguous: [h/m, w/m, m, m, 3, p, p]
+        x = x.transpose(0, 2, 1, 3, 4, 5, 6)
+        # Flatten: [num_patches, 3, p, p]
+        patches = x.reshape(-1, 3, p, p).astype(np.float32, copy=False)
+        return patches, h, w
+
+    def _load_image(self, image_input):
+        from PIL import Image
+
+        if isinstance(image_input, str):
+            return Image.open(image_input).convert("RGB")
+        if isinstance(image_input, Image.Image):
+            return image_input.convert("RGB")
+        raise ValueError(f"Unsupported image input type: {type(image_input)}")
+
+    def _normalize_image(self, pil_img):
+        """Resize to a multiple of patch*spatial_merge, normalize, return [3,H,W]."""
+        import numpy as np
+        from PIL import Image
+
+        cell = self.patch_size * self.spatial_merge_size
+        W, H = pil_img.size
+        # Round up to the next cell boundary; the vision tower handles variable
+        # resolution so we don't need a fixed canonical size.
+        new_W = max(((W + cell - 1) // cell) * cell, cell)
+        new_H = max(((H + cell - 1) // cell) * cell, cell)
+        if (new_W, new_H) != (W, H):
+            pil_img = pil_img.resize((new_W, new_H), Image.BICUBIC)
+
+        arr = np.asarray(pil_img, dtype=np.float32) / 255.0
+        mean = np.array(self._IMAGE_MEAN, dtype=np.float32).reshape(1, 1, 3)
+        std = np.array(self._IMAGE_STD, dtype=np.float32).reshape(1, 1, 3)
+        arr = (arr - mean) / std
+        return arr.transpose(2, 0, 1)  # HWC -> CHW
+
+    def _frame_to_chw(self, pil_img, target_h, target_w):
+        """Resize a PIL frame to (target_h, target_w) and CLIP-normalize to
+        [3,H,W]. Same normalization as _normalize_image, but the target size comes
+        from smart_resize (video) rather than round-up-to-cell."""
+        import numpy as np
+        from PIL import Image
+
+        pil_img = pil_img.convert("RGB")
+        if pil_img.size != (target_w, target_h):
+            pil_img = pil_img.resize((target_w, target_h), Image.BICUBIC)
+        arr = np.asarray(pil_img, dtype=np.float32) / 255.0
+        mean = np.array(self._IMAGE_MEAN, dtype=np.float32).reshape(1, 1, 3)
+        std = np.array(self._IMAGE_STD, dtype=np.float32).reshape(1, 1, 3)
+        arr = (arr - mean) / std
+        return arr.transpose(2, 0, 1)  # HWC -> CHW
+
+    _FONT_URL = (
+        "https://paddlenlp.bj.bcebos.com/vision-language-models/materials/Roboto-Regular.ttf"
+    )
+
+    def _font_path(self):
+        """Path to Roboto-Regular.ttf (the font HF burns timestamps with). Cached
+        next to this module; downloaded from the same source on first use so the
+        rendered glyphs are pixel-identical to HF's render_frame_timestamp."""
+        path = os.path.join(os.path.dirname(__file__), "Roboto-Regular.ttf")
+        if not os.path.exists(path):
+            import requests
+
+            resp = requests.get(self._FONT_URL)
+            resp.raise_for_status()
+            with open(path, "wb") as f:
+                f.write(resp.content)
+        return path
+
+    def _render_timestamp(self, pil_img, timestamp, font_rate=0.1):
+        """Burn 'time: HH:MM:SS.ss' into the top-left corner (black fill, white
+        stroke = 10% of font). Mirrors HF render_single_image_with_timestamp and,
+        like HF, runs at native resolution *before* smart-resize."""
+        from PIL import ImageDraw, ImageFont
+
+        text = "time: " + _timestamp_converting(timestamp)
+        draw = ImageDraw.Draw(pil_img)
+        width, height = pil_img.size
+        font_size = int(min(width, height) * font_rate)
+        outline_size = int(font_size * 0.1)
+        font = ImageFont.truetype(self._font_path(), font_size)
+        draw.text(
+            (0, 0),
+            text,
+            font=font,
+            fill=(0, 0, 0),
+            stroke_width=outline_size,
+            stroke_fill=(255, 255, 255),
+        )
+        return pil_img
+
+    def _get_frame_indices(self, vlen, target_frames, target_fps, input_fps):
+        """Mirror of HF get_frame_indices for frames_sample='leading'.
+
+        target_frames>0: split [0,vlen) into target_frames intervals, take each
+        interval's left edge. Else (fps mode): sample at 1/target_fps s and round
+        to the nearest source frame index."""
+        import numpy as np
+
+        if target_frames > 0:
+            acc = min(target_frames, vlen)
+            intervals = np.linspace(0, vlen, acc + 1).astype(int)
+            return [int(intervals[i]) for i in range(acc)]  # leading = interval left edge
+        delta = 1.0 / target_fps
+        duration = float(vlen) / input_fps
+        frame_seconds = np.arange(0, duration, delta)
+        idx = np.around(frame_seconds * input_fps).astype(int)
+        return [int(e) for e in idx if e < vlen]
+
+    def _decode_and_sample_frames(self, video_input):
+        """decord decode + HF-matching frame sampling + timestamp burn-in + even
+        pad. Returns RGB PIL frames at the video's native resolution."""
+        from decord import VideoReader
+        from PIL import Image
+
+        if not isinstance(video_input, str):
+            raise ValueError(
+                f"video input must be a file path str, got {type(video_input)}"
+            )
+        vr = VideoReader(video_input, num_threads=1)
+        vlen = len(vr)
+        input_fps = float(vr.get_avg_fps())
+        duration = vlen / input_fps
+
+        # _set_video_frame_args: target_frames=-1 -> fps path, clamped into
+        # [min_frames, max_frames] by switching to a fixed target_frames count.
+        fps = self.video_fps
+        target_frames = -1
+        frames_to_extract = int(duration * fps)
+        if self.video_min_frames > 0 and frames_to_extract < self.video_min_frames:
+            target_frames = self.video_min_frames
+            fps = -1
+        elif self.video_max_frames > 0 and frames_to_extract > self.video_max_frames:
+            target_frames = self.video_max_frames
+            fps = -1
+
+        frame_indices = self._get_frame_indices(vlen, target_frames, fps, input_fps)
+
+        frames = [Image.fromarray(vr[fi].asnumpy(), "RGB") for fi in frame_indices]
+        # timestamp(sec) = frame_idx * duration / num_of_frame = frame_idx / input_fps
+        timestamps = [fi * duration / vlen for fi in frame_indices]
+        frames = [self._render_timestamp(f, ts) for f, ts in zip(frames, timestamps)]
+        # Resampler temporal merge is 2:1, so frame count must be even (HF pads the
+        # last frame when odd).
+        if len(frames) % 2 != 0:
+            frames.append(frames[-1].copy())
+        return frames
+
+    def _preprocess_one_video(self, video_input):
+        """Decode -> sample -> burn timestamps -> smart-resize -> patchify a single
+        video. Returns (patches [t*ph*pw,3,p,p], grid_row [t,ph,pw], count).
+
+        count = t*ph*pw // (spatial_block * temporal_conv_size) = t_eff*gh*gw, the
+        number of vision tokens the resampler emits after spatial + temporal merge."""
+        import numpy as np
+
+        frames = self._decode_and_sample_frames(video_input)
+        t = len(frames)
+        w0, h0 = frames[0].size  # PIL size is (W, H)
+        factor = self.patch_size * self.spatial_merge_size
+        rh, rw = smart_resize(h0, w0, factor, self.video_min_pixels, self.video_max_pixels)
+        ph, pw = rh // self.patch_size, rw // self.patch_size
+
+        patch_list = []
+        for f in frames:
+            chw = self._frame_to_chw(f, rh, rw)
+            patches, _, _ = self._patchify_frame(chw)  # h==ph, w==pw by construction
+            patch_list.append(patches)
+
+        pixel_values = np.concatenate(patch_list, axis=0)
+        block = self.spatial_conv_size * self.spatial_conv_size
+        count = (t * ph * pw) // (block * self.temporal_conv_size)
+        return pixel_values, [t, ph, pw], count
+
+    def _build_3d_position_ids(self, input_ids, grid_thw):
+        """Qwen2-VL-style get_rope_index -> [3][seq] = (time, height, width).
+
+        Text tokens advance sequentially on all three axes. Each im_patch run gets
+        2D (height,width) grid positions offset by the running start; the next text
+        token resumes from max(position)+1. The merged grid uses spatial_conv_size
+        (the resampler's spatial merge): hh=h//s, ww=w//s.
+        VERIFY: match HF modeling_ernie4_5_vl.get_rope_index (axis order + the
+        position offset accounting after each image span).
+        """
+        s = self.spatial_conv_size
+        grids = grid_thw.tolist() if hasattr(grid_thw, "tolist") else list(grid_thw)
+        tpos, hpos, wpos = [], [], []
+        st = 0
+        img_idx = 0
+        i = 0
+        n = len(input_ids)
+        while i < n:
+            if input_ids[i] == self.im_patch_id:
+                t, h, w = grids[img_idx]
+                img_idx += 1
+                hh, ww = int(h) // s, int(w) // s
+                # Temporal merge: the resampler downsamples time by temporal_conv_size
+                # (video), so the placeholder run is t_eff*hh*ww long, not t*hh*ww.
+                # Mirrors HF _compute_3d_positions: t_eff = t//temporal_conv if t!=1
+                # else 1. Image (t==1) is unchanged.
+                t_eff = int(t) // self.temporal_conv_size if int(t) != 1 else 1
+                count = t_eff * hh * ww
+                for idx in range(count):
+                    ti = idx // (hh * ww)
+                    rem = idx % (hh * ww)
+                    hi = rem // ww
+                    wi = rem % ww
+                    tpos.append(st + ti)
+                    hpos.append(st + hi)
+                    wpos.append(st + wi)
+                # Next start = max coord + 1 = st + max(t_eff, hh, ww)
+                # (HF: cur_position = np.max(pos_ids) + 1).
+                st = st + max(t_eff, hh, ww)
+                i += count
+            else:
+                tpos.append(st)
+                hpos.append(st)
+                wpos.append(st)
+                st += 1
+                i += 1
+        return [tpos, hpos, wpos]
+
+    def build_model_inputs(self, scheduler_output, temperature=1.0, top_p=0.8, top_k=1):
+        """Inject multimodal tensors + 3D mrope positions onto the base text inputs.
+
+        Multimodal data lives on the request's processed_inputs (from __call__).
+        pixel_values/tgt_sizes are sent only during prefill (vision is cached after);
+        position_ids are replaced with the [3, seq] mrope layout for the tokens
+        computed this step. Text-only requests fall through to the base unchanged.
+        """
+        base = super().build_model_inputs(scheduler_output, temperature, top_p, top_k)
+
+        reqs = getattr(scheduler_output, "scheduled_requests", None)
+        if not reqs:
+            return base
+        req = reqs[0]
+        pi = getattr(req, "processed_inputs", None)
+        if not pi or pi.get("pixel_values") is None:
+            return base
+
+        import infinicore
+        import numpy as np
+
+        grid_thw = np.asarray(pi["grid_thw"]).astype(np.int64)
+        pos3d = self._build_3d_position_ids(req.get_all_token_ids(), grid_thw)
+
+        if getattr(scheduler_output, "is_prefill", True):
+            prefix = getattr(scheduler_output, "prefix_hit_len", 0) or 0
+            end = len(req.get_input_tokens())
+            pos_slice = [row[prefix:end] for row in pos3d]
+
+            # Flatten patches to [num_patches, C*p*p]; the C++ patch_embed views it
+            # back. Build in model dtype so it matches the vision weights. Use
+            # from_numpy (not from_list(.tolist())): a video has ~19200*588 = 11.3M
+            # elements, and materializing that as a nested Python list is slow and
+            # memory-heavy for no benefit (from_list just rebuilds a numpy array).
+            pv2d = np.ascontiguousarray(pi["pixel_values"]).reshape(pi["pixel_values"].shape[0], -1)
+            base["pixel_values"] = infinicore.from_numpy(pv2d, dtype=self._infini_dtype())
+            base["tgt_sizes"] = infinicore.from_list(grid_thw.tolist(), dtype=infinicore.int64)
+        else:
+            pos = req.get_total_length() - 1
+            pos_slice = [[row[pos]] for row in pos3d]
+
+        base["position_ids"] = infinicore.from_list(pos_slice, dtype=infinicore.int64)
+
+        return base
+
+    def _infini_dtype(self):
+        """Model compute dtype for pixel_values (must match the vision weights)."""
+        import infinicore
+
+        name = (getattr(self, "_config_dtype", "bfloat16") or "bfloat16").lower()
+        return {
+            "bfloat16": infinicore.bfloat16,
+            "float16": infinicore.float16,
+            "float32": infinicore.float32,
+        }.get(name, infinicore.bfloat16)

--- a/test/models/ernie4_5_moe_vl/test_correctness.py
+++ b/test/models/ernie4_5_moe_vl/test_correctness.py
@@ -63,8 +63,15 @@ def build_conversation(text, image=None, video=None):
     return [{"role": "user", "content": content}]
 
 
-def run_infinilm(model_path, device, conversation, max_new_tokens, ignore_eos=False, tp=1,
-                 max_cache_len=1024):
+def run_infinilm(
+    model_path,
+    device,
+    conversation,
+    max_new_tokens,
+    ignore_eos=False,
+    tp=1,
+    max_cache_len=1024,
+):
     from infinilm.llm.llm import LLM
     from infinilm.llm.sampling_params import SamplingParams
 
@@ -129,7 +136,9 @@ def run_reference(model_path, conversation, max_new_tokens):
         return_dict=True,
         return_tensors="pt",
     )
-    inputs = {k: (v.to(model.device) if hasattr(v, "to") else v) for k, v in inputs.items()}
+    inputs = {
+        k: (v.to(model.device) if hasattr(v, "to") else v) for k, v in inputs.items()
+    }
 
     prompt_len = inputs["input_ids"].shape[1]
     with torch.no_grad():
@@ -146,7 +155,11 @@ def run_reference(model_path, conversation, max_new_tokens):
 
 def _infinilm_text(infinilm_out):
     """Best-effort extraction of decoded text from LLM.chat output."""
-    o = infinilm_out[0] if isinstance(infinilm_out, (list, tuple)) and infinilm_out else infinilm_out
+    o = (
+        infinilm_out[0]
+        if isinstance(infinilm_out, (list, tuple)) and infinilm_out
+        else infinilm_out
+    )
     if isinstance(o, str):
         return o
     for attr in ("text", "generated_text", "outputs"):
@@ -174,7 +187,7 @@ def compare(infinilm_out, reference_ids, reference_text):
 
 
 CASES = [
-    ("text",  dict(text="用一句话介绍你自己。")),
+    ("text", dict(text="用一句话介绍你自己。")),
     ("image", dict(text="描述这张图片。", image="IMAGE_PATH")),
     ("video", dict(text="描述这段视频的内容。", video="VIDEO_PATH")),
 ]
@@ -187,16 +200,27 @@ def main():
     ap.add_argument("--image", default=None)
     ap.add_argument("--video", default=None)
     ap.add_argument("--max-new-tokens", type=int, default=128)
-    ap.add_argument("--max-cache-len", type=int, default=1024,
-                    help="KV cache length; raise for video (>=3072) since a clip "
-                         "expands to thousands of vision tokens.")
+    ap.add_argument(
+        "--max-cache-len",
+        type=int,
+        default=1024,
+        help="KV cache length; raise for video (>=3072) since a clip "
+        "expands to thousands of vision tokens.",
+    )
     ap.add_argument("--with-reference", action="store_true")
     ap.add_argument("--cases", default="text,image,video")
-    ap.add_argument("--tp", type=int, default=1,
-                    help="Tensor-parallel size. Use 2 on MetaX C500 ×2 (the 59GB "
-                         "weights do not fit one 64GB card alongside activations/KV).")
-    ap.add_argument("--ignore-eos", action="store_true",
-                    help="Ignore EOS during generation to see what tokens follow (debug mode).")
+    ap.add_argument(
+        "--tp",
+        type=int,
+        default=1,
+        help="Tensor-parallel size. Use 2 on MetaX C500 ×2 (the 59GB "
+        "weights do not fit one 64GB card alongside activations/KV).",
+    )
+    ap.add_argument(
+        "--ignore-eos",
+        action="store_true",
+        help="Ignore EOS during generation to see what tokens follow (debug mode).",
+    )
     args = ap.parse_args()
 
     selected = set(args.cases.split(","))
@@ -217,13 +241,20 @@ def main():
         print(f"\n===== case: {name} =====")
         conversation = build_conversation(**kw)
         infinilm_out = run_infinilm(
-            args.model, args.device, conversation, args.max_new_tokens,
-            ignore_eos=args.ignore_eos, tp=args.tp, max_cache_len=args.max_cache_len,
+            args.model,
+            args.device,
+            conversation,
+            args.max_new_tokens,
+            ignore_eos=args.ignore_eos,
+            tp=args.tp,
+            max_cache_len=args.max_cache_len,
         )
         print(f"[InfiniLM] {infinilm_out}")
 
         if args.with_reference:
-            ref_ids, ref_text = run_reference(args.model, conversation, args.max_new_tokens)
+            ref_ids, ref_text = run_reference(
+                args.model, conversation, args.max_new_tokens
+            )
             print(f"[Reference] {ref_text}")
             compare(infinilm_out, ref_ids, ref_text)
 

--- a/test/models/ernie4_5_moe_vl/test_correctness.py
+++ b/test/models/ernie4_5_moe_vl/test_correctness.py
@@ -1,0 +1,232 @@
+"""Inference correctness test for ERNIE-4.5-VL-28B-A3B.
+
+Covers the three required input modalities and compares InfiniLM output token
+sequences against HuggingFace transformers (the reference) under greedy decoding.
+
+Usage:
+    python test/models/ernie4_5_moe_vl/test_correctness.py \
+        --model /path/to/ERNIE-4.5-VL-28B-A3B-Thinking \
+        --device nvidia \
+        --image test/assets/demo.jpg \
+        --video test/assets/demo.mp4
+
+The HF reference path is gated behind --with-reference (needs the model loadable
+by transformers). Without it, the script just runs InfiniLM and prints outputs.
+Per the task rules, transformers is used ONLY as a test reference here; the
+adapted model/processor code does not depend on it for inference.
+"""
+
+import argparse
+import ctypes
+import os
+
+
+def _disable_maca_device_heap():
+    """Set MACA device malloc heap size to 0 before any GPU allocation.
+
+    On MetaX C500 (64 GB), the model weights consume nearly all VRAM, leaving
+    too little for MACA to create its default 8 MB kernel-side heap.  Setting
+    the limit to 0 disables the heap entirely; model inference does not use
+    device-side malloc so this is safe.
+    """
+    for libname in ("libmcruntime.so", "libhcruntime.so"):
+        try:
+            lib = ctypes.CDLL(libname)
+            # mcLimitMallocHeapSize / hcLimitMallocHeapSize = 2 (same as cudaLimitMallocHeapSize)
+            ret = lib.mcDeviceSetLimit(2, ctypes.c_size_t(0))
+            if ret == 0:
+                print(f"[INFO] {libname}: mcDeviceSetLimit(MallocHeapSize, 0) OK")
+                return
+            # fallback: try hc variant
+            ret2 = lib.hcDeviceSetLimit(2, ctypes.c_size_t(0))
+            if ret2 == 0:
+                print(f"[INFO] {libname}: hcDeviceSetLimit(MallocHeapSize, 0) OK")
+                return
+        except OSError:
+            continue
+    print("[WARN] could not set device malloc heap size to 0 (library not found)")
+
+
+_disable_maca_device_heap()
+
+
+def build_conversation(text, image=None, video=None):
+    # InfiniLM framework format: resolve_multimodal_inputs expects type=="image"
+    # with image_url holding the file path. The HF reference path may need its own
+    # message format — adapt in run_reference if the installed processor differs.
+    content = []
+    if image is not None:
+        content.append({"type": "image", "image_url": image})
+    if video is not None:
+        content.append({"type": "video", "video_url": video})
+    content.append({"type": "text", "text": text})
+    return [{"role": "user", "content": content}]
+
+
+def run_infinilm(model_path, device, conversation, max_new_tokens, ignore_eos=False, tp=1,
+                 max_cache_len=1024):
+    from infinilm.llm.llm import LLM
+    from infinilm.llm.sampling_params import SamplingParams
+
+    model = LLM(
+        model_path=os.path.expanduser(model_path),
+        device=device,
+        tensor_parallel_size=tp,
+        cache_type="static",
+        max_batch_size=1,
+        max_tokens=max_new_tokens,
+        # A video expands to thousands of vision tokens (min_frames=16 -> >=2400
+        # for a 320x240 clip), so the prompt alone can exceed the text/image
+        # default; raise --max-cache-len for video. default 4096 (224 MB) exceeds
+        # free VRAM on C500.
+        max_cache_len=max_cache_len,
+        temperature=1.0,
+        top_k=1,  # greedy
+        top_p=1.0,
+    )
+
+    sp = SamplingParams(
+        temperature=1.0,
+        top_k=1,
+        top_p=1.0,
+        max_tokens=max_new_tokens,
+        ignore_eos=ignore_eos,
+    )
+    outputs = model.chat(messages=[conversation], sampling_params=sp)
+    return outputs
+
+
+def run_reference(model_path, conversation, max_new_tokens):
+    """Reference path: load ERNIE-4.5-VL with transformers and greedy-generate.
+
+    Used ONLY as a correctness reference (task §4); the adapted InfiniLM
+    inference path does not depend on transformers. Returns (token_ids, text).
+
+    The checkpoint is loaded with trust_remote_code=True so its bundled
+    processing_ernie4_5_vl / modeling code drives tokenization and the vision
+    pipeline. The processor.apply_chat_template(..., return_dict=True) call is
+    the unified multimodal entry: it renders text + image/video placeholders and
+    attaches pixel values in one shot, so the same `conversation` used by
+    InfiniLM feeds the reference unchanged.
+    """
+    import torch
+    from transformers import AutoModelForCausalLM, AutoProcessor
+
+    model_path = os.path.expanduser(model_path)
+    processor = AutoProcessor.from_pretrained(model_path, trust_remote_code=True)
+    model = AutoModelForCausalLM.from_pretrained(
+        model_path,
+        dtype=torch.bfloat16,
+        device_map="auto",
+        trust_remote_code=True,
+    )
+    model.eval()
+
+    inputs = processor.apply_chat_template(
+        conversation,
+        add_generation_prompt=True,
+        tokenize=True,
+        return_dict=True,
+        return_tensors="pt",
+    )
+    inputs = {k: (v.to(model.device) if hasattr(v, "to") else v) for k, v in inputs.items()}
+
+    prompt_len = inputs["input_ids"].shape[1]
+    with torch.no_grad():
+        generated = model.generate(
+            **inputs,
+            max_new_tokens=max_new_tokens,
+            do_sample=False,  # greedy, matches InfiniLM top_k=1 / temperature ignored
+            num_beams=1,
+        )
+    output_ids = generated[0][prompt_len:].tolist()
+    text = processor.decode(output_ids, skip_special_tokens=True)
+    return output_ids, text
+
+
+def _infinilm_text(infinilm_out):
+    """Best-effort extraction of decoded text from LLM.chat output."""
+    o = infinilm_out[0] if isinstance(infinilm_out, (list, tuple)) and infinilm_out else infinilm_out
+    if isinstance(o, str):
+        return o
+    for attr in ("text", "generated_text", "outputs"):
+        val = getattr(o, attr, None)
+        if isinstance(val, str):
+            return val
+    return str(o)
+
+
+def compare(infinilm_out, reference_ids, reference_text):
+    """Compare InfiniLM output against the HF reference (task §4).
+
+    Primary metric is exact token-sequence match; that requires InfiniLM to
+    surface generated token ids here. Until LLM.chat exposes them, we compare on
+    decoded text (exact match; semantic equivalence is left to manual review).
+    """
+    text = _infinilm_text(infinilm_out)
+    if text.strip() == (reference_text or "").strip():
+        print("[PASS] exact text match")
+        return True
+    print("[FAIL] output differs from reference")
+    print(f"  InfiniLM : {text!r}")
+    print(f"  Reference: {reference_text!r}  ({len(reference_ids)} ref tokens)")
+    return False
+
+
+CASES = [
+    ("text",  dict(text="用一句话介绍你自己。")),
+    ("image", dict(text="描述这张图片。", image="IMAGE_PATH")),
+    ("video", dict(text="描述这段视频的内容。", video="VIDEO_PATH")),
+]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model", required=True)
+    ap.add_argument("--device", default="cuda")
+    ap.add_argument("--image", default=None)
+    ap.add_argument("--video", default=None)
+    ap.add_argument("--max-new-tokens", type=int, default=128)
+    ap.add_argument("--max-cache-len", type=int, default=1024,
+                    help="KV cache length; raise for video (>=3072) since a clip "
+                         "expands to thousands of vision tokens.")
+    ap.add_argument("--with-reference", action="store_true")
+    ap.add_argument("--cases", default="text,image,video")
+    ap.add_argument("--tp", type=int, default=1,
+                    help="Tensor-parallel size. Use 2 on MetaX C500 ×2 (the 59GB "
+                         "weights do not fit one 64GB card alongside activations/KV).")
+    ap.add_argument("--ignore-eos", action="store_true",
+                    help="Ignore EOS during generation to see what tokens follow (debug mode).")
+    args = ap.parse_args()
+
+    selected = set(args.cases.split(","))
+    for name, kw in CASES:
+        if name not in selected:
+            continue
+        if name == "image":
+            if not args.image:
+                print("[SKIP] image case: no --image provided")
+                continue
+            kw["image"] = args.image
+        if name == "video":
+            if not args.video:
+                print("[SKIP] video case: no --video provided")
+                continue
+            kw["video"] = args.video
+
+        print(f"\n===== case: {name} =====")
+        conversation = build_conversation(**kw)
+        infinilm_out = run_infinilm(
+            args.model, args.device, conversation, args.max_new_tokens,
+            ignore_eos=args.ignore_eos, tp=args.tp, max_cache_len=args.max_cache_len,
+        )
+        print(f"[InfiniLM] {infinilm_out}")
+
+        if args.with_reference:
+            ref_ids, ref_text = run_reference(args.model, conversation, args.max_new_tokens)
+            print(f"[Reference] {ref_text}")
+            compare(infinilm_out, ref_ids, ref_text)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# T2\-1\-1 赛题报告：ERNIE\-4\.5\-VL\-28B\-A3B 模型适配



>　小组：justdoit　赛题：T2\-1\-1 模型适配
> 
> 

---

## 一、实现的功能概述

将百度 **ERNIE\-4\.5\-VL\-28B\-A3B\-Thinking**（多模态 MoE 大模型）适配到 **InfiniCore / InfiniLM** 推理框架，在框架内完整实现视觉编码器、MoE、多模态适配器与单机多卡分布式推理，支持三种输入模态：

- **正确性验证**：以 HuggingFace transformers 官方模型作为**测试参照**，进行 processor 级逐位对齐与端到端 greedy 逐 token 对照；**适配代码本身的推理不依赖任何第三方框架**。

- **模型规模**：28 层文本骨干 \+ 文本/视觉双模态 MoE（各 64 专家）\+ DFNRope 视觉塔（32 层）\+ 重采样/merger 适配器 \+ 权重共享 lm\_head；权重约 59GB（bf16）。

- **平台**：NVIDIA（4×RTX 4090D，TP=4）三模态全部正确；MetaX C500（2×C500，TP=2）文本、图像正确。

---

## 二、使用的技术方案和参考资料

### 2\.1 预处理（processor，平台无关，与 HF 逐位一致）

复现于 `python/infinilm/processors/ernie4_5_moe_vl_processor.py`，与 HF `processing_ernie4_5_vl.py` 逐位对齐：

- **图像**：CLIP 归一化、`grid_thw` 计算、patch 切分顺序与 HF 一致。

- **视频**：decord 解码；`fps=2` leading 抽帧，帧数夹到 `[16,180]`，奇数补帧凑偶（配 resampler 2:1 时序合并）；**时间戳烧帧**（每帧左上角 `time: HH:MM:SS.ss`，黑字白描边，Roboto 字体，在原分辨率、resize 之前）；smart\_resize（视频像素预算 234416/937664）、patchify、归一化。

- **3D 位置编码**：视频时序合并 `t_eff = t // temporal_conv_size`，占位符数 `= t_eff·gh·gw`。

验证：自建脚本对同一输入分别过 HF 与本实现，`grid_thw`、占位符数、逐帧像素、`pixel_values` 均 `max|Δ|=0`。

### 2\.2 模型结构（C\+\+，`csrc/models/ernie4_5_moe_vl/`）

- **RoPE**：ERNIE 使用 **GPT\-J / interleaved** 旋转（非框架默认 GPT\-NeoX half\-split）；文本走 1D，视频/图像走 **3D mRoPE**（`rope_scaling.mrope_section`，如 \[22,22,20\]）。

- **模态 MoE**：**softmax** 门控（非 sigmoid）；按 token 模态（文本/视觉）分派到对应专家组；combine 权重取所选专家的原始 softmax 概率、不归一化，correction\_bias 仅影响选择。

- **视觉塔（DFNRope ViT）**：32 层、2D RoPE、块对角注意力（按帧分段 cu\_seqlens）、quick\_gelu；`patch_embed` → blocks → 最终 LayerNorm 与 HF 逐位一致。

- **重采样/merger 适配器**：图像（t=1）也须经 `temporal_linear`；`after_norm` 为 RMSNorm（eps=1e\-5）。

- **权重映射**（`python/infinilm/modeling_utils.py::_remap_ernie4_5_vl`，注册到框架 `_WEIGHT_REMAPPER` 扩展点）：`gate.weight` 需转置且 `.contiguous()`；`vision_model.*`→`visual.*`、`ln_1/ln_2`→`norm1/norm2`；`model.resampler_model.*`→`visual.merger.*`。

### 2\.3 定位并修复的关键问题

- **4 处数值 bug**：RoPE 算法（GPT\-J）、MoE 门控（softmax）、gate 权重转置 \+ `.contiguous()`、token\_type\_ids 在设备端构造不可靠（改 CPU 显式构造）。

- **`nn::Module::device_`**** 未初始化**（框架通用问题）：父模块 `device_` 为默认构造的非法设备，张量搬运会崩；在模型构造时显式保存计算设备 `compute_device_`。

- **MetaX 运行时适配**：大块 pixel\_values H2D 分块拷贝；MoE 大 prefill 命令队列在解码层内 `syncStream` 排空（MetaX 特有的功能性同步，**无硬件平台特判**——所有平台无条件执行）。

- **补齐 MetaX 算子**：为 InfiniCore 增加 MetaX\(MACA\) 的 `softmax`、`quickgelu` 实现并注册。

### 2\.4 验证方法

两级对照：processor 级逐位 diff（预处理）\+ HF greedy 逐 token 对照（端到端），以 forward hook 逐层 dump 精确定位每处偏差。**HF 仅作参照，推理不依赖之。**

### 2\.5 参考资料

- HuggingFace 官方模型与源码：`baidu/ERNIE-4.5-VL-28B-A3B-Thinking`（`modeling_ernie4_5_vl.py` / `processing_ernie4_5_vl.py`）。

- InfiniCore / InfiniLM 框架现有模块（RoPE 工厂、MoE/MLP、注意力、线性层、分布式 CCL 等）。

---

## 三、测试脚本在各平台的运行方式及运行效果

**测试脚本**：`test/models/ernie4_5_moe_vl/test_correctness.py`（覆盖三模态，与 HF greedy 逐 token 对照，`--with-reference` 开启参照）。

### 3\.1 NVIDIA（4×RTX 4090D 24GB，TP=4）

```Bash
export MODEL=/path/to/ERNIE-4.5-VL-28B-A3B-Thinking
# 文本
python test/models/ernie4_5_moe_vl/test_correctness.py \--model $MODEL --device cuda --tp 4 --cases text --max-new-tokens 32# 图像
python test/models/ernie4_5_moe_vl/test_correctness.py \--model $MODEL --device cuda --tp 4 --cases image \--image /tmp/test.jpg --max-cache-len 2048 --max-new-tokens 32# 视频
python test/models/ernie4_5_moe_vl/test_correctness.py \--model $MODEL --device cuda --tp 4 --cases video \--video /tmp/test.mp4 --max-cache-len 3072 --max-new-tokens 8
```

运行效果（合成测试素材：橙色竖条 \+ 蓝色横条的图/视频）：
<img width="1010" height="588" alt="image" src="https://github.com/user-attachments/assets/c764599d-fa00-4f86-a90b-68aa586e57ca" />


#### 终端运行效果截图

##### 文本
<img width="1280" height="589" alt="image" src="https://github.com/user-attachments/assets/020e88b1-dc1e-4522-9cc8-2e6d123699a0" />



 

##### 图片
<img width="1280" height="559" alt="image" src="https://github.com/user-attachments/assets/918eb754-0271-4868-890d-3f13e07e0275" />

 

##### 视频
<img width="1280" height="989" alt="image" src="https://github.com/user-attachments/assets/1b8487d7-2942-48f8-8f09-6588c519434f" />

 


### 3\.2 MetaX C500（2×C500 64GB，TP=2；MACA 3\.3\.0\.15，内核驱动 3\.8\.30）

与 NVIDIA 相同的测试脚本，`--device cuda --tp 2`（59GB 权重单卡放不下，须双卡 TP=2）：

```Bash
export MODEL=/path/to/ERNIE-4.5-VL-28B-A3B-Thinking
# 文本
python test/models/ernie4_5_moe_vl/test_correctness.py \--model $MODEL --device cuda --tp 2 --cases text --max-new-tokens 32# 图像
python test/models/ernie4_5_moe_vl/test_correctness.py \--model $MODEL --device cuda --tp 2 --cases image \--image /tmp/test.jpg --max-cache-len 2048 --max-new-tokens 32# 视频
python test/models/ernie4_5_moe_vl/test_correctness.py \--model $MODEL --device cuda --tp 2 --cases video \--video /tmp/test.mp4 --max-cache-len 3072 --max-new-tokens 8
```

运行效果：

> 说明：文本、图像与 NVIDIA 结果一致；视频命令与 NVIDIA 完全相同，仅在当前 MetaX 环境的驱动层受限（非代码问题，见 4\.1）。
> 
> 

#### 终端运行效果截图

##### 文本

<img width="1385" height="256" alt="image" src="https://github.com/user-attachments/assets/1ee6c600-68e0-4e9c-9486-2c42d6a6c318" />

##### 图片

<img width="1280" height="327" alt="image" src="https://github.com/user-attachments/assets/0c2a713f-7a9e-4b2b-941e-dca6ec4b923c" />

##### 视频

<img width="1664" height="256" alt="image" src="https://github.com/user-attachments/assets/1af1a1b3-3de7-464e-bdab-a0e75055b5c6" />
## 四、未实现或未适配部分的说明

### 4\.1 MetaX C500 视频模态

视频 `pixel_values`（约 21\.5MB）在 host→device 传输时，触发 MetaX 驱动的 `registered user pointer` 显存异常（`[MXKW][E] analysis_memory_exception`）并最终挂起。

**已做隔离实验确认根因不在代码/依赖**：将 InfiniLM 与 InfiniCore 均回退至此前视频可正常运行的版本——InfiniLM `c645e8d` \+ InfiniCore `fdc3c24f`（2026\-07\-03 该组合在早期 MetaX 环境下视频可正常运行）——在**当前 MetaX 环境**（MACA 3\.3\.0\.15 / 内核驱动 3\.8\.30 / 共享主机分配的 2×C500）上重建运行，仍复现同一异常并挂起。作为对照，当前提交版本为 InfiniLM `e9d2118` \+ InfiniCore `29f5afa2`，在当前环境同样复现。即"同一份早期可运行的代码，换到当前环境即失败"，变量仅剩环境层（容器/驱动/所分配的物理卡）。

代码层已尝试分块拷贝、pinned host 中转、逐块小 bounce 缓冲等多种传输方式，**故障区大小恒为完整缓冲（21\.5MB），与传输方式无关**，无法在代码层规避。据此定位为 **MetaX 环境对大块 host 内存注册的限制**，而非模型适配代码或依赖升级导致（早期 MetaX 环境下同一份代码视频可正常运行）。

> 说明：NVIDIA 平台视频模态正确运行，不受此问题影响。
> 
> 


---

## 五、赛题要求之外的额外功能说明

- **多平台适配**：在必选的 NVIDIA 之外，完成国产 **MetaX C500** 平台的文本/图像模态适配（含为 InfiniCore 补齐 MetaX `softmax`、`quickgelu` 算子），并打通 TP=2 多卡。

- **两级 HF 对照验证工具链**：processor 级逐位 diff \+ 端到端 greedy 逐 token 对照 \+ 逐层 hook dump，可精确定位任一数值偏差。

---

## 附：代码提交信息

- InfiniLM：分支 `2026-spring-goog00-T2-1-1`，单提交 `feat(ernie-vl): adapt ERNIE-4.5-VL-28B-A3B to InfiniLM`。

- InfiniCore：分支 `2026-spring-goog00-T2-1-1`，单提交 `feat(ernie-vl): MetaX softmax/quickgelu ops + nvidia build fixes`。

- 均已清理调试代码、还原框架公共文件、复用框架模块化设计、不使用 legacy llama 代码。

[Honor Code.pdf](https://github.com/user-attachments/files/29940823/2026.Honor.Code.1.pdf)

