### PR TITLE
[2026春季][T2-1-3] goog00

### DIFF
--- a/bench/qwen3_moe/README.md
+++ b/bench/qwen3_moe/README.md
@@ -1,0 +1,111 @@
+# Qwen3-MoE 并发吞吐基准（MetaX）
+
+T2-1-3 的服务吞吐基准，对齐赛题「测试风格参考长文本优化赛题（T2-1-2）」的要求：
+起 InfiniLM 服务 + `vllm bench serve` 压测 **concurrency × input-len × output-len** 矩阵，
+产出 **base vs this** 的输出吞吐 / 总吞吐对比（赛题「性能」维度的打分依据）。
+
+平台：沐曦 MetaX C500，TP=2。
+
+## 文件
+
+| 文件 | 作用 |
+|---|---|
+| `serve.sh` | 起 OpenAI 兼容服务（Qwen3-30B-A3B-Thinking，metax，TP=2，paged-attn + flash-attn + ignore-eos）|
+| `run_bench.sh` | 客户端 `vllm bench serve` 遍历矩阵（**需装 vllm**）|
+| `load_client.py` | **零依赖**并发压测客户端（纯标准库，无需 vllm/aiohttp）——vllm 装不上时用这个 |
+| `summarize.py` | 解析结果文件成表格；给两个目录则输出 base-vs-this 的 Δ% |
+
+> 两个客户端产出**同一格式**的结果文件（`bench_results/<TAG>/bsX_inY_outZ.txt`），
+> summarize.py 都能解析。**MetaX 容器一般没有 vllm**（且与 maca torch 易冲突），推荐用 `load_client.py`。
+
+## 服务依赖
+
+服务端只需轻量依赖：
+
+```bash
+pip install fastapi uvicorn
+```
+
+## 用 load_client.py（推荐，无 vllm）
+
+```bash
+# 终端 A：起服务（见下）
+# 终端 B：
+python3 bench/qwen3_moe/load_client.py --tag this      # 或 --tag base
+python3 bench/qwen3_moe/summarize.py bench_results/this
+```
+
+矩阵/并发/模型名均可用 `--batch-sizes/--input-lens/--output-lens/--model/--base-url` 覆盖。
+`load_client.py` 用非流式请求测**输出吞吐 / 总吞吐**（赛题打分项）；不测 TTFT/TPOT（需流式，表里显示 `-`）。
+输入长度用 CJK 填充字近似（~1 token/字）；要精确可加 `--tokenizer <模型路径>`（需 transformers）。
+
+## 默认压测矩阵
+
+- concurrency：`1 8 32`
+- input-len：`32 256 2048`
+- output-len：`256 1024`
+
+（均可用环境变量覆盖，见各脚本头部注释。）
+
+## base vs this 怎么跑
+
+「this」= T2-1-3 分支（grouped_gemm 批化 MoE）。「base」= 改造前的**朴素逐 token×逐 expert** MoE
+（`main` 分支 / grouped_gemm 之前的实现）。两者用**同一套客户端脚本**分别压测，只是换部署的 `.so`。
+
+### 1) 跑 this（当前 T2-1-3）
+
+```bash
+# 终端 A：起服务（保持前台）
+cd /data/InfiniLM
+MODEL=/data/huggingface_home/Qwen3-30B-A3B-Thinking-2507 \
+  bash bench/qwen3_moe/serve.sh
+# 等打印 “load weights over” + uvicorn 起监听
+
+# 终端 B：等服务 ready 后压测
+cd /data/InfiniLM
+curl -s http://127.0.0.1:8102/health && echo " <- server ready"
+TAG=this bash bench/qwen3_moe/run_bench.sh
+```
+
+### 2) 跑 base（朴素 MoE 基线）
+
+```bash
+# 切到基线实现并重建 + 部署 .so（示例，按你的基线 commit 调整）
+cd /data/InfiniLM && git stash && git checkout main
+cd /data/InfiniCore && xmake install
+cd /data/InfiniLM && xmake build _infinilm
+cp build/linux/x86_64/release/_infinilm.cpython-310-x86_64-linux-gnu.so python/infinilm/lib/
+
+# 起服务 + 压测（同上，改 TAG=base）
+MODEL=/data/huggingface_home/Qwen3-30B-A3B-Thinking-2507 bash bench/qwen3_moe/serve.sh   # 终端 A
+TAG=base bash bench/qwen3_moe/run_bench.sh                                                # 终端 B
+```
+
+> 注：base 与 this 必须用**完全相同的客户端参数**（矩阵、seed 策略、ignore-eos）才可比。
+> 脚本已固定这些；两次只改 `TAG` 和部署的 `.so`。
+
+### 3) 汇总对比
+
+```bash
+python3 bench/qwen3_moe/summarize.py bench_results/base bench_results/this
+```
+
+输出每个 (bs,in,out) 的 `out_tok/s` 与 `total_tok/s` 的 base→this 及 Δ%。
+只看单侧：`python3 bench/qwen3_moe/summarize.py bench_results/this`。
+
+## 显存 / 参数提示
+
+- `NUM_BLOCKS` 默认 1024（≈ 26 万 token 的 KV，覆盖 concurrency 32 × (2048+1024) 有余）。
+  **OOM 就调小**（`NUM_BLOCKS=512`），**报 KV 不足就调大**。
+- `MAX_CACHE`（--max-cache-len）需 ≥ 最大 input+output（默认 4096 覆盖 2048+1024）。
+- **注意力后端 `ATTN` 默认 `paged-attn`**：MetaX build **未编 flash-attn**（用 `--attn flash-attn`
+  会报 "FlashAttention is not enabled in this build" 并崩 forward）。若 paged-attn 在你的 build 也不可用，
+  退回 static cache：`PAGED=0 ATTN=default bash bench/qwen3_moe/serve.sh`（并发批处理能力会下降）。
+- `--enable-graph` 默认**关**：MoE 前向含数据相关的 host dispatch + syncStream，graph capture 可能不兼容。
+  想试开：`GRAPH=1 bash bench/qwen3_moe/serve.sh`，若起不来或结果异常就关掉。
+- 采样固定 `top-k 1`（greedy）+ `ignore-eos`，保证每请求生成满 output-len、结果可比。
+
+## 关注指标
+
+赛题打分看 **Output token throughput (tok/s)** 与 **Total Token throughput (tok/s)**；
+小规模（bs=1）作为「不回退」门槛。summarize.py 已抽取这两项 + req/s + TTFT + TPOT。

--- a/bench/qwen3_moe/load_client.py
+++ b/bench/qwen3_moe/load_client.py
@@ -19,6 +19,7 @@ Input length is approximated by repeating a CJK filler char (~1 token each);
 this is fine for relative base-vs-this comparison. Pass --tokenizer to count
 prompt tokens exactly if `transformers` is available.
 """
+
 import argparse
 import json
 import os
@@ -42,17 +43,22 @@ def build_prompt(input_len, tokenizer=None):
 
 def one_request(base_url, model, prompt, output_len, timeout):
     """Send one non-streaming chat request; return (ok, latency_s, completion_tokens)."""
-    payload = json.dumps({
-        "model": model,
-        "messages": [{"role": "user", "content": prompt}],
-        "max_tokens": output_len,
-        "ignore_eos": True,
-        "stream": False,
-        "temperature": 1.0,
-    }).encode("utf-8")
+    payload = json.dumps(
+        {
+            "model": model,
+            "messages": [{"role": "user", "content": prompt}],
+            "max_tokens": output_len,
+            "ignore_eos": True,
+            "stream": False,
+            "temperature": 1.0,
+        }
+    ).encode("utf-8")
     req = urllib.request.Request(
         base_url.rstrip("/") + "/v1/chat/completions",
-        data=payload, headers={"Content-Type": "application/json"}, method="POST")
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
     t0 = time.perf_counter()
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
@@ -63,7 +69,10 @@ def one_request(base_url, model, prompt, output_len, timeout):
     # Prefer server-reported usage; fall back to nominal output_len.
     comp = output_len
     usage = body.get("usage") or {}
-    if isinstance(usage.get("completion_tokens"), int) and usage["completion_tokens"] > 0:
+    if (
+        isinstance(usage.get("completion_tokens"), int)
+        and usage["completion_tokens"] > 0
+    ):
         comp = usage["completion_tokens"]
     return True, lat, comp, None
 
@@ -76,8 +85,10 @@ def run_config(base_url, model, bs, il, ol, repeat, timeout, tokenizer):
 
     t_start = time.perf_counter()
     with ThreadPoolExecutor(max_workers=bs) as pool:
-        futs = [pool.submit(one_request, base_url, model, prompt, ol, timeout)
-                for _ in range(num_prompts)]
+        futs = [
+            pool.submit(one_request, base_url, model, prompt, ol, timeout)
+            for _ in range(num_prompts)
+        ]
         for f in as_completed(futs):
             ok, lat, comp, err = f.result()
             results.append((ok, lat, comp))
@@ -126,8 +137,9 @@ def parse_list(s):
 
 
 def main():
-    ap = argparse.ArgumentParser(description=__doc__,
-                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
     ap.add_argument("--base-url", default="http://127.0.0.1:8102")
     ap.add_argument("--model", default="Qwen3-30B-A3B-Thinking-2507")
     ap.add_argument("--tag", default="this", help="result subdir under --outdir-root")
@@ -135,17 +147,25 @@ def main():
     ap.add_argument("--batch-sizes", type=parse_list, default=[1, 8, 32])
     ap.add_argument("--input-lens", type=parse_list, default=[32, 256, 2048])
     ap.add_argument("--output-lens", type=parse_list, default=[256, 1024])
-    ap.add_argument("--repeat", type=int, default=3,
-                    help="requests per config = concurrency * repeat")
+    ap.add_argument(
+        "--repeat",
+        type=int,
+        default=3,
+        help="requests per config = concurrency * repeat",
+    )
     ap.add_argument("--timeout", type=float, default=1200.0)
-    ap.add_argument("--tokenizer", default=None,
-                    help="optional HF tokenizer path for exact prompt token counts")
+    ap.add_argument(
+        "--tokenizer",
+        default=None,
+        help="optional HF tokenizer path for exact prompt token counts",
+    )
     args = ap.parse_args()
 
     tok = None
     if args.tokenizer:
         try:
             from transformers import AutoTokenizer
+
             tok = AutoTokenizer.from_pretrained(args.tokenizer, trust_remote_code=True)
         except Exception as e:  # noqa: BLE001
             print(f"(tokenizer load failed, using approximate prompt: {e})")
@@ -153,23 +173,37 @@ def main():
     outdir = os.path.join(args.outdir_root, args.tag)
     os.makedirs(outdir, exist_ok=True)
     print(f">>> tag={args.tag} url={args.base_url} model={args.model} -> {outdir}")
-    print(f">>> concurrency={args.batch_sizes} input={args.input_lens} output={args.output_lens}")
+    print(
+        f">>> concurrency={args.batch_sizes} input={args.input_lens} output={args.output_lens}"
+    )
 
     for bs in args.batch_sizes:
         for il in args.input_lens:
             for ol in args.output_lens:
                 path = os.path.join(outdir, f"bs{bs}_in{il}_out{ol}.txt")
                 print(f">>> bs={bs} in={il} out={ol} ...", end="", flush=True)
-                m = run_config(args.base_url, args.model, bs, il, ol,
-                               args.repeat, args.timeout, tok)
+                m = run_config(
+                    args.base_url,
+                    args.model,
+                    bs,
+                    il,
+                    ol,
+                    args.repeat,
+                    args.timeout,
+                    tok,
+                )
                 write_result(path, bs, il, ol, m)
                 if m["successful"] == 0:
                     print(f" FAIL ({m['err_sample']})")
                 else:
-                    print(f" ok  out={m['out_tok_s']:.1f} tok/s  total={m['total_tok_s']:.1f} tok/s"
-                          f"  ({m['successful']}/{m['num_prompts']})")
+                    print(
+                        f" ok  out={m['out_tok_s']:.1f} tok/s  total={m['total_tok_s']:.1f} tok/s"
+                        f"  ({m['successful']}/{m['num_prompts']})"
+                    )
 
-    print(f">>> done. 汇总: python3 {os.path.join(os.path.dirname(__file__), 'summarize.py')} {outdir}")
+    print(
+        f">>> done. 汇总: python3 {os.path.join(os.path.dirname(__file__), 'summarize.py')} {outdir}"
+    )
 
 
 if __name__ == "__main__":

--- a/bench/qwen3_moe/load_client.py
+++ b/bench/qwen3_moe/load_client.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Dependency-free concurrent load client for the InfiniLM OpenAI server.
+
+A stdlib-only alternative to `vllm bench serve` (no vllm / aiohttp needed), for
+environments where vllm is not installed (e.g. MetaX containers). Sweeps the
+concurrency × input-len × output-len matrix and writes one result file per
+config in the exact label format `summarize.py` parses.
+
+Because the server runs with `--ignore-eos`, each request generates exactly
+`output_len` tokens, so output-token throughput is measured against the nominal
+count (also reconciled with the response `usage` field when present).
+
+Usage:
+    python3 load_client.py --tag this
+    python3 load_client.py --tag base --base-url http://127.0.0.1:8102 \
+        --batch-sizes 1,8,32 --input-lens 32,256,2048 --output-lens 256,1024
+
+Input length is approximated by repeating a CJK filler char (~1 token each);
+this is fine for relative base-vs-this comparison. Pass --tokenizer to count
+prompt tokens exactly if `transformers` is available.
+"""
+import argparse
+import json
+import os
+import time
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+FILLER = "的"  # ~1 Qwen token each; used to build an approximately input_len prompt.
+
+
+def build_prompt(input_len, tokenizer=None):
+    """Return a user message string of approximately `input_len` tokens."""
+    if tokenizer is not None:
+        # Grow the filler until the tokenizer reports >= input_len tokens.
+        s = FILLER * input_len
+        while len(tokenizer(s)["input_ids"]) < input_len:
+            s += FILLER * 8
+        return s
+    return FILLER * input_len
+
+
+def one_request(base_url, model, prompt, output_len, timeout):
+    """Send one non-streaming chat request; return (ok, latency_s, completion_tokens)."""
+    payload = json.dumps({
+        "model": model,
+        "messages": [{"role": "user", "content": prompt}],
+        "max_tokens": output_len,
+        "ignore_eos": True,
+        "stream": False,
+        "temperature": 1.0,
+    }).encode("utf-8")
+    req = urllib.request.Request(
+        base_url.rstrip("/") + "/v1/chat/completions",
+        data=payload, headers={"Content-Type": "application/json"}, method="POST")
+    t0 = time.perf_counter()
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            body = json.loads(resp.read().decode("utf-8"))
+    except Exception as e:  # noqa: BLE001 - report and keep going
+        return False, time.perf_counter() - t0, 0, str(e)
+    lat = time.perf_counter() - t0
+    # Prefer server-reported usage; fall back to nominal output_len.
+    comp = output_len
+    usage = body.get("usage") or {}
+    if isinstance(usage.get("completion_tokens"), int) and usage["completion_tokens"] > 0:
+        comp = usage["completion_tokens"]
+    return True, lat, comp, None
+
+
+def run_config(base_url, model, bs, il, ol, repeat, timeout, tokenizer):
+    num_prompts = bs * repeat
+    prompt = build_prompt(il, tokenizer)
+    results = []
+    err_sample = None
+
+    t_start = time.perf_counter()
+    with ThreadPoolExecutor(max_workers=bs) as pool:
+        futs = [pool.submit(one_request, base_url, model, prompt, ol, timeout)
+                for _ in range(num_prompts)]
+        for f in as_completed(futs):
+            ok, lat, comp, err = f.result()
+            results.append((ok, lat, comp))
+            if not ok and err_sample is None:
+                err_sample = err
+    wall = time.perf_counter() - t_start
+
+    ok_n = sum(1 for ok, _, _ in results if ok)
+    out_tokens = sum(c for ok, _, c in results if ok)
+    in_tokens = ok_n * il  # approximate (see build_prompt)
+    lat_ok = [lat for ok, lat, _ in results if ok]
+    mean_lat_ms = 1000.0 * sum(lat_ok) / len(lat_ok) if lat_ok else 0.0
+
+    metrics = {
+        "successful": ok_n,
+        "num_prompts": num_prompts,
+        "duration_s": wall,
+        "req_s": ok_n / wall if wall > 0 else 0.0,
+        "out_tok_s": out_tokens / wall if wall > 0 else 0.0,
+        "total_tok_s": (in_tokens + out_tokens) / wall if wall > 0 else 0.0,
+        "mean_latency_ms": mean_lat_ms,
+        "err_sample": err_sample,
+    }
+    return metrics
+
+
+def write_result(path, bs, il, ol, m):
+    # Labels chosen to match summarize.py's regexes.
+    lines = [
+        "============ Serving Benchmark Result ============",
+        f"config:                                  bs={bs} in={il} out={ol}",
+        f"Successful requests:                     {m['successful']}/{m['num_prompts']}",
+        f"Benchmark duration (s):                  {m['duration_s']:.2f}",
+        f"Request throughput (req/s):              {m['req_s']:.4f}",
+        f"Output token throughput (tok/s):         {m['out_tok_s']:.2f}",
+        f"Total Token throughput (tok/s):          {m['total_tok_s']:.2f}",
+        f"Mean E2E latency (ms):                   {m['mean_latency_ms']:.2f}",
+    ]
+    if m["err_sample"]:
+        lines.append(f"error_sample:                            {m['err_sample']}")
+    open(path, "w", encoding="utf-8").write("\n".join(lines) + "\n")
+
+
+def parse_list(s):
+    return [int(x) for x in s.replace(",", " ").split()]
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--base-url", default="http://127.0.0.1:8102")
+    ap.add_argument("--model", default="Qwen3-30B-A3B-Thinking-2507")
+    ap.add_argument("--tag", default="this", help="result subdir under --outdir-root")
+    ap.add_argument("--outdir-root", default="bench_results")
+    ap.add_argument("--batch-sizes", type=parse_list, default=[1, 8, 32])
+    ap.add_argument("--input-lens", type=parse_list, default=[32, 256, 2048])
+    ap.add_argument("--output-lens", type=parse_list, default=[256, 1024])
+    ap.add_argument("--repeat", type=int, default=3,
+                    help="requests per config = concurrency * repeat")
+    ap.add_argument("--timeout", type=float, default=1200.0)
+    ap.add_argument("--tokenizer", default=None,
+                    help="optional HF tokenizer path for exact prompt token counts")
+    args = ap.parse_args()
+
+    tok = None
+    if args.tokenizer:
+        try:
+            from transformers import AutoTokenizer
+            tok = AutoTokenizer.from_pretrained(args.tokenizer, trust_remote_code=True)
+        except Exception as e:  # noqa: BLE001
+            print(f"(tokenizer load failed, using approximate prompt: {e})")
+
+    outdir = os.path.join(args.outdir_root, args.tag)
+    os.makedirs(outdir, exist_ok=True)
+    print(f">>> tag={args.tag} url={args.base_url} model={args.model} -> {outdir}")
+    print(f">>> concurrency={args.batch_sizes} input={args.input_lens} output={args.output_lens}")
+
+    for bs in args.batch_sizes:
+        for il in args.input_lens:
+            for ol in args.output_lens:
+                path = os.path.join(outdir, f"bs{bs}_in{il}_out{ol}.txt")
+                print(f">>> bs={bs} in={il} out={ol} ...", end="", flush=True)
+                m = run_config(args.base_url, args.model, bs, il, ol,
+                               args.repeat, args.timeout, tok)
+                write_result(path, bs, il, ol, m)
+                if m["successful"] == 0:
+                    print(f" FAIL ({m['err_sample']})")
+                else:
+                    print(f" ok  out={m['out_tok_s']:.1f} tok/s  total={m['total_tok_s']:.1f} tok/s"
+                          f"  ({m['successful']}/{m['num_prompts']})")
+
+    print(f">>> done. 汇总: python3 {os.path.join(os.path.dirname(__file__), 'summarize.py')} {outdir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/qwen3_moe/run_bench.sh
+++ b/bench/qwen3_moe/run_bench.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# 客户端并发吞吐压测（vllm bench serve），对齐 T2-1-2 的服务测法。
+# 遍历 concurrency × input-len × output-len 矩阵，每组结果落一个文件。
+#
+# 前置：serve.sh 已在同机 PORT 上把服务起好。
+#
+# 用法：
+#   TAG=base ./run_bench.sh        # 跑基线版（如 main 的 naive MoE），结果存 bench_results/base
+#   TAG=this ./run_bench.sh        # 跑本方案（T2-1-3 grouped_gemm），结果存 bench_results/this
+#
+# 环境变量：
+#   TAG          结果子目录名（base / this），用于 base-vs-this 对比
+#   PORT         服务端口（默认 8102）
+#   MODEL_NAME   请求里的 model 字段（服务单模型，一般被忽略；默认见下）
+#   TOKENIZER    分词器路径，用于准确统计 token 数
+#   BATCH_SIZES  concurrency 列表（默认 "1 8 32"）
+#   INPUT_LENS   输入长度列表（默认 "32 256 2048"）
+#   OUTPUT_LENS  输出长度列表（默认 "256 1024"）
+#   REPEAT       每组的请求数 = concurrency × REPEAT（默认 3）
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+TAG="${TAG:-this}"
+PORT="${PORT:-8102}"
+MODEL_NAME="${MODEL_NAME:-Qwen3-30B-A3B-Thinking-2507}"
+TOKENIZER="${TOKENIZER:-/data/huggingface_home/Qwen3-30B-A3B-Thinking-2507}"
+REPEAT="${REPEAT:-3}"
+
+read -r -a BATCH_SIZES <<< "${BATCH_SIZES:-1 8 32}"
+read -r -a INPUT_LENS  <<< "${INPUT_LENS:-32 256 2048}"
+read -r -a OUTPUT_LENS <<< "${OUTPUT_LENS:-256 1024}"
+
+OUTDIR="${OUTDIR:-bench_results/${TAG}}"
+mkdir -p "${OUTDIR}"
+unset http_proxy https_proxy all_proxy ALL_PROXY 2>/dev/null || true
+
+echo ">>> TAG=${TAG} port=${PORT} -> ${OUTDIR}"
+echo ">>> concurrency=[${BATCH_SIZES[*]}] input=[${INPUT_LENS[*]}] output=[${OUTPUT_LENS[*]}]"
+
+for bs in "${BATCH_SIZES[@]}"; do
+  for il in "${INPUT_LENS[@]}"; do
+    for ol in "${OUTPUT_LENS[@]}"; do
+      sleep 1
+      seed=$(date +%s)
+      num_prompts=$(( bs * REPEAT ))
+      out="${OUTDIR}/bs${bs}_in${il}_out${ol}.txt"
+      echo ">>> bs=${bs} in=${il} out=${ol} num_prompts=${num_prompts} -> ${out}"
+
+      # 用 --extra-body 把 max_tokens/ignore_eos 塞进 chat 请求，保证每请求生成满 output-len，
+      # 吞吐才可比（与 T2-1-2 一致）。--request-rate inf = 爆发模式。
+      vllm bench serve \
+        --backend openai-chat \
+        --model "${MODEL_NAME}" \
+        --tokenizer "${TOKENIZER}" \
+        --endpoint /v1/chat/completions \
+        --port "${PORT}" \
+        --request-rate inf \
+        --seed "${seed}" \
+        --num-prompts "${num_prompts}" \
+        --max-concurrency "${bs}" \
+        --random-input-len "${il}" \
+        --extra-body "{\"max_tokens\": ${ol}, \"ignore_eos\": true}" \
+        > "${out}" 2>&1 || { echo "!! 该组失败，见 ${out}"; continue; }
+    done
+  done
+done
+
+echo ">>> done. 汇总： python3 $(dirname "$0")/summarize.py ${OUTDIR}"

--- a/bench/qwen3_moe/serve.sh
+++ b/bench/qwen3_moe/serve.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# 启动 InfiniLM OpenAI 兼容服务，用于 Qwen3-30B-A3B-Thinking-2507 的并发吞吐基准。
+# 目标平台：沐曦 MetaX C500，TP=2（两张 64GB 卡）。
+#
+# 用法：
+#   MODEL=/data/huggingface_home/Qwen3-30B-A3B-Thinking-2507 ./serve.sh
+#   MAX_CON=32 NUM_BLOCKS=1024 ./serve.sh      # 覆盖默认值
+#   GRAPH=1 ./serve.sh                          # 试开 graph（MoE 含 host dispatch，可能不兼容）
+#
+# 环境变量（均可覆盖）：
+#   MODEL       模型路径
+#   PORT        服务端口（默认 8102，与客户端脚本一致）
+#   TP          张量并行度（默认 2）
+#   MAX_CON     --max-batch-size，必须 >= 你要压测的最大 concurrency（默认 32）
+#   NUM_BLOCKS  KV cache 分块数（默认 1024；OOM 就调小，不够就调大，见 README）
+#   MAX_NEW     单请求最大生成 token（默认 4096，需 >= 压测的最大 output-len）
+#   MAX_CACHE   --max-cache-len（默认 4096，需 >= 最大 input+output）
+#   ATTN        注意力后端（默认 paged-attn；MetaX 未编 flash-attn，不要用 flash-attn）
+#   PAGED       1=开 paged KV cache（默认，并发批处理需要）；0=退回 static cache
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+MODEL="${MODEL:-/data/huggingface_home/Qwen3-30B-A3B-Thinking-2507}"
+DEVICE="${DEVICE:-metax}"
+PORT="${PORT:-8102}"
+TP="${TP:-2}"
+MAX_CON="${MAX_CON:-32}"
+NUM_BLOCKS="${NUM_BLOCKS:-1024}"
+MAX_NEW="${MAX_NEW:-4096}"
+MAX_CACHE="${MAX_CACHE:-4096}"
+ATTN="${ATTN:-paged-attn}"
+
+REPO="$(cd "$(dirname "$0")/../.." && pwd)"
+export PYTHONPATH="${REPO}/python:${PYTHONPATH:-}"
+
+OPT_FLAGS=()
+[[ "${GRAPH:-0}" == "1" ]] && OPT_FLAGS+=(--enable-graph)
+[[ "${PAGED:-1}" == "1" ]] && OPT_FLAGS+=(--enable-paged-attn --num-blocks "${NUM_BLOCKS}")
+
+echo ">>> serving ${MODEL}"
+echo ">>> device=${DEVICE} tp=${TP} port=${PORT} max_batch=${MAX_CON} attn=${ATTN} paged=${PAGED:-1} num_blocks=${NUM_BLOCKS} graph=${GRAPH:-0}"
+
+exec python3 "${REPO}/python/infinilm/server/inference_server.py" \
+    --model "${MODEL}" \
+    --device "${DEVICE}" --tp "${TP}" \
+    --port "${PORT}" \
+    --max-batch-size "${MAX_CON}" \
+    --max-new-tokens "${MAX_NEW}" \
+    --max-cache-len "${MAX_CACHE}" \
+    --temperature 1.0 --top-p 0.8 --top-k 1 \
+    --attn "${ATTN}" \
+    --ignore-eos \
+    "${OPT_FLAGS[@]}"

--- a/bench/qwen3_moe/summarize.py
+++ b/bench/qwen3_moe/summarize.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Summarize `vllm bench serve` result files into a throughput table.
+
+Parses the `bsX_inY_outZ.txt` files produced by run_bench.sh and prints one row
+per (concurrency, input, output) config. Pass one result dir to just tabulate,
+or two dirs (base first, then this) to get a base-vs-this comparison with the
+output/total throughput deltas that the 赛题 scores on.
+
+Usage:
+    python3 summarize.py bench_results/this
+    python3 summarize.py bench_results/base bench_results/this
+"""
+import os
+import re
+import sys
+import glob
+
+# Label -> canonical metric. vllm 各版本标签略有差异，用宽松正则匹配数值。
+_METRICS = {
+    "req_s": r"Request throughput \(req/s\):\s*([\d.]+)",
+    "out_tok_s": r"Output token throughput \(tok/s\):\s*([\d.]+)",
+    "total_tok_s": r"Total Token throughput \(tok/s\):\s*([\d.]+)",
+    "ttft_ms": r"Mean TTFT \(ms\):\s*([\d.]+)",
+    "tpot_ms": r"Mean TPOT \(ms\):\s*([\d.]+)",
+}
+_FNAME = re.compile(r"bs(\d+)_in(\d+)_out(\d+)\.txt$")
+
+
+def parse_file(path):
+    text = open(path, encoding="utf-8", errors="replace").read()
+    row = {}
+    for key, pat in _METRICS.items():
+        m = re.search(pat, text)
+        row[key] = float(m.group(1)) if m else None
+    return row
+
+
+def load_dir(d):
+    """Return {(bs, in, out): metrics} for one result dir."""
+    out = {}
+    for path in sorted(glob.glob(os.path.join(d, "bs*_in*_out*.txt"))):
+        m = _FNAME.search(os.path.basename(path))
+        if not m:
+            continue
+        cfg = tuple(int(x) for x in m.groups())
+        out[cfg] = parse_file(path)
+    return out
+
+
+def fmt(v, width=10):
+    return ("%.2f" % v).rjust(width) if isinstance(v, float) else "-".rjust(width)
+
+
+def print_single(d):
+    data = load_dir(d)
+    if not data:
+        print(f"(无结果文件: {d})")
+        return
+    print(f"\n=== {d} ===")
+    hdr = ["bs", "in", "out", "out_tok/s", "total_tok/s", "req/s", "TTFT_ms", "TPOT_ms"]
+    print("  ".join(h.rjust(10) for h in hdr))
+    for cfg in sorted(data):
+        r = data[cfg]
+        cols = [str(cfg[0]), str(cfg[1]), str(cfg[2]),
+                r["out_tok_s"], r["total_tok_s"], r["req_s"], r["ttft_ms"], r["tpot_ms"]]
+        print("  ".join(c.rjust(10) if isinstance(c, str) else fmt(c) for c in cols))
+
+
+def print_compare(base_dir, this_dir):
+    base, this = load_dir(base_dir), load_dir(this_dir)
+    keys = sorted(set(base) | set(this))
+    if not keys:
+        print("(两目录都无结果)")
+        return
+    print(f"\n=== base={base_dir}  vs  this={this_dir} ===")
+    print("列: out_tok/s (base -> this, Δ%) | total_tok/s (base -> this, Δ%)")
+    hdr = ["bs", "in", "out", "out_base", "out_this", "out_Δ%", "tot_base", "tot_this", "tot_Δ%"]
+    print("  ".join(h.rjust(10) for h in hdr))
+    for cfg in keys:
+        b, t = base.get(cfg, {}), this.get(cfg, {})
+
+        def delta(bv, tv):
+            if isinstance(bv, float) and isinstance(tv, float) and bv > 0:
+                return (tv - bv) / bv * 100.0
+            return None
+
+        cols = [str(cfg[0]), str(cfg[1]), str(cfg[2]),
+                b.get("out_tok_s"), t.get("out_tok_s"), delta(b.get("out_tok_s"), t.get("out_tok_s")),
+                b.get("total_tok_s"), t.get("total_tok_s"), delta(b.get("total_tok_s"), t.get("total_tok_s"))]
+        print("  ".join(c.rjust(10) if isinstance(c, str) else fmt(c) for c in cols))
+
+
+def main():
+    args = sys.argv[1:]
+    if len(args) == 1:
+        print_single(args[0])
+    elif len(args) == 2:
+        print_compare(args[0], args[1])
+    else:
+        print(__doc__)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/qwen3_moe/summarize.py
+++ b/bench/qwen3_moe/summarize.py
@@ -10,10 +10,11 @@ Usage:
     python3 summarize.py bench_results/this
     python3 summarize.py bench_results/base bench_results/this
 """
+
+import glob
 import os
 import re
 import sys
-import glob
 
 # Label -> canonical metric. vllm 各版本标签略有差异，用宽松正则匹配数值。
 _METRICS = {
@@ -61,8 +62,16 @@ def print_single(d):
     print("  ".join(h.rjust(10) for h in hdr))
     for cfg in sorted(data):
         r = data[cfg]
-        cols = [str(cfg[0]), str(cfg[1]), str(cfg[2]),
-                r["out_tok_s"], r["total_tok_s"], r["req_s"], r["ttft_ms"], r["tpot_ms"]]
+        cols = [
+            str(cfg[0]),
+            str(cfg[1]),
+            str(cfg[2]),
+            r["out_tok_s"],
+            r["total_tok_s"],
+            r["req_s"],
+            r["ttft_ms"],
+            r["tpot_ms"],
+        ]
         print("  ".join(c.rjust(10) if isinstance(c, str) else fmt(c) for c in cols))
 
 
@@ -74,7 +83,17 @@ def print_compare(base_dir, this_dir):
         return
     print(f"\n=== base={base_dir}  vs  this={this_dir} ===")
     print("列: out_tok/s (base -> this, Δ%) | total_tok/s (base -> this, Δ%)")
-    hdr = ["bs", "in", "out", "out_base", "out_this", "out_Δ%", "tot_base", "tot_this", "tot_Δ%"]
+    hdr = [
+        "bs",
+        "in",
+        "out",
+        "out_base",
+        "out_this",
+        "out_Δ%",
+        "tot_base",
+        "tot_this",
+        "tot_Δ%",
+    ]
     print("  ".join(h.rjust(10) for h in hdr))
     for cfg in keys:
         b, t = base.get(cfg, {}), this.get(cfg, {})
@@ -84,9 +103,17 @@ def print_compare(base_dir, this_dir):
                 return (tv - bv) / bv * 100.0
             return None
 
-        cols = [str(cfg[0]), str(cfg[1]), str(cfg[2]),
-                b.get("out_tok_s"), t.get("out_tok_s"), delta(b.get("out_tok_s"), t.get("out_tok_s")),
-                b.get("total_tok_s"), t.get("total_tok_s"), delta(b.get("total_tok_s"), t.get("total_tok_s"))]
+        cols = [
+            str(cfg[0]),
+            str(cfg[1]),
+            str(cfg[2]),
+            b.get("out_tok_s"),
+            t.get("out_tok_s"),
+            delta(b.get("out_tok_s"), t.get("out_tok_s")),
+            b.get("total_tok_s"),
+            t.get("total_tok_s"),
+            delta(b.get("total_tok_s"), t.get("total_tok_s")),
+        ]
         print("  ".join(c.rjust(10) if isinstance(c, str) else fmt(c) for c in cols))
 
 

--- a/csrc/models/qwen3_moe/qwen3_moe_experts.cpp
+++ b/csrc/models/qwen3_moe/qwen3_moe_experts.cpp
@@ -1,21 +1,61 @@
 #include "qwen3_moe_experts.hpp"
 
+#include "../../global_state/global_state.hpp"
+#include "../../utils.hpp"
+#include "infinicore/context/context.hpp"
 #include "infinicore/ops.hpp"
+#include "infinicore/ops/distributed/allreduce.hpp"
 
-#include <string>
+#include <cstdint>
+#include <cstring>
+#include <vector>
 
 namespace infinilm::models::qwen3_moe {
 
 Qwen3MoeExperts::Qwen3MoeExperts(std::shared_ptr<infinilm::config::ModelConfig> model_config,
                                  const infinicore::Device &device) {
 
+    dtype_ = model_config->get_dtype();
+    device_ = device;
+
     num_experts_ = model_config->get<size_t>("num_experts");
     num_experts_per_tok_ = model_config->get<size_t>("num_experts_per_tok");
+    hidden_size_ = model_config->get<size_t>("hidden_size");
+    size_t moe_intermediate_size = model_config->get<size_t>("moe_intermediate_size");
 
     ASSERT((num_experts_ > 0) && (num_experts_per_tok_ > 0) && (num_experts_per_tok_ <= num_experts_));
 
+    const engine::distributed::RankInfo &rank_info = infinilm::global_state::get_tensor_model_parallel_rank_info();
+    tp_rank_ = rank_info.tp_rank;
+    tp_size_ = rank_info.tp_size;
+    communicator_ = rank_info.comm;
+    ASSERT(moe_intermediate_size % size_t(tp_size_) == 0);
+    moe_intermediate_size_per_rank_ = moe_intermediate_size / size_t(tp_size_);
+
+    gate_proj_stacked_ = infinicore::nn::Parameter(
+        {num_experts_, moe_intermediate_size_per_rank_, hidden_size_},
+        dtype_, device_);
+    up_proj_stacked_ = infinicore::nn::Parameter(
+        {num_experts_, moe_intermediate_size_per_rank_, hidden_size_},
+        dtype_, device_);
+    down_proj_stacked_ = infinicore::nn::Parameter(
+        {num_experts_, hidden_size_, moe_intermediate_size_per_rank_},
+        dtype_, device_);
+
     for (size_t i = 0; i < num_experts_; ++i) {
-        experts_.push_back(this->register_module<Qwen3MoeMLP>(std::to_string(i), model_config, device));
+        const std::string suffix = std::to_string(i) + ".";
+
+        auto gate_slab = gate_proj_stacked_->narrow({{0, i, 1}})->squeeze(0);
+        this->register_parameter(suffix + "gate_proj.weight",
+                                 infinicore::nn::Parameter(gate_slab, /*tp_dim=*/0, tp_rank_, tp_size_));
+
+        auto up_slab = up_proj_stacked_->narrow({{0, i, 1}})->squeeze(0);
+        this->register_parameter(suffix + "up_proj.weight",
+                                 infinicore::nn::Parameter(up_slab, /*tp_dim=*/0, tp_rank_, tp_size_));
+
+        auto down_slab = down_proj_stacked_->narrow({{0, i, 1}})->squeeze(0);
+        this->register_parameter(suffix + "down_proj.weight",
+                                 infinicore::nn::Parameter(down_slab, /*tp_dim=*/1, tp_rank_, tp_size_));
     }
 }
 
@@ -23,42 +63,106 @@ infinicore::Tensor Qwen3MoeExperts::forward(const infinicore::Tensor &hidden_sta
                                             const infinicore::Tensor &top_k_index,
                                             const infinicore::Tensor &top_k_weights) const {
     ASSERT(hidden_states->ndim() == 2);
+    ASSERT(top_k_index->ndim() == 2);
+    ASSERT(top_k_weights->ndim() == 2);
 
-    auto top_k_weights_cpu = top_k_weights->to(infinicore::Device::Type::CPU);
+    const size_t ntoken = hidden_states->shape()[0];
+    const size_t k = top_k_index->shape()[1];
+    const size_t total_assignments = ntoken * k;
+
+    // ---- Step 1: device->host sync of routing tables.
+    infinicore::context::syncStream();
     auto top_k_index_cpu = top_k_index->to(infinicore::Device::Type::CPU);
+    auto top_k_weights_cpu = top_k_weights->to(infinicore::Device::Type::CPU);
+    const int32_t *idx_host = reinterpret_cast<const int32_t *>(top_k_index_cpu->data());
+    const float *w_host = reinterpret_cast<const float *>(top_k_weights_cpu->data());
 
-    int *top_k_index_ptr = reinterpret_cast<int *>(top_k_index_cpu->data());
-    float *top_k_weights_ptr = reinterpret_cast<float *>(top_k_weights_cpu->data());
+    // ---- Step 2: CPU-side bucketing.
+    std::vector<int32_t> counts(num_experts_, 0);
+    for (size_t a = 0; a < total_assignments; ++a) {
+        int32_t e = idx_host[a];
+        ASSERT(e >= 0 && size_t(e) < num_experts_);
+        ++counts[e];
+    }
+    std::vector<int32_t> offsets(num_experts_, 0);
+    {
+        int32_t acc = 0;
+        for (size_t e = 0; e < num_experts_; ++e) {
+            offsets[e] = acc;
+            acc += counts[e];
+        }
+    }
 
-    size_t ntoken = hidden_states->shape()[0];
-    int index;
-    float score;
+    auto perm_token_cpu = infinicore::Tensor::empty(
+        {total_assignments}, infinicore::DataType::I32, infinicore::Device(infinicore::Device::Type::CPU));
+    auto perm_weight_cpu = infinicore::Tensor::empty(
+        {total_assignments}, dtype_, infinicore::Device(infinicore::Device::Type::CPU));
+    int32_t *perm_token = reinterpret_cast<int32_t *>(perm_token_cpu->data());
+    void *perm_weight_raw = perm_weight_cpu->data();
 
-    auto final_hidden_states = infinicore::Tensor::empty(hidden_states->shape(), hidden_states->dtype(), hidden_states->device());
-    for (size_t itok = 0; itok < ntoken; ++itok) {
-        auto hidden_states_i = hidden_states->narrow({{0, itok, 1}});
-        const size_t route_row = itok * num_experts_per_tok_;
-
-        infinicore::Tensor final_hidden_states_i;
-        for (size_t k = 0; k < num_experts_per_tok_; ++k) {
-            index = top_k_index_ptr[route_row + k];
-            score = top_k_weights_ptr[route_row + k];
-
-            ASSERT(index >= 0 && static_cast<size_t>(index) < num_experts_);
-
-            experts_[index]->set_alpha(score);
-            auto expert_out = experts_[index]->forward(hidden_states_i);
-
-            if (k == 0) {
-                final_hidden_states_i = expert_out;
-            } else {
-                infinicore::op::add_(final_hidden_states_i, final_hidden_states_i, expert_out);
+    {
+        std::vector<int32_t> cursor(offsets);
+        for (size_t a = 0; a < total_assignments; ++a) {
+            int32_t e = idx_host[a];
+            int32_t row = cursor[e]++;
+            perm_token[row] = int32_t(a / k);
+            switch (dtype_) {
+            case infinicore::DataType::BF16:
+                reinterpret_cast<uint16_t *>(perm_weight_raw)[row] = f32_to_bf16(w_host[a]);
+                break;
+            case infinicore::DataType::F16:
+                reinterpret_cast<uint16_t *>(perm_weight_raw)[row] = f32_to_f16(w_host[a]);
+                break;
+            case infinicore::DataType::F32:
+                reinterpret_cast<float *>(perm_weight_raw)[row] = w_host[a];
+                break;
+            default:
+                throw std::runtime_error("Qwen3MoeExperts: unsupported dtype for routing weight broadcast.");
             }
         }
-
-        final_hidden_states->narrow({{0, itok, 1}})->copy_from(final_hidden_states_i);
     }
-    return final_hidden_states;
+
+    auto counts_cpu = infinicore::Tensor::empty(
+        {num_experts_}, infinicore::DataType::I32, infinicore::Device(infinicore::Device::Type::CPU));
+    std::memcpy(counts_cpu->data(), counts.data(), counts.size() * sizeof(int32_t));
+
+    // ---- Step 3: upload bucketing results to the active device.
+    auto perm_token_dev = perm_token_cpu->to(device_);
+    auto perm_weight_dev = perm_weight_cpu->to(device_);
+    auto counts_dev = counts_cpu->to(device_);
+
+    // ---- Step 4: gather hidden states by permuted token indices.
+    auto permuted_hidden = infinicore::op::embedding(perm_token_dev, hidden_states);
+
+    // ---- Step 5: per-projection grouped GEMMs.
+    // `counts` already lives on the host (computed in Step 2), so we hand it to
+    // grouped_gemm directly: device backends then skip the per-call device->host
+    // copy + stream sync of the group sizes. On MetaX that copy is effectively a
+    // hard sync, so this removes 3 hard syncs per layer on the decode path.
+    // Under graph recording the op runs at replay time, after this local
+    // `counts` vector is gone; pass nullptr there so the device-sync path is used.
+    const int32_t *counts_host = infinicore::context::isGraphRecording() ? nullptr : counts.data();
+    auto gate_out = infinicore::op::grouped_gemm(permuted_hidden, gate_proj_stacked_, counts_dev, 1.0f, 0.0f, counts_host);
+    auto up_out = infinicore::op::grouped_gemm(permuted_hidden, up_proj_stacked_, counts_dev, 1.0f, 0.0f, counts_host);
+    auto intermediate = infinicore::op::swiglu(up_out, gate_out);
+    auto down_out = infinicore::op::grouped_gemm(intermediate, down_proj_stacked_, counts_dev, 1.0f, 0.0f, counts_host);
+
+    // ---- Step 6: scale each row by its routing weight (broadcast over hidden).
+    auto weight_broadcast = perm_weight_dev->as_strided(
+        {total_assignments, hidden_size_}, {1, 0});
+    auto scaled = infinicore::op::mul(down_out, weight_broadcast);
+
+    // ---- Step 7: scatter-add back into a zero-initialized per-token buffer.
+    auto output = infinicore::Tensor::zeros({ntoken, hidden_size_}, dtype_, device_);
+    infinicore::op::index_add_(output, output, /*dim=*/0, perm_token_dev, scaled, 1.0f);
+
+    // ---- Step 8: TP all-reduce on the partial down_proj output.
+    if (tp_size_ > 1 && communicator_ != nullptr) {
+        infinicore::op::distributed::allreduce_(output, output, INFINICCL_SUM, communicator_);
+        infinicore::context::syncStream();
+    }
+
+    return output;
 }
 
 } // namespace infinilm::models::qwen3_moe

--- a/csrc/models/qwen3_moe/qwen3_moe_experts.hpp
+++ b/csrc/models/qwen3_moe/qwen3_moe_experts.hpp
@@ -1,16 +1,21 @@
 #pragma once
 
-#include "../../layers/moe/legacy/moe_mlp.hpp"
-#include "infinicore/nn/module.hpp"
-#include "infinicore/tensor.hpp"
-
-#include <cstddef>
+#include <infiniccl.h>
 #include <memory>
 
 namespace infinilm::models::qwen3_moe {
 
-using Qwen3MoeMLP = infinilm::layers::moe::legacy::MoeMLP;
-
+// Stacked-weight experts that dispatch a single `grouped_gemm` per projection
+// instead of one MLP forward per (token, expert) pair.
+//
+// Weight layout (after TP slicing):
+//   gate_proj : [num_experts, moe_intermediate_size / tp_size, hidden_size]
+//   up_proj   : [num_experts, moe_intermediate_size / tp_size, hidden_size]
+//   down_proj : [num_experts, hidden_size, moe_intermediate_size / tp_size]
+//
+// HF state_dict keys `experts.{i}.{gate,up,down}_proj.weight` are aliased to
+// views into the corresponding slab so the existing safetensors loader fills
+// them directly -- no Python remapper required.
 class Qwen3MoeExperts : public infinicore::nn::Module {
 public:
     Qwen3MoeExperts(std::shared_ptr<infinilm::config::ModelConfig> model_config,
@@ -21,9 +26,23 @@ public:
                                const infinicore::Tensor &top_k_weights) const;
 
 protected:
-    INFINICORE_NN_MODULE_VEC(Qwen3MoeMLP, experts);
-    size_t num_experts_per_tok_{0};
+    // Stacked weight parameters. We register them under non-HF names so the
+    // load_state_dict walk never picks them up directly; only the per-expert
+    // aliases below are populated by the loader.
+    INFINICORE_NN_PARAMETER(gate_proj_stacked);
+    INFINICORE_NN_PARAMETER(up_proj_stacked);
+    INFINICORE_NN_PARAMETER(down_proj_stacked);
+
     size_t num_experts_{0};
+    size_t num_experts_per_tok_{0};
+    size_t hidden_size_{0};
+    size_t moe_intermediate_size_per_rank_{0};
+    infinicore::DataType dtype_;
+    infinicore::Device device_;
+
+    int tp_size_{1};
+    int tp_rank_{0};
+    infinicclComm_t communicator_{nullptr};
 };
 
 } // namespace infinilm::models::qwen3_moe

--- a/test/models/qwen3_moe/CORRECTNESS_README.md
+++ b/test/models/qwen3_moe/CORRECTNESS_README.md
@@ -1,0 +1,59 @@
+# Qwen3-MoE 端到端正确性验证（prefill 首步对齐 HF）
+
+验证 InfiniLM 适配的 Qwen3-30B-A3B-Thinking-2507 与 HuggingFace 参照在 **prefill 首步**
+的一致性。核心指标是**首个生成 token（= prefill logits 的 argmax）与 HF 一致**，并顺带校验
+**prompt 分词（chat template + `<think>` 前缀）与 HF 一致**。
+
+## 为什么是"首 token"而不是"整段 logits bit-exact"
+
+- 本模型 **run-to-run 非确定**（TP all-reduce 规约顺序 + BF16 `index_add_` 原子加），
+  同一二进制两次贪心生成会从中途分叉 → 整条 token 序列 / 逐元素 logit 对齐不可靠。
+- **首 token 的 argmax 对微小数值噪声鲁棒**，是贪心解码真正依赖的量，也正是赛题要求的
+  "输出 token 一致性"最本质的一步。脚本额外报告"前缀一致长度"作为更强的参考信号。
+
+## 为什么两阶段
+
+30B 模型放不下两份（InfiniLM TP=2 + HF 参照）。所以：
+1. 先单独用 HF 生成参照并存盘（`dump_hf_reference.py`）；
+2. 再单独用 InfiniLM 加载并对比（`check_prefill_logits.py`）。
+
+HF 仅作**测试参照**，不进入 InfiniLM 推理路径（符合赛题规则）。
+
+## 用法
+
+### 1) 生成 HF 参照（HF 单独占用显存/内存）
+
+```bash
+cd /data/InfiniLM
+pip install transformers torch    # 若未装
+
+# GPU（device_map=auto 可跨多卡）：
+python3 test/models/qwen3_moe/dump_hf_reference.py \
+    --model /data/huggingface_home/Qwen3-30B-A3B-Thinking-2507 \
+    --device cuda --out /tmp/qwen3_ref.json
+# 或 CPU（~60GB 内存，慢但不占 GPU）：--device cpu
+```
+
+### 2) InfiniLM 对比（确保 HF 进程已退出、显存已释放）
+
+```bash
+python3 test/models/qwen3_moe/check_prefill_logits.py \
+    --model /data/huggingface_home/Qwen3-30B-A3B-Thinking-2507 \
+    --device metax --tp 2 --ref /tmp/qwen3_ref.json
+```
+
+退出码 0 = PASS，非 0 = FAIL（可用于 CI）。
+
+## 判读
+
+- **全部 PASS**：first_tok 与 prompt_tok 都对齐 → 权重加载 / chat template / 路由正确。
+- **first_tok 或 prompt_tok 不一致 → 真 bug**（权重/模板/路由适配错误）。
+- 仅个别 **prefix 早停但 first_tok 全 ==** → 通常是非确定性或近似平票，非适配错误。
+
+## 参数
+
+- `--max-new-tokens`（dump 侧，默认 16）：生成多少 token 供比对前缀。
+- `--prefix-threshold`（check 侧，默认 1）：PASS 要求每条前缀一致的最少 token 数；
+  设 1 即"首 token 对齐"。
+- prompts 固定在 `dump_hf_reference.py` 的 `DEFAULT_PROMPTS`，并写入参照文件，
+  checker 复用同一批 messages，保证两侧 prompt 完全一致。

--- a/test/models/qwen3_moe/check_prefill_logits.py
+++ b/test/models/qwen3_moe/check_prefill_logits.py
@@ -20,6 +20,7 @@ Usage:
     python3 check_prefill_logits.py --model /path/Qwen3-30B-A3B-Thinking-2507 \
         --device metax --tp 2 --ref qwen3_moe_prefill_reference.json
 """
+
 import argparse
 import json
 import os
@@ -32,25 +33,46 @@ from infinilm.llm.llm import LLM  # noqa: E402
 # Same mapping as BaseConfig.get_device_str: the LLM engine only accepts backend
 # strings (cpu/cuda/mlu/musa/...), so e.g. "metax"/"iluvatar" must map to "cuda".
 _DEVICE_STR_MAP = {
-    "cpu": "cpu", "nvidia": "cuda", "qy": "cuda", "cambricon": "mlu",
-    "ascend": "ascend", "metax": "cuda", "moore": "musa", "iluvatar": "cuda",
-    "kunlun": "kunlun", "hygon": "cuda", "ali": "cuda",
+    "cpu": "cpu",
+    "nvidia": "cuda",
+    "qy": "cuda",
+    "cambricon": "mlu",
+    "ascend": "ascend",
+    "metax": "cuda",
+    "moore": "musa",
+    "iluvatar": "cuda",
+    "kunlun": "kunlun",
+    "hygon": "cuda",
+    "ali": "cuda",
     # already-backend strings pass through:
-    "cuda": "cuda", "mlu": "mlu", "musa": "musa",
+    "cuda": "cuda",
+    "mlu": "mlu",
+    "musa": "musa",
 }
 
 
 def main():
-    ap = argparse.ArgumentParser(description=__doc__,
-                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
     ap.add_argument("--model", required=True)
-    ap.add_argument("--ref", required=True, help="reference json from dump_hf_reference.py")
+    ap.add_argument(
+        "--ref", required=True, help="reference json from dump_hf_reference.py"
+    )
     ap.add_argument("--device", default="metax")
     ap.add_argument("--tp", type=int, default=2)
-    ap.add_argument("--prefix-threshold", type=int, default=1,
-                    help="min matching leading tokens required per prompt to PASS (default 1)")
-    ap.add_argument("--cache-type", default="static", choices=["static", "paged"],
-                    help="KV cache type; static matches examples/test_infer.py's proven path")
+    ap.add_argument(
+        "--prefix-threshold",
+        type=int,
+        default=1,
+        help="min matching leading tokens required per prompt to PASS (default 1)",
+    )
+    ap.add_argument(
+        "--cache-type",
+        default="static",
+        choices=["static", "paged"],
+        help="KV cache type; static matches examples/test_infer.py's proven path",
+    )
     args = ap.parse_args()
 
     with open(args.ref, encoding="utf-8") as f:
@@ -69,7 +91,7 @@ def main():
         max_batch_size=len(entries),
         max_tokens=max_new,
         temperature=1.0,
-        top_k=1,   # greedy
+        top_k=1,  # greedy
         top_p=1.0,
         enable_graph=False,
         attn_backend="default",
@@ -96,22 +118,32 @@ def main():
                 break
         first_match = bool(ref_gen and this_gen and ref_gen[0] == this_gen[0])
 
-        ok = first_match and prefix >= args.prefix_threshold and (prompt_match is not False)
+        ok = (
+            first_match
+            and prefix >= args.prefix_threshold
+            and (prompt_match is not False)
+        )
         all_pass &= ok
 
         rt = ref_gen[0] if ref_gen else None
         tt = this_gen[0] if this_gen else None
         pm = {True: "ok", False: "MISMATCH", None: "n/a"}[prompt_match]
-        print(f"{'PASS' if ok else 'FAIL':6} | {pm:10} | {str(rt):>7} {'==' if first_match else '!='} "
-              f"{str(tt):<7} | {prefix:>2}/{min(len(ref_gen), len(this_gen))} | "
-              f"{e['messages'][0]['content'][:24]!r}")
+        print(
+            f"{'PASS' if ok else 'FAIL':6} | {pm:10} | {str(rt):>7} {'==' if first_match else '!='} "
+            f"{str(tt):<7} | {prefix:>2}/{min(len(ref_gen), len(this_gen))} | "
+            f"{e['messages'][0]['content'][:24]!r}"
+        )
 
     print("-" * 90)
-    print(f"=== OVERALL: {'PASS' if all_pass else 'FAIL'} "
-          f"({sum(1 for _ in entries)} prompts) ===")
+    print(
+        f"=== OVERALL: {'PASS' if all_pass else 'FAIL'} "
+        f"({sum(1 for _ in entries)} prompts) ==="
+    )
     if not all_pass:
-        print("提示：若仅个别 prefix 早停而 first_tok 全 ==，通常是非确定性/近似平票，非适配错误；"
-              "若 first_tok 或 prompt_tok 不一致，才是真 bug（权重加载 / chat template / 路由）。")
+        print(
+            "提示：若仅个别 prefix 早停而 first_tok 全 ==，通常是非确定性/近似平票，非适配错误；"
+            "若 first_tok 或 prompt_tok 不一致，才是真 bug（权重加载 / chat template / 路由）。"
+        )
     sys.exit(0 if all_pass else 1)
 
 

--- a/test/models/qwen3_moe/check_prefill_logits.py
+++ b/test/models/qwen3_moe/check_prefill_logits.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Stage 2/2 of the Qwen3-MoE prefill correctness check: compare InfiniLM vs HF.
+
+Loads the model through the InfiniLM engine (no transformers dependency in the
+inference path), greedily generates for the same prompts saved by
+`dump_hf_reference.py`, and checks alignment with the HF reference:
+
+  1. prompt tokenization matches HF (validates chat template + thinking prefix),
+  2. **first generated token matches** — the prefill next-token = argmax of the
+     prefill logits; this is the meaningful "prefill 首步 logits 对齐" signal and
+     is robust to the model's run-to-run non-determinism (TP all-reduce order +
+     BF16 atomic scatter), which makes a full token-sequence / bit-exact logit
+     comparison unreliable,
+  3. matching-prefix length is reported as a stronger (best-effort) signal.
+
+PASS when, for every prompt, the prompt tokens match and the first generated
+token matches (and prefix >= --prefix-threshold).
+
+Usage:
+    python3 check_prefill_logits.py --model /path/Qwen3-30B-A3B-Thinking-2507 \
+        --device metax --tp 2 --ref qwen3_moe_prefill_reference.json
+"""
+import argparse
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../python"))
+
+from infinilm.llm.llm import LLM  # noqa: E402
+
+# Same mapping as BaseConfig.get_device_str: the LLM engine only accepts backend
+# strings (cpu/cuda/mlu/musa/...), so e.g. "metax"/"iluvatar" must map to "cuda".
+_DEVICE_STR_MAP = {
+    "cpu": "cpu", "nvidia": "cuda", "qy": "cuda", "cambricon": "mlu",
+    "ascend": "ascend", "metax": "cuda", "moore": "musa", "iluvatar": "cuda",
+    "kunlun": "kunlun", "hygon": "cuda", "ali": "cuda",
+    # already-backend strings pass through:
+    "cuda": "cuda", "mlu": "mlu", "musa": "musa",
+}
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--model", required=True)
+    ap.add_argument("--ref", required=True, help="reference json from dump_hf_reference.py")
+    ap.add_argument("--device", default="metax")
+    ap.add_argument("--tp", type=int, default=2)
+    ap.add_argument("--prefix-threshold", type=int, default=1,
+                    help="min matching leading tokens required per prompt to PASS (default 1)")
+    ap.add_argument("--cache-type", default="static", choices=["static", "paged"],
+                    help="KV cache type; static matches examples/test_infer.py's proven path")
+    args = ap.parse_args()
+
+    with open(args.ref, encoding="utf-8") as f:
+        ref = json.load(f)
+    entries = ref["entries"]
+    max_new = ref.get("max_new_tokens", 16)
+
+    device_str = _DEVICE_STR_MAP.get(args.device.lower(), "cpu")
+    # Mirror examples/test_infer.py's proven invocation (static cache, default
+    # attn, no graph) so the engine initializes the same way it does there.
+    model = LLM(
+        model_path=os.path.expanduser(args.model),
+        device=device_str,
+        tensor_parallel_size=args.tp,
+        cache_type=args.cache_type,
+        max_batch_size=len(entries),
+        max_tokens=max_new,
+        temperature=1.0,
+        top_k=1,   # greedy
+        top_p=1.0,
+        enable_graph=False,
+        attn_backend="default",
+    )
+
+    conversations = [e["messages"] for e in entries]
+    outputs = model.chat(messages=conversations)
+
+    all_pass = True
+    print(f"\n{'result':6} | prompt_tok | first_tok (ref vs this) | prefix | prompt")
+    print("-" * 90)
+    for e, out in zip(entries, outputs):
+        ref_gen = e["gen_token_ids"]
+        this_gen = list(out.outputs[0].token_ids)
+        this_prompt = list(out.prompt_token_ids or [])
+
+        prompt_match = (this_prompt == e["prompt_token_ids"]) if this_prompt else None
+
+        prefix = 0
+        for a, b in zip(ref_gen, this_gen):
+            if a == b:
+                prefix += 1
+            else:
+                break
+        first_match = bool(ref_gen and this_gen and ref_gen[0] == this_gen[0])
+
+        ok = first_match and prefix >= args.prefix_threshold and (prompt_match is not False)
+        all_pass &= ok
+
+        rt = ref_gen[0] if ref_gen else None
+        tt = this_gen[0] if this_gen else None
+        pm = {True: "ok", False: "MISMATCH", None: "n/a"}[prompt_match]
+        print(f"{'PASS' if ok else 'FAIL':6} | {pm:10} | {str(rt):>7} {'==' if first_match else '!='} "
+              f"{str(tt):<7} | {prefix:>2}/{min(len(ref_gen), len(this_gen))} | "
+              f"{e['messages'][0]['content'][:24]!r}")
+
+    print("-" * 90)
+    print(f"=== OVERALL: {'PASS' if all_pass else 'FAIL'} "
+          f"({sum(1 for _ in entries)} prompts) ===")
+    if not all_pass:
+        print("提示：若仅个别 prefix 早停而 first_tok 全 ==，通常是非确定性/近似平票，非适配错误；"
+              "若 first_tok 或 prompt_tok 不一致，才是真 bug（权重加载 / chat template / 路由）。")
+    sys.exit(0 if all_pass else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/models/qwen3_moe/dump_hf_reference.py
+++ b/test/models/qwen3_moe/dump_hf_reference.py
@@ -16,6 +16,7 @@ Usage:
     # CPU (needs ~60GB RAM for bf16; slow but avoids GPU contention):
     python3 dump_hf_reference.py --model /path/... --device cpu
 """
+
 import argparse
 import json
 
@@ -33,8 +34,9 @@ DEFAULT_PROMPTS = [
 
 
 def main():
-    ap = argparse.ArgumentParser(description=__doc__,
-                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
     ap.add_argument("--model", required=True)
     ap.add_argument("--out", default="qwen3_moe_prefill_reference.json")
     ap.add_argument("--device", default="cuda", choices=["cuda", "cpu"])
@@ -70,19 +72,25 @@ def main():
             attn = attn.to(model.device) if attn is not None else None
         with torch.no_grad():
             out = model.generate(
-                input_ids, attention_mask=attn,
-                max_new_tokens=args.max_new_tokens, do_sample=False,
+                input_ids,
+                attention_mask=attn,
+                max_new_tokens=args.max_new_tokens,
+                do_sample=False,
             )
-        gen_ids = out[0, input_ids.shape[1]:].tolist()
-        entries.append({
-            "messages": messages,
-            "prompt_token_ids": input_ids[0].tolist(),
-            "gen_token_ids": gen_ids,
-            "gen_text": tok.decode(gen_ids),
-        })
+        gen_ids = out[0, input_ids.shape[1] :].tolist()
+        entries.append(
+            {
+                "messages": messages,
+                "prompt_token_ids": input_ids[0].tolist(),
+                "gen_token_ids": gen_ids,
+                "gen_text": tok.decode(gen_ids),
+            }
+        )
         first = gen_ids[0] if gen_ids else None
-        print(f"[hf] {messages[0]['content'][:20]!r} -> first_tok={first} "
-              f"{tok.decode(gen_ids[:1])!r}")
+        print(
+            f"[hf] {messages[0]['content'][:20]!r} -> first_tok={first} "
+            f"{tok.decode(gen_ids[:1])!r}"
+        )
 
     payload = {
         "model": args.model,

--- a/test/models/qwen3_moe/dump_hf_reference.py
+++ b/test/models/qwen3_moe/dump_hf_reference.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Stage 1/2 of the Qwen3-MoE prefill correctness check: dump the HF reference.
+
+Loads Qwen3-30B-A3B-Thinking-2507 with HuggingFace transformers (**reference
+only** — the InfiniLM adaptation itself must not depend on transformers), greedily
+generates a few tokens for a fixed set of prompts, and saves the prompt token ids
++ generated token ids to JSON. Stage 2 (`check_prefill_logits.py`) then loads the
+InfiniLM engine and compares against this file.
+
+Two-phase design because the 30B model does not fit in memory twice: run this
+first (HF alone), then run the checker (InfiniLM alone).
+
+Usage:
+    # single GPU / multi-GPU (device_map=auto splits across visible GPUs):
+    python3 dump_hf_reference.py --model /path/Qwen3-30B-A3B-Thinking-2507 --device cuda
+    # CPU (needs ~60GB RAM for bf16; slow but avoids GPU contention):
+    python3 dump_hf_reference.py --model /path/... --device cpu
+"""
+import argparse
+import json
+
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+# Fixed prompts covering zh/en + reasoning. Kept in the reference file so the
+# checker replays the exact same messages (single source of truth).
+DEFAULT_PROMPTS = [
+    [{"role": "user", "content": "你好，请介绍一下自己"}],
+    [{"role": "user", "content": "用一句话解释什么是量子纠缠。"}],
+    [{"role": "user", "content": "What is the capital of France?"}],
+    [{"role": "user", "content": "计算 17 乘以 23 等于多少？请给出计算步骤。"}],
+]
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--model", required=True)
+    ap.add_argument("--out", default="qwen3_moe_prefill_reference.json")
+    ap.add_argument("--device", default="cuda", choices=["cuda", "cpu"])
+    ap.add_argument("--dtype", default="bfloat16")
+    ap.add_argument("--max-new-tokens", type=int, default=16)
+    args = ap.parse_args()
+
+    tok = AutoTokenizer.from_pretrained(args.model, trust_remote_code=True)
+    dtype = getattr(torch, args.dtype)
+    model = AutoModelForCausalLM.from_pretrained(
+        args.model,
+        torch_dtype=dtype,
+        trust_remote_code=True,
+        device_map="auto" if args.device == "cuda" else None,
+    )
+    if args.device == "cpu":
+        model = model.to("cpu")
+    model.eval()
+
+    entries = []
+    for messages in DEFAULT_PROMPTS:
+        # Newer transformers return a BatchEncoding (dict) here instead of a bare
+        # tensor; handle both. Also pass attention_mask when available.
+        tpl = tok.apply_chat_template(
+            messages, add_generation_prompt=True, return_tensors="pt"
+        )
+        if torch.is_tensor(tpl):
+            input_ids = tpl.to(model.device)
+            attn = None
+        else:
+            input_ids = tpl["input_ids"].to(model.device)
+            attn = tpl.get("attention_mask")
+            attn = attn.to(model.device) if attn is not None else None
+        with torch.no_grad():
+            out = model.generate(
+                input_ids, attention_mask=attn,
+                max_new_tokens=args.max_new_tokens, do_sample=False,
+            )
+        gen_ids = out[0, input_ids.shape[1]:].tolist()
+        entries.append({
+            "messages": messages,
+            "prompt_token_ids": input_ids[0].tolist(),
+            "gen_token_ids": gen_ids,
+            "gen_text": tok.decode(gen_ids),
+        })
+        first = gen_ids[0] if gen_ids else None
+        print(f"[hf] {messages[0]['content'][:20]!r} -> first_tok={first} "
+              f"{tok.decode(gen_ids[:1])!r}")
+
+    payload = {
+        "model": args.model,
+        "max_new_tokens": args.max_new_tokens,
+        "note": "greedy (do_sample=False) HF reference; compare with check_prefill_logits.py",
+        "entries": entries,
+    }
+    with open(args.out, "w", encoding="utf-8") as f:
+        json.dump(payload, f, ensure_ascii=False, indent=2)
+    print(f"saved {len(entries)} entries -> {args.out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION


# T2\-1\-3 Qwen3\-MoE 推理性能优化 — 赛题报告

> 小组：justdoit \| 目标模型：Qwen/Qwen3\-30B\-A3B\-Thinking\-2507
> 平台：**沐曦 MetaX C500（TP=2）\+ NVIDIA RTX 4090D（TP=4）双平台正确性 PASS \+ 并发吞吐实测** 
> 代码：InfiniCore `2026-spring-goog00-T2-1-3` 分支 · InfiniLM `2026-spring-goog00-T2-1-3` 分支
> 
> 
> 

---

## 实现的功能概述

在 InfiniLM/InfiniCore 框架上完成 **Qwen3\-30B\-A3B\-Thinking\-2507**（30B 总参 / 3B 激活，
128 专家、top\-8、48 层全 MoE、BF16）的**可运行 \+ 性能优化**适配，并给出正确性与性能的实测证据。
<img width="1454" height="900" alt="image" src="https://github.com/user-attachments/assets/c73a698d-d366-4696-9d9d-146b85e4c4dd" />


---

## 使用的技术方案与参考资料

### 2\.1 架构确认（对照 HF）

对照 `config.json` 与 transformers `modeling_qwen3_moe` 确认：`model_type=qwen3_moe`，
**无共享专家、无 aux\-free 偏置、per\-expert split 权重、48 层全 MoE**，与 InfiniLM 现有
`qwen3_moe` 骨架完全兼容，**无需新建模型目录、无需扩展路由算子**。风险集中在性能优化。


### 2\.2 核心方案：`grouped_gemm` 专家批化

**问题**：原朴素实现对 ntoken × top\-8 个 \(token, expert\) 组合**逐个**调用单专家 MLP，
每次都是 1×hidden 的小 GEMM，完全失去 batch 性，kernel launch 爆炸。

**方案**（InfiniCore 新增 `grouped_gemm` 算子 \+ InfiniLM 重写 `Qwen3MoeExperts::forward`）：

1. CPU 端对路由 indices 分桶，得到每专家 token 数 `counts` 与置换 `perm`；

2. `embedding` 按 `perm` gather → 三次 `grouped_gemm`（gate/up/down，各一次覆盖全部专家）

    - `swiglu`；

3. 路由权重广播缩放 → `index_add_` scatter 回原 token；

4. TP `allreduce`。

`grouped_gemm` 接收 `group_sizes`，一次调用内对各专家 slab 依次发 GEMM（行主序
`C=A@Bᵀ`，列主序转置实现），CPU/NVIDIA/MetaX 三后端 \+ CPU 参考实现 \+ Python 单测。

### 2\.3 `grouped_gemm` 的 host\-counts 直通接口

`grouped_gemm` 额外提供**可选**的 host 端 `group_sizes` 直通参数（默认 `nullptr`，向后兼容），
允许调用方在已知各专家 token 数时跳过算子内部的 device→host 同步拷贝。该接口为拷贝\-同步
受限平台预留优化位，不影响默认路径行为。性能主线是 §2\.2 的 grouped\_gemm 批化（见 §3 实测）。

### 2\.4 参考资料

- HF 模型与配置：`Qwen/Qwen3-30B-A3B-Thinking-2507`（config\.json / generation\_config / tokenizer）

- transformers `modeling_qwen3_moe.py`（权重命名、路由、chat template 参照）

- InfiniLM/InfiniCore 框架现有 `qwen3_moe` 骨架、`op::topksoftmax`、`moe_mlp`、TP 通信

---

## 测试脚本：运行方式与运行效果

> 硬件：**NVIDIA RTX 4090D × 4（TP=4）** 与 **沐曦 MetaX C500 × 2（TP=2）** 两套环境，均为**真机实测**。
> 本章按平台分列：先 §3\.1 NVIDIA，后 §3\.2 沐曦，§3\.3 双平台一致性小结。
> 
> 

**通用方法（两平台一致）：**

- **正确性 = prefill 对齐 HF（两阶段）**：30B 放不下两份，故 HF 参照离线先跑存盘，再用 InfiniLM 对比。
HF 仅作参照，不进入推理路径。

```Bash
# 阶段1：HF 参照（两平台共用一份）
python3 test/models/qwen3_moe/dump_hf_reference.py \--model <path>/Qwen3-30B-A3B-Thinking-2507 --device cuda --out /tmp/qwen3_ref.json
# 阶段2：InfiniLM 对比（退出码 0=PASS；--device 换 nvidia/metax，--tp 换 4/2）
python3 test/models/qwen3_moe/check_prefill_logits.py \--model <path>/Qwen3-30B-A3B-Thinking-2507 --device <nvidia|metax> --tp <4|2> --ref /tmp/qwen3_ref.json
```

- 判读：`prompt_tok ok`（chat template/分词一致）\+ `first_tok ==`（prefill 首步 argmax 与 HF 一致）

    - `prefix 16/16`（前 16 个贪心 token 逐一命中）。

> - 本模型 run\-to\-run 非确定（TP all\-reduce 规约顺序 \+ BF16 `index_add_` 原子加），长序列必然分叉，
> 故用首/前缀 token argmax 对齐（贪心解码真正依赖的量）而非整段 bit\-exact。
> 
> 

- **性能 = 并发服务吞吐**：`bench/qwen3_moe/`，server \+ 零依赖并发客户端。
`out_tok/s` = 聚合输出吞吐，`total_tok/s` = 含 prefill 的聚合总吞吐（单流速率 = 聚合 / 并发数）。

```Bash
MODEL=<path> DEVICE=<nvidia|metax> TP=<4|2> ATTN=paged-attn bash bench/qwen3_moe/serve.sh
python3 bench/qwen3_moe/load_client.py --tag this
python3 bench/qwen3_moe/summarize.py bench_results/this
```

---

### 3\.1 NVIDIA RTX 4090D（TP=4）

#### 3\.1\.1 正确性：prefill 对齐 HF —— 4/4 PASS

<img width="1981" height="256" alt="image" src="https://github.com/user-attachments/assets/e405825d-80a6-49a3-a0d8-a979572e237a" />


<img width="1280" height="409" alt="image" src="https://github.com/user-attachments/assets/8b673248-6319-400b-9371-da42af0a6b2d" />


*图 3\.1\.1：RTX 4090D TP=4 **`check_prefill_logits.py`** —— 4 条 prompt 首 token \+ 前 16 token 全命中 HF，OVERALL PASS。*

#### 3\.1\.2 并发吞吐

4090D 单卡 24GB，30B 权重（TP=4 每卡 \~15GB）后 KV 空间有限，取代表性子集：

<img width="1280" height="486" alt="image" src="https://github.com/user-attachments/assets/98549029-b8ee-4a79-9c63-2621d9e36505" />


<img width="1280" height="261" alt="image" src="https://github.com/user-attachments/assets/fdac8c63-609d-441b-a06b-85c9a76c1534" />


*图 3\.1\.2：RTX 4090D TP=4 **`load_client.py`** —— 单流 decode ≈ 34 tok/s；bs=8 聚合 \~178 tok/s；长输入 in=2048 总吞吐达 ****1605 tok/s****。*

- **单流 decode ≈ 34 tok/s**（Ada 架构）；输出吞吐随并发放大、长输入总吞吐极高。

#### 3\.1\.3 端到端连贯输出

<img width="1280" height="300" alt="image" src="https://github.com/user-attachments/assets/13f49fcd-3fce-415f-9b01-ce2760605d22" />



*图 3\.1\.3：RTX 4090D TP=4 **`test_infer.py --backend cpp`** —— "How are you" → 正常 **`<think>…</think>`** 思考链 \+ 连贯英文回答，**`total_time`** ≈ 7\.6 s。*

---

### 3\.2 沐曦 MetaX C500（TP=2）

#### 3\.2\.1 正确性：prefill 对齐 HF —— 4/4 PASS

<img width="1280" height="386" alt="image" src="https://github.com/user-attachments/assets/56a0f94a-67ba-4c24-86da-723eae74d1a3" />


<img width="1280" height="511" alt="image" src="https://github.com/user-attachments/assets/48a6feb7-4937-4bf1-8f96-8c311609efe6" />


*图 3\.2\.1：沐曦 C500 TP=2 **`check_prefill_logits.py`** —— 4 条 prompt 首 token \+ 前 16 token 全命中 HF，OVERALL PASS。*

- 首 token 与 NVIDIA 逐一相同（106287 / 106287 / 32313 / 107520），验证**两平台行为一致**。

#### 3\.2\.2 性能：base vs this（grouped\_gemm 的收益）

base=朴素逐 token MoE，this=grouped\_gemm，同参数可比：
<img width="1280" height="731" alt="image" src="https://github.com/user-attachments/assets/5a22be3c-4aac-4877-9706-ddd88615f6d0" />



*图 3\.2\.2：**`summarize.py base this`** —— bs=1 输出吞吐 base 10\.98 → this 15\.56（****\+41\.7%****），bs=8 \+4\.8%。*

- **bs=1：grouped\_gemm 输出吞吐 \+42%**——朴素版每 token 跑 8 个独立小专家 MLP（8× launch/token），
grouped\_gemm 批成 3 次 grouped GEMM，launch 大减。

- **小规模（bs=1）不但不回退，还大幅提升**（超额满足赛题「小规模不回退」要求）。

#### 3\.2\.3 并发 × 长输入 × 长输出 完整矩阵

`concurrency ∈ {1,8,32} × input ∈ {32,256,2048} × output ∈ {256,1024}`，共 18 组，全部实测通过
（C500 单卡 64GB，可跑完整矩阵）：

<img width="1280" height="573" alt="image" src="https://github.com/user-attachments/assets/82433061-fe03-465b-867d-ef9105668057" />


<img width="1280" height="500" alt="image" src="https://github.com/user-attachments/assets/c41c3f7a-d237-49c5-a502-bb0b5ade1f65" />



<img width="1280" height="490" alt="image" src="https://github.com/user-attachments/assets/da9722b7-812b-4f3d-a807-c15fa660ab44" />


*图 3\.2\.3：沐曦 C500 TP=2 **`load_client.py`** 完整矩阵（18 组）—— 输出吞吐随并发放大（in=256/out=256 段 bs 1→8→32 = 24\.5 → 86\.5 → 143\.2 tok/s，峰值 270 tok/s）；长输入 in=2048、bs=32 总吞吐达 ****1236\.7 tok/s****。*

- **输出吞吐随并发放大**：同配置 bs 1→8→32 聚合 out\_tok/s 逐级抬升（如 in=256/out=256 段
24\.5 → 86\.5 → 143\.2，≈3\.5×/5\.8×），峰值 **270 tok/s**，调度器组批有效、grouped\_gemm 批量 decode 持续获益。

- **总吞吐（含 prefill）在长输入下极高**：in=2048、bs=32 达 **1236\.7 tok/s** → prefill 大矩阵正是
grouped\_gemm 批处理的强项。

#### 3\.2\.4 端到端连贯输出

<img width="1280" height="705" alt="image" src="https://github.com/user-attachments/assets/6a93f67f-0807-4400-91d7-9474eeee2446" />


*图 3\.2\.4：沐曦 C500 TP=2 —— "你好，请介绍一下自己" → 正常 **`<think>…</think>`** 思考链 \+ 连贯中文自我介绍，**`total_time`** ≈ 12\.2 s。*

---

### 3\.3 双平台一致性小结

<img width="1350" height="678" alt="image" src="https://github.com/user-attachments/assets/f54cf16d-cc05-4051-8e63-c765d4bef696" />

→ **同一套 InfiniLM ****`T2-1-3`**** \+ InfiniCore ****`grouped_gemm`**** 代码在两平台正确性一致、性能趋势一致，**
**`grouped_gemm`**** 的 CPU/NVIDIA/MetaX 三后端均验证有效。**

---



---

## 附录 A：关键代码位置


<meta charset="utf-8"><div data-page-id="FILCdKBEFonU2BxQZ1EcWdfxneQ" data-lark-html-role="root" data-docx-has-block-data="true"><div data-type="sheet" class=" old-record-id-Gx5NdUZmWo2KGzxweT3czE27nNc"><!--StartFragment--><meta http-equiv="Content-Type" content="text/html; charset=utf-8"><style><!--br {mso-data-placement:same-cell;}--> td {white-space:nowrap;border:0.5pt solid #dee0e3;font-size:10pt;font-style:normal;font-weight:normal;vertical-align:middle;word-break:normal;word-wrap:normal;}</style><byte-sheet-html-origin data-id="" data-version="4" data-is-embed="true" data-grid-line-hidden="false" data-lark-html-role="root" data-copy-type="col">
仓库 | 路径 | 内容
-- | -- | --
InfiniCore | src/infiniop/ops/grouped_gemm/（cpu/nvidia/metax） | 算子三后端 + C/Graph API + Python 单测
InfiniCore | src/infinicore/ops/grouped_gemm/ | infinicore op 层封装（含 host counts 直通）
InfiniLM | csrc/models/qwen3_moe/qwen3_moe_experts.cpp | MoE experts 批化前向
InfiniLM | test/models/qwen3_moe/{dump_hf_reference,check_prefill_logits}.py | 正确性脚本
InfiniLM | bench/qwen3_moe/ | 并发吞吐基准（serve/load_client/summarize/README）

</byte-sheet-html-origin><!--EndFragment--></div></div><span data-lark-record-data="{&quot;isCut&quot;:false,&quot;rootId&quot;:&quot;FILCdKBEFonU2BxQZ1EcWdfxneQ&quot;,&quot;parentId&quot;:&quot;FILCdKBEFonU2BxQZ1EcWdfxneQ&quot;,&quot;blockIds&quot;:[576],&quot;recordIds&quot;:[&quot;Gx5NdUZmWo2KGzxweT3czE27nNc&quot;],&quot;recordMap&quot;:{&quot;Gx5NdUZmWo2KGzxweT3czE27nNc&quot;:{&quot;id&quot;:&quot;Gx5NdUZmWo2KGzxweT3czE27nNc&quot;,&quot;snapshot&quot;:{&quot;hidden&quot;:false,&quot;author&quot;:&quot;7339394918640140289&quot;,&quot;token&quot;:&quot;C6V9seoFYhXPobtr4xkcS2y9nlc_D4MEGn&quot;,&quot;type&quot;:&quot;sheet&quot;,&quot;parent_id&quot;:&quot;FILCdKBEFonU2BxQZ1EcWdfxneQ&quot;,&quot;comments&quot;:[],&quot;revisions&quot;:[],&quot;locked&quot;:false}},&quot;FILCdKBEFonU2BxQZ1EcWdfxneQ&quot;:{&quot;id&quot;:&quot;FILCdKBEFonU2BxQZ1EcWdfxneQ&quot;,&quot;snapshot&quot;:{&quot;revisions&quot;:[],&quot;hidden&quot;:false,&quot;author&quot;:&quot;7339394918640140289&quot;,&quot;children&quot;:[&quot;VPUOd1h9LoTa42xHIVNcl5Adnaf&quot;,&quot;SV87dbVu9oTcn5x3flschgiJnwd&quot;,&quot;B21rd7SxIoZ8LkxPlumcLGebnUc&quot;,&quot;Z27tdeV4PoMhdfxBoWWcszS1nDd&quot;,&quot;DVoidsg4xohYOMxY03XcdwDNnRg&quot;,&quot;EhywdLLQFoHFPpxuZ6ncwQ2Vn28&quot;,&quot;WeWqdrZd4o5CLQxyuREceBo7n9e&quot;,&quot;V6mYdJpxVoqtQ7x375YcuWegnBb&quot;,&quot;VN14dmB0noQ3K5xWYvKc2t6OnTc&quot;,&quot;Hkead3goSoYRfHxwLN1c9fMXn7b&quot;,&quot;ZiXNdJkssoNa9Rxe9yScb3sznNc&quot;,&quot;OecldOoG1odJZ3x9XEUc7d2MnIg&quot;,&quot;TgMlddT3EossRHxCLvhcnwfrnZe&quot;,&quot;VLK9dBh8YoA4hFxc0g0cwSyyneh&quot;,&quot;CykTdUEGqoLW3uxD76GcUoprnve&quot;,&quot;HGN7dNjIJoS1FhxGsCXcALIFnTU&quot;,&quot;YTSadRAl9ojPuVxh1Qlc0pLUnth&quot;,&quot;Gjjyd5CLSoizcBxvFYxc2Uurnub&quot;,&quot;Mk0kdEuPDogPzexHtgZcb85tnfd&quot;,&quot;EDdIddfRxooay7xa0Nnc24y3nHf&quot;,&quot;R4h0da7cXoI6enx1AyFcQcVvnkb&quot;,&quot;IWxqdDNHVoB8XrxpBotcunwunfd&quot;,&quot;A0erdI8bWoV3jZxDspYctjAencg&quot;,&quot;Mu35dPkHGoXO0XxPCnNc1YlSnae&quot;,&quot;ZgVxd4qtcoDyRVx2X4ncjNSKnxe&quot;,&quot;CAORdKMZlox5N2xBVTFcJS61n5d&quot;,&quot;Be5od6fRboRIrhx1SBacxWj0npe&quot;,&quot;CVgxdvinnot3e5xDTcLcWXYLnDh&quot;,&quot;X00adoGoOoFZ1Sxu707cLlZmnNb&quot;,&quot;XlNHd7poVoYcu3xtLJpcUaR9nKe&quot;,&quot;XLcOd3CCZo2iYTxgfu8cr1U2nTb&quot;,&quot;V9ZedxHGGoy22ixIkLPcvJ7jnzh&quot;,&quot;IGtpdbsFwovTrQxj3i5co29znSh&quot;,&quot;MmjcdpQM6oExUzxazV3cG9GqnVh&quot;,&quot;UVUydXrONojXL9xvdeecmKRTnzh&quot;,&quot;XvdIdAOaDoyQtlxfGKbcD7hJnfd&quot;,&quot;NFQvd6NlOoiWCwxVBZ0cNQNCnJe&quot;,&quot;CxEudTCjwoMOoRx9OSycwWbqnj0&quot;,&quot;YzKtdI22No4LTvx9t8lcRFH9nKc&quot;,&quot;NzyWd177xoENxGxb0AxchcTpn4f&quot;,&quot;D8WIddtK4ow7BJx3ds1c65fhnOy&quot;,&quot;IWoCdQGN0oPiOgxLj1ScUO96nud&quot;,&quot;K0a9dzISDo3ucSxKvFIcvobHnxe&quot;,&quot;JH5fdDLfooRDWzxbg8TcZbsWnEf&quot;,&quot;SlpMdAY7woKmI2x2IbxcNc02nbf&quot;,&quot;J6QkdbR4joLq1nxt4aNchO51nsb&quot;,&quot;JFkKdMvQPoHxmoxSNkUcremxnkg&quot;,&quot;X422dkMDSoJxurxNgKicSugDnXg&quot;,&quot;UgZmdwJVVobwQuxKY1Hccj29n9f&quot;,&quot;Oofzdl699oF04SxDgXTckiYPnvb&quot;,&quot;QftudFfZ6oyiMRxQFkjcp3j2nkb&quot;,&quot;CQ4udbeL3oGaEDxeIZscIc9unPh&quot;,&quot;CrkedgoCColcTDxtnx7ct4oYnIc&quot;,&quot;XtrJdDNLgoW0xmxJobkcJeKnn7g&quot;,&quot;WdrpdEio6org5bxncARctfB8ntg&quot;,&quot;SskRdOntDocORrxSAv6cgJs2nYb&quot;,&quot;HzN0dPR0kopPFJxKMAnc2SM8nSf&quot;,&quot;Fua6dVF6noutoWxrNXQcXvvynBd&quot;,&quot;Qt7JdW2tWo3WuWx1zZgcysnYnDh&quot;,&quot;T08ldhXoFohhJYxK6kmc7AHLnSg&quot;,&quot;XIT1d8h0PoVqCyx5SHxcPF12njg&quot;,&quot;UILCdDT6NoPqDexv4fcc3PWZnMH&quot;,&quot;JzUddkPYeobXIUxuRQocOqcrnyx&quot;,&quot;Ye6Jd5giSo217xxWxQQc9jqSnmh&quot;,&quot;VkapdnmVjo3H7SxlRtRcFL9onAh&quot;,&quot;HcJ9dgMp2oFltCxU2egcs4fAnZe&quot;,&quot;CDo6dJkYdokzX0xnirqcoQ45nYf&quot;,&quot;Tg8Ddbw8SoVBrwx9OfFcRscsnqg&quot;,&quot;A7Y8d1SARoDbihxRN2HccDFsnlf&quot;,&quot;MMopdcbSWoadAKxiAgpcnVOVnRf&quot;,&quot;IGmXdW6j2of9uYxWzWncsl2Rnyh&quot;,&quot;R5wjdN3EPojwrsxTb1Gchm8ansf&quot;,&quot;W7hTdWx45oskJixEcxqch5vcnt9&quot;,&quot;KqcadB1eyo20iMxRU4xc8HRDnUd&quot;,&quot;OSPfdMZkQoim26xzvhtcF5mmnsd&quot;,&quot;TDjzd1oq3oQ9vZxMxuDcbWIdnmb&quot;,&quot;CtQ6dnF3Boyye0xElWvcpr16nTh&quot;,&quot;GWDedO3tuocs1Ox569RcvXQun3L&quot;,&quot;NY9udsnXRoxqmlxQMH6cwtA0nAd&quot;,&quot;TakHdXBH6o95ELxx2KSc0vINnof&quot;,&quot;ME1RdCQQQoaPlnxrellcuYDxnBf&quot;,&quot;YkI7dxiB1oO8mKxRjtNcKRTPnBc&quot;,&quot;J5sudbAk7ohd58xAeIGclZehnze&quot;,&quot;KUGFd1iPdoMECux9egPcV3N7nCh&quot;,&quot;Gx5NdUZmWo2KGzxweT3czE27nNc&quot;,&quot;IhwNd2XyJoLmzKxtQSJcyeVanEb&quot;,&quot;PPZQdRa1wo6af9xxAOzcqxd9nNg&quot;],&quot;text&quot;:{&quot;apool&quot;:{&quot;nextNum&quot;:1,&quot;numToAttrib&quot;:{&quot;0&quot;:[&quot;author&quot;,&quot;7339394918640140289&quot;]}},&quot;initialAttributedTexts&quot;:{&quot;attribs&quot;:{&quot;0&quot;:&quot;*0+u&quot;},&quot;text&quot;:{&quot;0&quot;:&quot;T2-1-3 Qwen3-MoE 推理性能优化 — 赛题报告&quot;}}},&quot;parent_id&quot;:&quot;&quot;,&quot;comments&quot;:[],&quot;align&quot;:&quot;&quot;,&quot;doc_info&quot;:{&quot;option_modified&quot;:null,&quot;editors&quot;:[&quot;7339394918640140289&quot;],&quot;options&quot;:[&quot;editors&quot;,&quot;edit_time&quot;],&quot;deleted_editors&quot;:null},&quot;type&quot;:&quot;page&quot;,&quot;locked&quot;:false}}},&quot;payloadMap&quot;:{},&quot;extra&quot;:{&quot;channel&quot;:&quot;saas&quot;,&quot;pasteRandomId&quot;:&quot;c0bad32e-0878-4cd3-818e-c4906d1255af&quot;,&quot;mention_page_title&quot;:{},&quot;external_mention_url&quot;:{},&quot;isEqualBlockSelection&quot;:true},&quot;isKeepQuoteContainer&quot;:false,&quot;selection&quot;:[{&quot;id&quot;:576,&quot;type&quot;:&quot;block&quot;,&quot;recordId&quot;:&quot;Gx5NdUZmWo2KGzxweT3czE27nNc&quot;}],&quot;pasteFlag&quot;:&quot;137adcab-cd64-41c7-b850-5ff083b8e29e&quot;}" data-lark-record-format="docx/record" class="lark-record-clipboard"></span>


[Honor Code.pdf](https://github.com/user-attachments/files/29940699/2026.Honor.Code.1.pdf)
