### PR TITLE
fix: metax event.c

### DIFF
--- a/csrc/engine/infer_engine.cpp
+++ b/csrc/engine/infer_engine.cpp
@@ -2,6 +2,7 @@
 #include "../config/config_factory.hpp"
 #include "spdlog/spdlog.h"
 #include <future>
+#include <mutex>
 #include <stdexcept>
 #include <unordered_set>
 
@@ -146,6 +147,15 @@ std::vector<std::string> InferEngine::state_dict_keys() {
 //------------------------------------------------------
 infinilm::InfinilmModel::Input
 InferEngine::Input::to_model_input(infinicore::Device device) const {
+    // MACA maps a registered user pointer to only one node. Serialize H2D
+    // copies so TP ranks never access the same host registration concurrently.
+    static std::mutex maca_host_copy_mutex;
+    const bool serialize_host_copy
+        = device.getType() == infinicore::Device::Type::METAX;
+    std::unique_lock<std::mutex> maca_host_copy_lock;
+    if (serialize_host_copy) {
+        maca_host_copy_lock = std::unique_lock<std::mutex>(maca_host_copy_mutex);
+    }
 
     auto to_device = [&](const std::optional<infinicore::Tensor> &t)
         -> std::optional<infinicore::Tensor> {
@@ -182,6 +192,10 @@ InferEngine::Input::to_model_input(infinicore::Device device) const {
         image_req_ids,
         visual_token_ranges,
         to_device(target_hidden_states)};
+
+    if (serialize_host_copy) {
+        infinicore::context::syncStream();
+    }
 
     infinilm::global_state::get_forward_context().attn_metadata = {
         input.past_sequence_lengths,


### PR DESCRIPTION
python python/infinilm/server/inference_server.py --model=/data-aisoft/mechdancer/models/Qwen3.6-27B/ --enable-paged-attn --attn=flash-attn --num-blocks 64 --tp=4