### PR TITLE
Feat/mars devices split

### DIFF
--- a/csrc/models/deepseek_v2/deepseek_v2_moe.cpp
+++ b/csrc/models/deepseek_v2/deepseek_v2_moe.cpp
@@ -18,6 +18,7 @@ bool supports_fused_deepseek_moe(infinicore::Device::Type device_type) {
     case infinicore::Device::Type::HYGON:
     case infinicore::Device::Type::ILUVATAR:
     case infinicore::Device::Type::METAX:
+    case infinicore::Device::Type::MARS:
     case infinicore::Device::Type::MOORE:
         return true;
     default:

--- a/python/infinilm/base_config.py
+++ b/python/infinilm/base_config.py
@@ -155,27 +155,26 @@ class BaseConfig:
         if self.enable_paged_attn and self.attn == "default":
             self.attn = "paged-attn"
 
-        # Force sync weight loading for Metax devices
-        self._force_sync_for_metax()
+        self._force_sync_weight_loading()
 
-    def _force_sync_for_metax(self):
-        """Force weight_load_mode to 'sync' for Metax devices."""
-        # Check if device is explicitly set to Metax
-        if self.device.lower() == "metax":
+    def _force_sync_weight_loading(self):
+        """Force synchronous weight loading on MetaX and Mars devices."""
+        device = self.device.lower()
+        if device in ("metax", "mars"):
             self.weight_load_mode = "sync"
             warnings.warn(
-                "Metax device detected: forcing weight_load_mode to 'sync'",
+                f"{device} device detected: forcing weight_load_mode to 'sync'",
                 UserWarning,
             )
             return
 
-        # Check if auto-detected device is Metax
-        if self.device.lower() == "auto":
+        if device == "auto":
             detected_device = self.detect_device()
-            if detected_device.lower() == "metax":
+            if detected_device.lower() in ("metax", "mars"):
                 self.weight_load_mode = "sync"
                 warnings.warn(
-                    "Auto-detected Metax device: forcing weight_load_mode to 'sync'",
+                    f"Auto-detected {detected_device} device: "
+                    "forcing weight_load_mode to 'sync'",
                     UserWarning,
                 )
 
@@ -199,8 +198,8 @@ class BaseConfig:
             type=str,
             default="auto",
             help=(
-                "device platform: auto, cpu, nvidia, qy, metax, moore, iluvatar, "
-                "ali, cambricon, ascend, kunlun, hygon, or backend name "
+                "device platform: auto, cpu, nvidia, qy, metax, mars, moore, "
+                "iluvatar, ali, cambricon, ascend, kunlun, hygon, or backend name "
                 "(cuda/mlu/musa/npu)"
             ),
         )
@@ -519,6 +518,7 @@ class BaseConfig:
                 return device_name
 
         env_checks = [
+            ("mars", ["HPCC_PATH", "HPCC_HOME"]),
             ("metax", ["MACA_PATH", "MACA_HOME", "MACA_ROOT"]),
             ("hygon", ["DTK_HOME", "DTK_PATH"]),
         ]
@@ -530,7 +530,8 @@ class BaseConfig:
             ("cambricon", ["cnmon"]),
             ("ascend", ["npu-smi"]),
             ("moore", ["mthreads-gmi"]),
-            ("metax", ["mx-smi", "ht-smi"]),
+            ("mars", ["ht-smi"]),
+            ("metax", ["mx-smi"]),
             ("hygon", ["hy-smi"]),
             ("ali", ["ppu-smi"]),
             ("iluvatar", ["ixsmi"]),
@@ -558,6 +559,7 @@ class BaseConfig:
             "cambricon": "mlu",
             "ascend": "npu",
             "metax": "cuda",
+            "mars": "cuda",
             "moore": "musa",
             "iluvatar": "cuda",
             "kunlun": "cuda",

--- a/python/infinilm/exception_utils.py
+++ b/python/infinilm/exception_utils.py
@@ -24,7 +24,7 @@ def _iter_exception_chain(
 
 def is_oom_exception(e: BaseException) -> bool:
     """
-    Conservative OOM detector for MetaX allocator failures and CUDA/PyTorch OOMs.
+    Conservative OOM detector for MetaX/Mars allocator failures and CUDA/PyTorch OOMs.
     Checks exception type (when available) and message substrings across chained exceptions.
     """
     # PyTorch OOM exception type (only if torch is present in this environment)
@@ -42,7 +42,7 @@ def is_oom_exception(e: BaseException) -> bool:
     # Common patterns observed for allocator failures.
     # Keep this allowlist small to avoid hard-exiting on unrelated errors.
     patterns = (
-        # MetaX / infinirt allocator
+        # MetaX/Mars and InfiniRT allocators
         "hcmalloc",
         "infinirtmalloc",
         "out of memory",

--- a/test/bench/backends/infinilm.py
+++ b/test/bench/backends/infinilm.py
@@ -17,6 +17,7 @@ class InfiniLMBenchmark(BaseBenchmark):
         enable_paged_attn=False,
         enable_graph=False,
         attn_backend="default",
+        weight_load_mode="async",
     ):
         from infinilm import LLM
 
@@ -61,6 +62,7 @@ class InfiniLMBenchmark(BaseBenchmark):
             block_size=256,
             enable_graph=enable_graph,
             attn_backend=attn_backend,
+            weight_load_mode=weight_load_mode,
         )
         self.processor = self.model.engine.processor
         self.tokenizer = self.processor.get_tokenizer()

--- a/test/bench/backends/infinilm.py
+++ b/test/bench/backends/infinilm.py
@@ -28,6 +28,7 @@ class InfiniLMBenchmark(BaseBenchmark):
             "cambricon": "mlu",
             "ascend": "npu",
             "metax": "cuda",
+            "mars": "cuda",
             "moore": "musa",
             "iluvatar": "cuda",
             "kunlun": "cuda",

--- a/test/bench/test_benchmark.py
+++ b/test/bench/test_benchmark.py
@@ -606,13 +606,14 @@ def main():
         model = VLLMBenchmark(cfg.model, device_str, cfg.tp, cfg.bench)
     elif cfg.backend in {"infinilm", "cpp", "python"}:
         model = InfiniLMBenchmark(
-            cfg.model,
-            device_str,
-            cfg.tp,
-            cfg.bench,
-            cfg.enable_paged_attn,
-            cfg.enable_graph,
-            cfg.attn,
+            model_dir_path=cfg.model,
+            device_type_str=device_str,
+            tensor_parallel_size=cfg.tp,
+            benchmark=cfg.bench,
+            enable_paged_attn=cfg.enable_paged_attn,
+            enable_graph=cfg.enable_graph,
+            attn_backend=cfg.attn,
+            weight_load_mode=cfg.weight_load_mode,
         )
     else:
         raise ValueError(f"Unsupported backend: {cfg.backend}")

--- a/test/models/qwen3_moe/attention_test.py
+++ b/test/models/qwen3_moe/attention_test.py
@@ -1,10 +1,10 @@
 import os
-import time
 import sys
+import time
+
 import safetensors
 import torch
-from transformers import AutoConfig
-from transformers import DynamicCache
+from transformers import AutoConfig, DynamicCache
 from transformers.models import qwen3_moe
 
 WARMUPS = 10
@@ -46,6 +46,11 @@ def get_args():
         "--metax",
         action="store_true",
         help="Run metax test",
+    )
+    parser.add_argument(
+        "--mars",
+        action="store_true",
+        help="Run Mars test",
     )
     parser.add_argument(
         "--moore",
@@ -446,14 +451,16 @@ if __name__ == "__main__":
         device = "cuda"
     elif args.metax:
         device = "cuda"
+    elif args.mars:
+        device = "cuda"
     elif args.moore:
         device = "musa"
-        import torch_musa
+        import torch_musa  # noqa: F401 - registers the torch.musa backend
     elif args.iluvatar:
         device = "cuda"
     else:
         print(
-            "Usage:  python test/models/qwen3_moe/attention_test.py [--cpu | --nvidia | --metax | --moore | --iluvatar] --model_path=<path/to/model_path>"
+            "Usage:  python test/models/qwen3_moe/attention_test.py [--cpu | --nvidia | --metax | --mars | --moore | --iluvatar] --model_path=<path/to/model_path>"
         )
         sys.exit(1)
 

--- a/test/models/qwen3_moe/moe_test.py
+++ b/test/models/qwen3_moe/moe_test.py
@@ -1,11 +1,11 @@
-import time
-import torch
-import transformers
-import safetensors
 import os
+import sys
+import time
+
+import safetensors
+import torch
 from transformers import AutoConfig
 from transformers.models import qwen3_moe
-import sys
 
 WARMUPS = 10
 RUNS = 100
@@ -46,6 +46,11 @@ def get_args():
         "--metax",
         action="store_true",
         help="Run metax test",
+    )
+    parser.add_argument(
+        "--mars",
+        action="store_true",
+        help="Run Mars test",
     )
     parser.add_argument(
         "--moore",
@@ -139,14 +144,16 @@ if __name__ == "__main__":
         device = "cuda"
     elif args.metax:
         device = "cuda"
+    elif args.mars:
+        device = "cuda"
     elif args.moore:
         device = "musa"
-        import torch_musa
+        import torch_musa  # noqa: F401 - registers the torch.musa backend
     elif args.iluvatar:
         device = "cuda"
     else:
         print(
-            "Usage:  python test/models/qwen3_moe/moe_test.py [--cpu | --nvidia | --metax | --moore | --iluvatar] --model_path=<path/to/model_path>"
+            "Usage:  python test/models/qwen3_moe/moe_test.py [--cpu | --nvidia | --metax | --mars | --moore | --iluvatar] --model_path=<path/to/model_path>"
         )
         sys.exit(1)
 

--- a/test/test_base_config.py
+++ b/test/test_base_config.py
@@ -1,0 +1,68 @@
+import json
+import os
+import tempfile
+import unittest
+import warnings
+from pathlib import Path
+from unittest import mock
+
+from bench.backends.infinilm import InfiniLMBenchmark
+from infinilm.base_config import BaseConfig
+
+
+class TestMarsBaseConfig(unittest.TestCase):
+    def make_config(self, device="mars", weight_load_mode="async"):
+        config = BaseConfig.__new__(BaseConfig)
+        config.device = device
+        config.weight_load_mode = weight_load_mode
+        return config
+
+    def test_explicit_mars_forces_sync_weight_loading(self):
+        config = self.make_config()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            config._force_sync_weight_loading()
+        self.assertEqual(config.weight_load_mode, "sync")
+
+    def test_auto_detects_mars_from_hpcc(self):
+        config = self.make_config(device="auto")
+        config._torch_device_available = lambda _device_type: False
+        with mock.patch.dict(os.environ, {"HPCC_PATH": "/opt/hpcc"}, clear=True):
+            with mock.patch("infinilm.base_config.shutil.which", return_value=None):
+                self.assertEqual(config.detect_device(), "mars")
+
+    def test_auto_detects_metax_from_maca(self):
+        config = self.make_config(device="auto")
+        config._torch_device_available = lambda _device_type: False
+        with mock.patch.dict(os.environ, {"MACA_PATH": "/opt/maca"}, clear=True):
+            with mock.patch("infinilm.base_config.shutil.which", return_value=None):
+                self.assertEqual(config.detect_device(), "metax")
+
+    def test_mars_uses_legacy_cuda_device(self):
+        config = self.make_config()
+        self.assertEqual(config.get_device_str("mars"), "cuda")
+
+    def test_metax_uses_legacy_cuda_device(self):
+        config = self.make_config(device="metax")
+        self.assertEqual(config.get_device_str("metax"), "cuda")
+
+
+class TestInfiniLMBenchmark(unittest.TestCase):
+    @mock.patch("infinilm.LLM")
+    def test_forwards_sync_weight_loading(self, llm):
+        processor = mock.Mock()
+        processor.get_tokenizer.return_value = mock.Mock()
+        llm.return_value.engine.processor = processor
+
+        with tempfile.TemporaryDirectory() as model_dir:
+            Path(model_dir, "config.json").write_text(
+                json.dumps({"max_position_embeddings": 2048}),
+                encoding="utf-8",
+            )
+            InfiniLMBenchmark(model_dir, weight_load_mode="sync")
+
+        self.assertEqual(llm.call_args.kwargs["weight_load_mode"], "sync")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!--
Thanks for contributing to InfiniLM! Please read `CONTRIBUTING.md` before
opening a pull request and fill out every section below. Delete any section
that is genuinely not applicable (and note why), but do not delete the
"Checklist" section — it must be filled in for every PR.

The PR title MUST follow Conventional Commits, e.g.
  feat: support Llama 3 models
  fix: correct linear attention calculations
See: https://www.conventionalcommits.org/
-->

## Summary

<!--
A concise description of **what** this PR changes. Prefer bullet points over
prose. Reference files with backtick-fenced paths (e.g. `csrc/models/llama/*`).
-->

- Add `mars` as a distinct device across configuration, auto-detection, launch scripts, server mappings, benchmarks, and model tests.
- Map Mars to the CUDA-compatible PyTorch device while keeping it separate from the MetaX/MACA device path.
- Force synchronous weight loading for Mars and propagate the option through the benchmark backend.
- Enable Mars dispatch for fused DeepSeek MoE and OOM detection.
- Validate `INFINI_RT_ROOT` and add its `include`, `lib`, and `lib64` paths to prevent linking against a stale InfiniRT installation.
- Add regression tests and document Mars device selection and external InfiniRT setup.

## Motivation

<!--
Explain **why** this change is needed. Link to any related issue, bug, or
discussion. If this is a performance change, include before/after numbers
(hardware, shape, dtype, and the measurement methodology).
-->

MetaX/MACA and Mars/HPCC are now represented as separate devices in InfiniCore and InfiniRT. InfiniLM previously treated the HPCC-based Mars platform as MetaX, so Mars could not be selected or detected independently and could silently link against a stale InfiniRT installation.

This PR completes the corresponding InfiniLM integration while preserving the existing MetaX/MACA path.

Related to InfiniTensor/InfiniCore#1373.

## Type of Change

<!-- Tick one or more. -->

- [x] `feat` — new feature / new model
- [x] `fix` — bug fix
- [ ] `perf` — performance improvement (no behavioral change)
- [ ] `refactor` — code restructuring without behavior change
- [x] `test` — adding or fixing tests only
- [x] `docs` — documentation only
- [x] `build` / `ci` — build system or CI configuration
- [ ] `chore` — tooling, formatting, or other non-code changes
- [ ] Breaking change

## Test Results of Involved Models on Supported Platforms (Please attach screenshots)

<!--
For now, provide the screenshots for involved tests performed on platforms supposed to support the changes.

Tests that might be involved:
Single request test: examples/test_infer.py
Offline performance: examples/bench.py
Sanity test: test/bench/test_benchmark.py
Service: python/infinilm/server/inference_server.py + scripts/test_perf.py

Model adaptations may involve all four tests, unless specifying partial support for vastly new structures and confirmed with admin.

Python-level changes may involve less tests depending on which files/features are modified. 

Framework-level and Python-level changes may affect different models. Test a few models that might be affected.
-->

## Benchmark / Performance Impact

<!--
Required for `perf` PRs; optional otherwise. Describe the benchmark harness,
shapes, dtypes, hardware, and include baseline vs. new numbers. If the PR is
not performance-sensitive, write "N/A".
-->

## Notes for Reviewers

<!--
Anything reviewers should focus on: subtle invariants, known trade-offs,
follow-up work intentionally left out of scope, etc.
-->

## CI / ChatOps

<!--
CI does not run automatically on pull requests. Trigger it manually from the
Actions tab (workflow: **CI**, branch: this PR's head branch), or ask a
maintainer to comment `/retest` or `/test` on this PR.
-->

---

## Checklist

> Every contributor **must** verify every item below before requesting
> review. Tick each box only after the check has actually been performed —
> do not tick speculatively. If an item truly does not apply, replace the
> checkbox with `N/A` and briefly explain why in an inline comment.

### Title, Branch, and Commits

- [ ] PR **title** follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(nvidia): …`, `fix(cuda/gemm): …`).
- [ ] Branch name follows `<type>/xxx-yyyy-zzzz` where `<type>` matches the PR title's Conventional Commits type and words are joined with hyphens (see `CONTRIBUTING.md` §Branches).
- [ ] Each **commit** message follows Conventional Commits.
- [ ] Small PR is a **single squashable commit**; or, for a large PR, every commit is meaningful, well-formed, and independently reviewable (see `CONTRIBUTING.md` §Pull Requests).
- [ ] No stray merge commits from `main` — the branch is rebased cleanly on top of the current `main`.
- [ ] No `fixup!` / `squash!` / `wip` commits remain.
- [ ] Existing PR/branch/commit that followed the legacy issue format.

### Scope and Design

- [ ] Changes are **minimal** — nothing unrelated to the stated motivation was added (`CONTRIBUTING.md` §Code/General).
- [ ] No dead code, commented-out blocks, debug prints, `printf`/`std::cout`/`print(...)` left behind, or `TODO` without an owner and issue link.
- [ ] No unrelated formatting churn that would obscure the diff.
- [ ] Public API changes (if any) are intentional, documented, and reflected in affected callers/tests.

### General Code Hygiene (applies to all languages)

- [ ] The code is self-explanatory; comments were added **only** where the *why* is non-obvious (`CONTRIBUTING.md` §Code/General).
- [ ] Every modified or added file **ends with a single trailing newline** (`CONTRIBUTING.md` §Code/General).
- [ ] No trailing whitespace, tab/space mixing, or stray BOMs.
- [ ] Identifiers in comments and error messages are wrapped in backticks (e.g. ``the `seqlens_k` tensor``) (`CONTRIBUTING.md` §Code/General).
- [ ] All comments and error messages are in **English** (`CONTRIBUTING.md` §Code/General).
- [ ] Comments and error messages are complete sentences — capitalized first letter, terminal punctuation — **unless** the language/framework convention says otherwise (`CONTRIBUTING.md` §Code/General; §Python).

### C++ Specific (if C++ files changed)

- [ ] Code follows the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) strictly.
- [ ] Error and warning message wording follows the [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html#error-and-warning-messages) (`CONTRIBUTING.md` §C++).
- [ ] Constructor **initializer list order matches member declaration order** (`CONTRIBUTING.md` §C++).
- [ ] No raw `new`/`delete`; RAII / smart pointers / existing allocators are used.
- [ ] Changed files are formatted by `scripts/format.py`.
- [ ] No changes/reference to `csrc/models/llama_legacy/`.

### Python Specific (if Python files changed)

- [ ] Code is [PEP 8](https://peps.python.org/pep-0008/) compliant.
- [ ] Comments are complete English sentences, starting with a capital letter and ending with punctuation; Markdown backticks are used for code references (`CONTRIBUTING.md` §Python).
- [ ] Docstrings (if any) follow [PEP 257](https://peps.python.org/pep-0257/) (`CONTRIBUTING.md` §Python).
- [ ] Changed files are formatted by `scripts/format.py`.
- [ ] No changes/reference to `python/infinilm/auto_config.py`.

### Testing

- [ ] For any platform that could not be tested, an explicit reason is given in the table and a reviewer with access has been tagged.
- [ ] Passed single request test (`examples/test_infer.py`), or specify the reason for skipping.
- [ ] Passed offline performance test (`examples/bench.py`), or specify the reason for skipping.
- [ ] Passed sanity test (`test/bench/test_benchmark.py`), or specify the reason for skipping.
- [ ] Passed service test (`python/infinilm/server/inference_server.py` + `scripts/test_perf.py`), or specify the reason for skipping.

### Build, CI, and Tooling

- [ ] The project builds cleanly from a fresh directory on at least one affected platform.
- [ ] CI has been triggered manually (Actions → **CI** on this branch), or `/retest` was requested.

### Documentation

- [ ] `README.md`, `CONTRIBUTING.md`, or inline docs updated when behavior, build flags, or developer workflow changed.
- [ ] Any user-visible breaking change is called out explicitly under "Motivation" **and** in the commit/PR title with a `!` or `BREAKING CHANGE:` footer.

### Security and Safety

- [ ] No secrets, access tokens, internal URLs, customer data, or personal hardware identifiers have been committed.
- [ ] Third-party code is license-compatible and attributed.
- [ ] No unsafe pointer arithmetic, uninitialized reads, or missing bounds checks were introduced.
