### PR TITLE
feat: qwen3-next model with graph support

### DIFF
--- a/csrc/engine/compiler/paged_compiler.cpp
+++ b/csrc/engine/compiler/paged_compiler.cpp
@@ -2,7 +2,27 @@
 #include "../../global_state/global_state.hpp"
 #include "../../utils.hpp"
 
+#include <algorithm>
+#include <cstdint>
+#include <vector>
+
 namespace infinilm::engine {
+namespace {
+
+bool has_mamba_cache(const infinilm::global_state::ForwardContext &forward_context) {
+    auto has_state = [](const std::vector<infinicore::Tensor> &state_vec) {
+        for (const auto &state : state_vec) {
+            if (state) {
+                return true;
+            }
+        }
+        return false;
+    };
+
+    return has_state(forward_context.conv_state_vec) || has_state(forward_context.ssm_state_vec);
+}
+
+} // namespace
 
 PagedCompiler::PagedCompiler(const std::shared_ptr<InfinilmModel> &model, RankBarrier *barrier)
     : GraphCompiler(model, barrier) {
@@ -23,6 +43,9 @@ PagedCompiler::PagedCompiler(const std::shared_ptr<InfinilmModel> &model, RankBa
 void PagedCompiler::compile() {
     if (model_->get_cache_config() != nullptr && dynamic_cast<const cache::PagedKVCacheConfig *>(model_->get_cache_config())) {
         size_t nblocks = dynamic_cast<const cache::PagedKVCacheConfig *>(model_->get_cache_config())->num_blocks();
+        auto &forward_context = infinilm::global_state::get_forward_context();
+        const bool has_mamba_state = has_mamba_cache(forward_context);
+
         size_t max_batch_size = *std::max_element(decode_batch_sizes_.begin(), decode_batch_sizes_.end());
         compiled_map_decode_.clear();
         block_tables_holder_ = infinicore::Tensor::empty(
@@ -52,14 +75,41 @@ void PagedCompiler::compile() {
             input.slot_mapping = infinicore::Tensor::empty({b}, infinicore::DataType::I64, infinicore::context::getDevice());
             set_zeros(input.slot_mapping.value());
 
+            if (has_mamba_state) {
+                input.mamba_init_state_indices = infinicore::Tensor::empty(
+                    {b}, infinicore::DataType::I32, infinicore::context::getDevice());
+                input.mamba_final_state_indices = infinicore::Tensor::empty(
+                    {b}, infinicore::DataType::I32, infinicore::context::getDevice());
+                std::vector<int32_t> init_state_indices_vec(b, 0);
+                std::vector<int32_t> final_state_indices_vec(b, 1);
+                infinicore::context::memcpyH2D(
+                    input.mamba_init_state_indices.value()->data(),
+                    init_state_indices_vec.data(),
+                    b * sizeof(int32_t),
+                    false);
+                infinicore::context::memcpyH2D(
+                    input.mamba_final_state_indices.value()->data(),
+                    final_state_indices_vec.data(),
+                    b * sizeof(int32_t),
+                    false);
+            }
+
             // Attention reads attn_metadata from thread-local forward context.
-            infinilm::global_state::get_forward_context().attn_metadata = {
+            forward_context.attn_metadata = {
                 input.past_sequence_lengths,
                 input.total_sequence_lengths,
                 input.input_offsets,
                 input.cu_seqlens,
                 input.block_tables,
                 input.slot_mapping,
+            };
+            // Hybrid linear-attention layers read cache indices from the same
+            // thread-local context. These tensors remain alive in CompiledResult
+            // and are updated in place before every graph replay.
+            forward_context.mamba_metadata = {
+                input.input_offsets,
+                input.mamba_init_state_indices,
+                input.mamba_final_state_indices,
             };
             return input;
         };
@@ -135,6 +185,18 @@ PagedCompiler::Compiled PagedCompiler::get_compiled(const InfinilmModel::Input &
             set_minus_one_device_async(graph_block_tables);
             graph_block_tables->narrow({{1, 0, block_per_req}})->copy_from(input.block_tables.value());
             graph_input.slot_mapping.value()->copy_from(input.slot_mapping.value());
+
+            const bool graph_has_mamba_indices = graph_input.mamba_init_state_indices.has_value() && graph_input.mamba_final_state_indices.has_value();
+            const bool input_has_mamba_indices = input.mamba_init_state_indices.has_value() && input.mamba_final_state_indices.has_value();
+            if (graph_has_mamba_indices != input_has_mamba_indices) {
+                return {nullptr, nullptr};
+            }
+            if (graph_has_mamba_indices) {
+                graph_input.mamba_init_state_indices.value()->copy_from(
+                    input.mamba_init_state_indices.value());
+                graph_input.mamba_final_state_indices.value()->copy_from(
+                    input.mamba_final_state_indices.value());
+            }
             // CUDA graph replay reuses the same per-layer Marlin workspaces.
             // The graph itself does not contain a workspace reset, so enqueue
             // one on the same stream before launch. This is correct but costs

--- a/csrc/models/qwen3_next/qwen3_next_attention.cpp
+++ b/csrc/models/qwen3_next/qwen3_next_attention.cpp
@@ -1,8 +1,11 @@
 #include "qwen3_next_attention.hpp"
 
 #include "../../global_state/global_state.hpp"
+#include "../../layers/attention/attention.hpp"
+#include "../../utils.hpp"
 #include <cmath>
-#include <spdlog/spdlog.h>
+#include <infinicore/ops/mul.hpp>
+#include <infinicore/ops/sigmoid.hpp>
 #include <stdexcept>
 
 namespace infinilm::models::qwen3_next {
@@ -51,12 +54,119 @@ Qwen3NextAttention::Qwen3NextAttention(std::shared_ptr<infinilm::config::ModelCo
 
     INFINICORE_NN_MODULE_INIT(q_norm, head_dim_, rms_norm_eps, dtype, device);
     INFINICORE_NN_MODULE_INIT(k_norm, head_dim_, rms_norm_eps, dtype, device);
+
+    infinilm::layers::attention::init_kv_cache_quant_params(register_fn, device, kv_cache_k_scale_, kv_cache_v_scale_);
 }
 
 infinicore::Tensor Qwen3NextAttention::forward(const infinicore::Tensor &positions,
                                                const infinicore::Tensor &hidden_states) const {
-    spdlog::error("infinilm::models::qwen3_next::Qwen3NextAttention: forward not implemented");
-    return hidden_states;
+    if (::infinilm::backends::AttentionBackend::STATIC_ATTN == attention_backend_) {
+        return forward_static_(positions, hidden_states);
+    }
+    return forward_paged_(positions, hidden_states);
+}
+
+infinicore::Tensor Qwen3NextAttention::forward_static_(const infinicore::Tensor &position_ids,
+                                                       const infinicore::Tensor &hidden_states) const {
+    auto hidden_states_mutable = hidden_states;
+    auto shape = hidden_states->shape();
+    size_t batch_size = shape[0];
+    size_t seq_len = shape[1];
+
+    auto [q_proj_out, k, v] = qkv_proj_->forward_split(hidden_states_mutable);
+    auto q_proj_heads = q_proj_out->as_strided(
+        {batch_size * seq_len, num_attention_heads_, head_dim_ * 2},
+        {q_proj_out->stride(1), static_cast<infinicore::Stride>(head_dim_ * 2), 1});
+    auto q = q_proj_heads->narrow({{2, 0, head_dim_}});
+    auto gate = q_proj_heads->narrow({{2, head_dim_, head_dim_}})
+                    ->contiguous()
+                    ->view({batch_size, seq_len, num_attention_heads_ * head_dim_});
+
+    q = q_norm_->forward(q);
+    auto k_heads = k->as_strided(
+        {batch_size * seq_len, num_key_value_heads_, head_dim_},
+        {k->stride(1), static_cast<infinicore::Stride>(head_dim_), 1});
+    k = k_norm_->forward(k_heads);
+
+    auto q_reshaped = q->as_strided(
+        {batch_size, seq_len, num_attention_heads_, head_dim_},
+        {static_cast<infinicore::Stride>(seq_len * num_attention_heads_ * head_dim_),
+         static_cast<infinicore::Stride>(num_attention_heads_ * head_dim_),
+         static_cast<infinicore::Stride>(head_dim_),
+         1});
+    auto k_reshaped = k->as_strided(
+        {batch_size, seq_len, num_key_value_heads_, head_dim_},
+        {static_cast<infinicore::Stride>(seq_len * num_key_value_heads_ * head_dim_),
+         static_cast<infinicore::Stride>(num_key_value_heads_ * head_dim_),
+         static_cast<infinicore::Stride>(head_dim_),
+         1});
+    auto v_reshaped = v->as_strided(
+        {batch_size, seq_len, num_key_value_heads_, head_dim_},
+        {v->stride(0), v->stride(1), static_cast<infinicore::Stride>(head_dim_), 1});
+
+    auto pos_shape = position_ids->shape();
+    infinicore::Tensor pos_ids_for_rope = position_ids;
+    if (pos_shape.size() == 2) {
+        auto pos_narrowed = position_ids->narrow({{0, 0, 1}});
+        pos_ids_for_rope = pos_narrowed->contiguous()->view({pos_shape[1]});
+    } else if (pos_shape.size() == 1) {
+        pos_ids_for_rope = position_ids->contiguous();
+    } else {
+        throw std::runtime_error("infinilm::models::qwen3_next::Qwen3NextAttention: Unexpected position_ids shape");
+    }
+
+    rotary_emb_->forward(q_reshaped, pos_ids_for_rope, true);
+    rotary_emb_->forward(k_reshaped, pos_ids_for_rope, true);
+
+    auto attn_output = attn_->forward(q_reshaped, k_reshaped, v_reshaped);
+    attn_output = infinicore::op::mul(attn_output, infinicore::op::sigmoid(gate));
+    return o_proj_->forward(attn_output);
+}
+
+infinicore::Tensor Qwen3NextAttention::forward_paged_(const infinicore::Tensor &position_ids,
+                                                      const infinicore::Tensor &hidden_states) const {
+    auto hidden_states_mutable = hidden_states;
+    auto shape = hidden_states->shape();
+    size_t batch_size = shape[0];
+    size_t seq_len = shape[1];
+
+    ASSERT_EQ(batch_size, 1);
+
+    auto [q_proj_out, k, v] = qkv_proj_->forward_split(hidden_states_mutable);
+    auto q_proj_heads = q_proj_out->as_strided(
+        {seq_len, num_attention_heads_, head_dim_ * 2},
+        {q_proj_out->stride(1), static_cast<infinicore::Stride>(head_dim_ * 2), 1});
+    auto q = q_proj_heads->narrow({{2, 0, head_dim_}});
+    auto gate = q_proj_heads->narrow({{2, head_dim_, head_dim_}})
+                    ->contiguous()
+                    ->view({seq_len, num_attention_heads_ * head_dim_});
+
+    auto q_reshaped = q_norm_->forward(q);
+    auto k_heads = k->as_strided(
+        {seq_len, num_key_value_heads_, head_dim_},
+        {k->stride(1), static_cast<infinicore::Stride>(head_dim_), 1});
+    auto k_reshaped = k_norm_->forward(k_heads);
+    auto v_reshaped = v->as_strided(
+        {seq_len, num_key_value_heads_, head_dim_},
+        {v->stride(1), static_cast<infinicore::Stride>(head_dim_), 1});
+
+    auto pos_shape = position_ids->shape();
+    infinicore::Tensor pos_ids_for_rope = position_ids;
+    if (pos_shape.size() == 2) {
+        auto pos_narrowed = position_ids->narrow({{0, 0, 1}});
+        pos_ids_for_rope = pos_narrowed->view({pos_shape[1]});
+    } else if (pos_shape.size() == 1) {
+        pos_ids_for_rope = position_ids;
+    } else {
+        throw std::runtime_error("infinilm::models::qwen3_next::Qwen3NextAttention: Unexpected position_ids shape");
+    }
+
+    rotary_emb_->forward(q_reshaped, pos_ids_for_rope, true);
+    rotary_emb_->forward(k_reshaped, pos_ids_for_rope, true);
+
+    auto attn_output = attn_->forward(q_reshaped, k_reshaped, v_reshaped);
+    attn_output = infinicore::op::mul(attn_output, infinicore::op::sigmoid(gate)->view(attn_output->shape()));
+    return o_proj_->forward(attn_output);
 }
 
 } // namespace infinilm::models::qwen3_next

--- a/csrc/models/qwen3_next/qwen3_next_attention.hpp
+++ b/csrc/models/qwen3_next/qwen3_next_attention.hpp
@@ -20,6 +20,11 @@ public:
     size_t hidden_size() const { return hidden_size_; }
 
 protected:
+    infinicore::Tensor forward_static_(const infinicore::Tensor &position_ids,
+                                       const infinicore::Tensor &hidden_states) const;
+    infinicore::Tensor forward_paged_(const infinicore::Tensor &position_ids,
+                                      const infinicore::Tensor &hidden_states) const;
+
     std::shared_ptr<infinilm::layers::linear::QKVParallelLinear> qkv_proj_;
     std::shared_ptr<infinilm::layers::linear::RowParallelLinear> o_proj_;
     INFINICORE_NN_MODULE(infinicore::nn::RMSNorm, q_norm);

--- a/csrc/models/qwen3_next/qwen3_next_decoderLayer.hpp
+++ b/csrc/models/qwen3_next/qwen3_next_decoderLayer.hpp
@@ -1,13 +1,12 @@
 #pragma once
 
-#include "../qwen3_moe/qwen3_moe_sparse_moe_block.hpp"
 #include "qwen3_next_attention.hpp"
 #include "qwen3_next_gated_deltanet.hpp"
+#include "qwen3_next_sparse_moe_block.hpp"
 #include <string>
 #include <tuple>
 
 namespace infinilm::models::qwen3_next {
-using Qwen3NextSparseMoeBlock = qwen3_moe::Qwen3MoeSparseMoeBlock;
 
 class Qwen3NextDecoderLayer : public infinicore::nn::Module {
 public:

--- a/csrc/models/qwen3_next/qwen3_next_gated_deltanet.cpp
+++ b/csrc/models/qwen3_next/qwen3_next_gated_deltanet.cpp
@@ -167,12 +167,22 @@ infinicore::Tensor Qwen3NextGatedDeltaNet::forward(const infinicore::Tensor &hid
     infinicore::Tensor delta_out;
     if (is_decode) {
         auto ssm_state = forward_context.ssm_state_vec[layer_idx_];
-        auto q_delta = q->view({seq_len, 1, local_num_key_heads_, key_head_dim_});
-        auto k_delta = k->view({seq_len, 1, local_num_key_heads_, key_head_dim_});
-        auto v_delta = v->view({seq_len, 1, local_num_value_heads_, value_head_dim_});
+        auto q_delta = q->as_strided(
+            {seq_len, 1, local_num_key_heads_, key_head_dim_},
+            {q->stride(1), q->stride(0), static_cast<infinicore::Stride>(key_head_dim_), 1});
+        auto k_delta = k->as_strided(
+            {seq_len, 1, local_num_key_heads_, key_head_dim_},
+            {k->stride(1), k->stride(0), static_cast<infinicore::Stride>(key_head_dim_), 1});
+        auto v_delta = v->as_strided(
+            {seq_len, 1, local_num_value_heads_, value_head_dim_},
+            {v->stride(1), v->stride(0), static_cast<infinicore::Stride>(value_head_dim_), 1});
 
-        auto a_heads = a->view({seq_len, 1, local_num_value_heads_});
-        auto b_heads = b->view({seq_len, 1, local_num_value_heads_});
+        auto a_heads = a->as_strided(
+            {seq_len, 1, local_num_value_heads_},
+            {a->stride(1), a->stride(0), 1});
+        auto b_heads = b->as_strided(
+            {seq_len, 1, local_num_value_heads_},
+            {b->stride(1), b->stride(0), 1});
         auto [g, beta] = infinicore::op::fused_gated_delta_net_gating(A_log_, a_heads, b_heads, dt_bias_);
 
         delta_out = infinicore::op::recurrent_gated_delta_rule_indexed(
@@ -185,15 +195,27 @@ infinicore::Tensor Qwen3NextGatedDeltaNet::forward(const infinicore::Tensor &hid
             mamba_metadata.init_state_indices.value(),
             mamba_metadata.final_state_indices.value(),
             true);
-        delta_out = delta_out->view({seq_len, local_num_value_heads_, value_head_dim_});
+        delta_out = delta_out->as_strided(
+            {seq_len, local_num_value_heads_, value_head_dim_},
+            {delta_out->stride(0), delta_out->stride(2), delta_out->stride(3)});
     } else {
         auto ssm_state = forward_context.ssm_state_vec[layer_idx_];
-        auto q_delta = q->view({1, seq_len, local_num_key_heads_, key_head_dim_});
-        auto k_delta = k->view({1, seq_len, local_num_key_heads_, key_head_dim_});
-        auto v_delta = v->view({1, seq_len, local_num_value_heads_, value_head_dim_});
+        auto q_delta = q->as_strided(
+            {1, seq_len, local_num_key_heads_, key_head_dim_},
+            {q->stride(0), q->stride(1), static_cast<infinicore::Stride>(key_head_dim_), 1});
+        auto k_delta = k->as_strided(
+            {1, seq_len, local_num_key_heads_, key_head_dim_},
+            {k->stride(0), k->stride(1), static_cast<infinicore::Stride>(key_head_dim_), 1});
+        auto v_delta = v->as_strided(
+            {1, seq_len, local_num_value_heads_, value_head_dim_},
+            {v->stride(0), v->stride(1), static_cast<infinicore::Stride>(value_head_dim_), 1});
 
-        auto a_heads = a->view({1, seq_len, local_num_value_heads_});
-        auto b_heads = b->view({1, seq_len, local_num_value_heads_});
+        auto a_heads = a->as_strided(
+            {1, seq_len, local_num_value_heads_},
+            {a->stride(0), a->stride(1), 1});
+        auto b_heads = b->as_strided(
+            {1, seq_len, local_num_value_heads_},
+            {b->stride(0), b->stride(1), 1});
         auto [g, beta] = infinicore::op::fused_gated_delta_net_gating(A_log_, a_heads, b_heads, dt_bias_);
 
         delta_out = infinicore::op::chunk_gated_delta_rule(
@@ -207,11 +229,18 @@ infinicore::Tensor Qwen3NextGatedDeltaNet::forward(const infinicore::Tensor &hid
             mamba_metadata.init_state_indices.value(),
             mamba_metadata.final_state_indices.value(),
             true);
-        delta_out = delta_out->view({seq_len, local_num_value_heads_, value_head_dim_});
+        delta_out = delta_out->as_strided(
+            {seq_len, local_num_value_heads_, value_head_dim_},
+            {delta_out->stride(1), delta_out->stride(2), delta_out->stride(3)});
     }
 
-    auto v_norm = norm_->forward(delta_out->view({batch_size * seq_len * local_num_value_heads_, value_head_dim_}))
-                      ->view({batch_size, seq_len, local_value_dim_});
+    auto delta_out_2d = delta_out->as_strided(
+        {batch_size * seq_len * local_num_value_heads_, value_head_dim_},
+        {static_cast<infinicore::Stride>(value_head_dim_), 1});
+    auto v_norm_2d = norm_->forward(delta_out_2d);
+    auto v_norm = v_norm_2d->as_strided(
+        {batch_size, seq_len, local_value_dim_},
+        {static_cast<infinicore::Stride>(seq_len * local_value_dim_), static_cast<infinicore::Stride>(local_value_dim_), 1});
     auto gated = infinicore::op::mul(v_norm, infinicore::op::silu(z));
     return out_proj_->forward(gated);
 }

--- a/csrc/models/qwen3_next/qwen3_next_sparse_moe_block.cpp
+++ b/csrc/models/qwen3_next/qwen3_next_sparse_moe_block.cpp
@@ -1,0 +1,106 @@
+#include "qwen3_next_sparse_moe_block.hpp"
+
+#include "../../global_state/global_state.hpp"
+
+#include <infinicore/ops/add.hpp>
+#include <infinicore/ops/distributed/allreduce.hpp>
+#include <infinicore/ops/linear.hpp>
+#include <infinicore/ops/mul.hpp>
+#include <infinicore/ops/sigmoid.hpp>
+#include <infinicore/ops/swiglu.hpp>
+
+#include <string>
+
+namespace infinilm::models::qwen3_next {
+
+Qwen3NextSharedExpert::Qwen3NextSharedExpert(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+                                             const infinicore::Device &device) {
+    const auto &dtype{model_config->get_dtype()};
+    const size_t hidden_size = model_config->get<size_t>("hidden_size");
+    const size_t intermediate_size = model_config->get<size_t>("shared_expert_intermediate_size");
+
+    const engine::distributed::RankInfo &rank_info = infinilm::global_state::get_tensor_model_parallel_rank_info();
+    auto quantization_method = model_config->get_quantization_method();
+    auto register_fn = [this](const std::string &n, infinicore::nn::Parameter p) { this->register_parameter(n, std::move(p)); };
+    gate_up_proj_ = std::make_shared<infinilm::layers::linear::GateUpParallelLinear>(
+        hidden_size,
+        intermediate_size,
+        "gate_proj",
+        "up_proj",
+        register_fn,
+        quantization_method,
+        false,
+        dtype,
+        device,
+        rank_info);
+    down_proj_ = this->register_module<infinilm::layers::linear::RowParallelLinear>(
+        "down_proj",
+        intermediate_size,
+        hidden_size,
+        quantization_method,
+        false,
+        dtype,
+        device,
+        rank_info.tp_rank,
+        rank_info.tp_size,
+        rank_info.comm);
+}
+
+infinicore::Tensor Qwen3NextSharedExpert::forward(const infinicore::Tensor &hidden_states) const {
+    auto hidden_states_mutable = hidden_states;
+    auto [gate, up] = gate_up_proj_->forward_split(hidden_states_mutable);
+    auto intermediate = infinicore::op::swiglu(up, gate);
+    return down_proj_->forward(intermediate);
+}
+
+Qwen3NextSparseMoeBlock::Qwen3NextSparseMoeBlock(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+                                                 const infinicore::Device &device)
+    : Qwen3NextSparseMoeBlock(model_config, 0, device) {
+}
+
+Qwen3NextSparseMoeBlock::Qwen3NextSparseMoeBlock(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+                                                 size_t layer_idx,
+                                                 const infinicore::Device &device) {
+    gate_ = this->register_module<infinilm::layers::moe::TopKRouter>("gate", model_config, device);
+    experts_ = this->register_module<infinilm::layers::moe::FusedMoeExperts>("experts", model_config, device);
+    fused_moe_ = this->register_module<infinilm::layers::moe::FusedMoE>("fused_moe", model_config, device, layer_idx);
+    shared_expert_ = this->register_module<Qwen3NextSharedExpert>("shared_expert", model_config, device);
+    shared_expert_gate_ = this->register_module<infinilm::layers::linear::ReplicatedLinear>(
+        "shared_expert_gate",
+        model_config->get<size_t>("hidden_size"),
+        1,
+        false,
+        model_config->get_dtype(),
+        device);
+}
+
+infinicore::Tensor Qwen3NextSparseMoeBlock::forward(const infinicore::Tensor &hidden_states) const {
+    ASSERT(hidden_states->ndim() == 3);
+
+    auto shape = hidden_states->shape();
+    auto hidden_states_reshaped = hidden_states->view({shape[0] * shape[1], shape[2]});
+
+    auto [routing_weights, selected_experts] = gate_->forward(hidden_states_reshaped);
+    infinilm::layers::moe::TopKOutput topk_output{
+        routing_weights,
+        selected_experts,
+        infinicore::Tensor(),
+    };
+    auto routed_states = fused_moe_->forward(
+        hidden_states_reshaped,
+        topk_output,
+        experts_->moe_weights());
+
+    auto shared_states = shared_expert_->forward(hidden_states);
+    auto hidden_states_for_gate = hidden_states;
+    auto shared_gate = infinicore::op::sigmoid(shared_expert_gate_->forward(hidden_states_for_gate));
+    shared_gate = shared_gate->as_strided(shared_states->shape(), {shared_gate->stride(0), shared_gate->stride(1), 0});
+    shared_states = infinicore::op::mul(shared_states, shared_gate);
+
+    auto routed_states_3d = routed_states->as_strided(
+        {shape[0], shape[1], shape[2]},
+        {static_cast<infinicore::Stride>(shape[1] * shape[2]), static_cast<infinicore::Stride>(shape[2]), 1});
+    return infinicore::op::add(routed_states_3d, shared_states);
+}
+
+} // namespace infinilm::models::qwen3_next

--- a/csrc/models/qwen3_next/qwen3_next_sparse_moe_block.hpp
+++ b/csrc/models/qwen3_next/qwen3_next_sparse_moe_block.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "../../config/model_config.hpp"
+#include "../../layers/linear/linear.hpp"
+#include "../../layers/moe/experts/fused_moe_experts.hpp"
+#include "../../layers/moe/fused_moe.hpp"
+#include "../../layers/moe/router/topk_router.hpp"
+
+#include <memory>
+
+namespace infinilm::models::qwen3_next {
+
+class Qwen3NextSharedExpert : public infinicore::nn::Module {
+public:
+    Qwen3NextSharedExpert(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+                          const infinicore::Device &device);
+
+    infinicore::Tensor forward(const infinicore::Tensor &hidden_states) const;
+
+protected:
+    std::shared_ptr<infinilm::layers::linear::GateUpParallelLinear> gate_up_proj_;
+    std::shared_ptr<infinilm::layers::linear::RowParallelLinear> down_proj_;
+};
+
+class Qwen3NextSparseMoeBlock : public infinicore::nn::Module {
+public:
+    Qwen3NextSparseMoeBlock(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+                            const infinicore::Device &device);
+    Qwen3NextSparseMoeBlock(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+                            size_t layer_idx,
+                            const infinicore::Device &device);
+
+    infinicore::Tensor forward(const infinicore::Tensor &hidden_states) const;
+
+protected:
+    std::shared_ptr<infinilm::layers::moe::TopKRouter> gate_;
+    std::shared_ptr<infinilm::layers::moe::FusedMoeExperts> experts_;
+    std::shared_ptr<infinilm::layers::moe::FusedMoE> fused_moe_;
+    std::shared_ptr<Qwen3NextSharedExpert> shared_expert_;
+    std::shared_ptr<infinilm::layers::linear::ReplicatedLinear> shared_expert_gate_;
+};
+
+} // namespace infinilm::models::qwen3_next

--- a/python/infinilm/modeling_utils.py
+++ b/python/infinilm/modeling_utils.py
@@ -893,6 +893,73 @@ def _remap_ernie4_5_moe_vl(state_dict, config=None):
     return remapped
 
 
+def _remap_qwen3_next(state_dict, config):
+    """Adapt Qwen3Next fused linear-attention weights to InfiniLM module names."""
+    state_dict = drop_keys(state_dict, ["mtp."])
+    num_key_heads = config["linear_num_key_heads"]
+    num_value_heads = config["linear_num_value_heads"]
+    key_head_dim = config["linear_key_head_dim"]
+    value_head_dim = config["linear_value_head_dim"]
+    values_per_key = num_value_heads // num_key_heads
+    value_group_dim = values_per_key * value_head_dim
+    norm_weight_suffixes = (
+        "input_layernorm.weight",
+        "post_attention_layernorm.weight",
+        "self_attn.q_norm.weight",
+        "self_attn.k_norm.weight",
+    )
+
+    to_drop = []
+    to_add = {}
+    for key, tensor in state_dict.items():
+        if key == "model.norm.weight" or key.endswith(norm_weight_suffixes):
+            state_dict[key] = tensor + torch.ones_like(tensor)
+        elif key.endswith("linear_attn.in_proj_qkvz.weight"):
+            prefix = key[: -len("in_proj_qkvz.weight")]
+            grouped = tensor.view(
+                num_key_heads,
+                2 * key_head_dim + 2 * value_group_dim,
+                tensor.shape[1],
+            )
+            q, k, v, z = torch.split(
+                grouped,
+                [key_head_dim, key_head_dim, value_group_dim, value_group_dim],
+                dim=1,
+            )
+            to_add[prefix + "in_proj_q.weight"] = q.reshape(
+                -1, tensor.shape[1]
+            ).contiguous()
+            to_add[prefix + "in_proj_k.weight"] = k.reshape(
+                -1, tensor.shape[1]
+            ).contiguous()
+            to_add[prefix + "in_proj_v.weight"] = v.reshape(
+                -1, tensor.shape[1]
+            ).contiguous()
+            to_add[prefix + "in_proj_z.weight"] = z.reshape(
+                -1, tensor.shape[1]
+            ).contiguous()
+            to_drop.append(key)
+        elif key.endswith("linear_attn.in_proj_ba.weight"):
+            prefix = key[: -len("in_proj_ba.weight")]
+            grouped = tensor.view(
+                num_key_heads,
+                2 * values_per_key,
+                tensor.shape[1],
+            )
+            b, a = torch.split(grouped, [values_per_key, values_per_key], dim=1)
+            to_add[prefix + "in_proj_b.weight"] = b.reshape(
+                -1, tensor.shape[1]
+            ).contiguous()
+            to_add[prefix + "in_proj_a.weight"] = a.reshape(
+                -1, tensor.shape[1]
+            ).contiguous()
+            to_drop.append(key)
+
+    state_dict = drop_keys(state_dict, to_drop)
+    state_dict.update(to_add)
+    return state_dict
+
+
 _WEIGHT_REMAPPER = {
     "glm4": _remap_glm4,
     "chatglm": _remap_chatglm,
@@ -902,4 +969,5 @@ _WEIGHT_REMAPPER = {
     "videonsa": _remap_videonsa,
     "qwen3_5": _remap_qwen3_5,
     "ernie4_5_moe_vl": _remap_ernie4_5_moe_vl,
+    "qwen3_next": _remap_qwen3_next,
 }

--- a/python/infinilm/processors/qwen3_next_processor.py
+++ b/python/infinilm/processors/qwen3_next_processor.py
@@ -1,0 +1,47 @@
+import infinicore
+from typing_extensions import override
+
+from ..llm.scheduler import SchedulerOutput
+from ..llm.static_scheduler import StaticSchedulerOutput
+from .basic_llm_processor import BasicLLMProcessor
+from .processor import register_processor
+
+
+@register_processor("qwen3_next")
+class Qwen3NextProcessor(BasicLLMProcessor):
+    @override
+    def build_model_inputs(
+        self,
+        scheduler_output: SchedulerOutput | StaticSchedulerOutput,
+        temperature: float = 1.0,
+        top_p: float = 0.8,
+        top_k: int = 1,
+        **kwargs,
+    ) -> dict:
+        model_inputs = super().build_model_inputs(
+            scheduler_output,
+            temperature,
+            top_p,
+            top_k,
+            **kwargs,
+        )
+
+        init_indices = []
+        final_indices = []
+        for req in scheduler_output.scheduled_requests:
+            if req.mamba_cache_index is None:
+                raise RuntimeError(
+                    f"Request {req.request_id} has no assigned mamba cache index"
+                )
+            init_indices.append(
+                0 if scheduler_output.is_prefill else req.mamba_cache_index
+            )
+            final_indices.append(req.mamba_cache_index)
+
+        model_inputs["mamba_init_state_indices"] = infinicore.from_list(
+            init_indices, dtype=infinicore.int32
+        )
+        model_inputs["mamba_final_state_indices"] = infinicore.from_list(
+            final_indices, dtype=infinicore.int32
+        )
+        return model_inputs


### PR DESCRIPTION
<!--
Thanks for contributing to InfiniLM! Please read `CONTRIBUTING.md` before
opening a pull request and fill out every section below. Delete any section
that is genuinely not applicable (and note why), but do not delete the
"Checklist" section — it must be filled in for every PR.

The PR title MUST follow Conventional Commits, e.g.
  feat: support Llama 3 models
  fix: correct linear attention calculations
See: https://www.conventionalcommits.org/
-->

## Summary

<!--
A concise description of **what** this PR changes. Prefer bullet points over
prose. Reference files with backtick-fenced paths (e.g. `csrc/models/llama/*`).
-->

- Implement qwen3-next model in InfiniLM
- Extend paged compiler with mamba cache support

## Motivation

<!--
Explain **why** this change is needed. Link to any related issue, bug, or
discussion. If this is a performance change, include before/after numbers
(hardware, shape, dtype, and the measurement methodology).
-->

Closes #503 

## Type of Change

<!-- Tick one or more. -->

- [x] `feat` — new feature / new model
- [ ] `fix` — bug fix
- [ ] `perf` — performance improvement (no behavioral change)
- [ ] `refactor` — code restructuring without behavior change
- [ ] `test` — adding or fixing tests only
- [ ] `docs` — documentation only
- [ ] `build` / `ci` — build system or CI configuration
- [ ] `chore` — tooling, formatting, or other non-code changes
- [ ] Breaking change

## Test Results of Involved Models on Supported Platforms (Please attach screenshots)

<!--
For now, provide the screenshots for involved tests performed on platforms supposed to support the changes.

Tests that might be involved:
Single request test: examples/test_infer.py
Offline performance: examples/bench.py
Sanity test: test/bench/test_benchmark.py
Service: python/infinilm/server/inference_server.py + scripts/test_perf.py

Model adaptations may involve all four tests, unless specifying partial support for vastly new structures and confirmed with admin.

Python-level changes may involve less tests depending on which files/features are modified. 

Framework-level and Python-level changes may affect different models. Test a few models that might be affected.
-->
- qwen3-next without graph (waiting for infiniop elementwise graph support)
<img width="2074" height="400" alt="image" src="https://github.com/user-attachments/assets/6a149eee-6da7-4cef-b89e-1669d3c5622d" />
- qwen3 with graph (regression)
python examples/test_infer.py --device=nvidia --model=/data-aisoft/mechdancer/models/Qwen3-32B/ --enable-paged-attn --attn=flash-attn --num-blocks=128 --tp=4 --enable-graph
<img width="2090" height="530" alt="image" src="https://github.com/user-attachments/assets/ef06567a-02ce-46d4-9f9f-8ce34af9fe7b" />


## Benchmark / Performance Impact

<!--
Required for `perf` PRs; optional otherwise. Describe the benchmark harness,
shapes, dtypes, hardware, and include baseline vs. new numbers. If the PR is
not performance-sensitive, write "N/A".
-->

## Notes for Reviewers

<!--
Anything reviewers should focus on: subtle invariants, known trade-offs,
follow-up work intentionally left out of scope, etc.
-->

## CI / ChatOps

<!--
CI does not run automatically on pull requests. Trigger it manually from the
Actions tab (workflow: **CI**, branch: this PR's head branch), or ask a
maintainer to comment `/retest` or `/test` on this PR.
-->

---

## Checklist

> Every contributor **must** verify every item below before requesting
> review. Tick each box only after the check has actually been performed —
> do not tick speculatively. If an item truly does not apply, replace the
> checkbox with `N/A` and briefly explain why in an inline comment.

### Title, Branch, and Commits

- [ ] PR **title** follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(nvidia): …`, `fix(cuda/gemm): …`).
- [ ] Branch name follows `<type>/xxx-yyyy-zzzz` where `<type>` matches the PR title's Conventional Commits type and words are joined with hyphens (see `CONTRIBUTING.md` §Branches).
- [ ] Each **commit** message follows Conventional Commits.
- [ ] Small PR is a **single squashable commit**; or, for a large PR, every commit is meaningful, well-formed, and independently reviewable (see `CONTRIBUTING.md` §Pull Requests).
- [ ] No stray merge commits from `main` — the branch is rebased cleanly on top of the current `main`.
- [ ] No `fixup!` / `squash!` / `wip` commits remain.
- [ ] Existing PR/branch/commit that followed the legacy issue format.

### Scope and Design

- [ ] Changes are **minimal** — nothing unrelated to the stated motivation was added (`CONTRIBUTING.md` §Code/General).
- [ ] No dead code, commented-out blocks, debug prints, `printf`/`std::cout`/`print(...)` left behind, or `TODO` without an owner and issue link.
- [ ] No unrelated formatting churn that would obscure the diff.
- [ ] Public API changes (if any) are intentional, documented, and reflected in affected callers/tests.

### General Code Hygiene (applies to all languages)

- [ ] The code is self-explanatory; comments were added **only** where the *why* is non-obvious (`CONTRIBUTING.md` §Code/General).
- [ ] Every modified or added file **ends with a single trailing newline** (`CONTRIBUTING.md` §Code/General).
- [ ] No trailing whitespace, tab/space mixing, or stray BOMs.
- [ ] Identifiers in comments and error messages are wrapped in backticks (e.g. ``the `seqlens_k` tensor``) (`CONTRIBUTING.md` §Code/General).
- [ ] All comments and error messages are in **English** (`CONTRIBUTING.md` §Code/General).
- [ ] Comments and error messages are complete sentences — capitalized first letter, terminal punctuation — **unless** the language/framework convention says otherwise (`CONTRIBUTING.md` §Code/General; §Python).

### C++ Specific (if C++ files changed)

- [ ] Code follows the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) strictly.
- [ ] Error and warning message wording follows the [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html#error-and-warning-messages) (`CONTRIBUTING.md` §C++).
- [ ] Constructor **initializer list order matches member declaration order** (`CONTRIBUTING.md` §C++).
- [ ] No raw `new`/`delete`; RAII / smart pointers / existing allocators are used.
- [ ] Changed files are formatted by `scripts/format.py`.
- [ ] No changes/reference to `csrc/models/llama_legacy/`.

### Python Specific (if Python files changed)

- [ ] Code is [PEP 8](https://peps.python.org/pep-0008/) compliant.
- [ ] Comments are complete English sentences, starting with a capital letter and ending with punctuation; Markdown backticks are used for code references (`CONTRIBUTING.md` §Python).
- [ ] Docstrings (if any) follow [PEP 257](https://peps.python.org/pep-0257/) (`CONTRIBUTING.md` §Python).
- [ ] Changed files are formatted by `scripts/format.py`.
- [ ] No changes/reference to `python/infinilm/auto_config.py`.

### Testing

- [ ] For any platform that could not be tested, an explicit reason is given in the table and a reviewer with access has been tagged.
- [ ] Passed single request test (`examples/test_infer.py`), or specify the reason for skipping.
- [ ] Passed offline performance test (`examples/bench.py`), or specify the reason for skipping.
- [ ] Passed sanity test (`test/bench/test_benchmark.py`), or specify the reason for skipping.
- [ ] Passed service test (`python/infinilm/server/inference_server.py` + `scripts/test_perf.py`), or specify the reason for skipping.

### Build, CI, and Tooling

- [ ] The project builds cleanly from a fresh directory on at least one affected platform.
- [ ] CI has been triggered manually (Actions → **CI** on this branch), or `/retest` was requested.

### Documentation

- [ ] `README.md`, `CONTRIBUTING.md`, or inline docs updated when behavior, build flags, or developer workflow changed.
- [ ] Any user-visible breaking change is called out explicitly under "Motivation" **and** in the commit/PR title with a `!` or `BREAKING CHANGE:` footer.

### Security and Safety

- [ ] No secrets, access tokens, internal URLs, customer data, or personal hardware identifiers have been committed.
- [ ] Third-party code is license-compatible and attributed.
- [ ] No unsafe pointer arithmetic, uninitialized reads, or missing bounds checks were introduced.
