### PR TITLE
issue/515 - feat: refactor prefix caching with request-side hashing and deferred cache publication

### DIFF
--- a/examples/bench.py
+++ b/examples/bench.py
@@ -197,6 +197,7 @@ class TestModel:
         weight_load_mode="async",
         moe_ep_backend="disabled",
         moe_ep_size=1,
+        enable_prefix_caching=False,
     ) -> None:
         model_path = os.path.expanduser(model_path)
         self.draft_model_path = draft_model_path
@@ -210,6 +211,7 @@ class TestModel:
         self.use_mla = use_mla
         self.weight_load_mode = weight_load_mode
         self.skip_load = skip_load
+        self.enable_prefix_caching = enable_prefix_caching
 
         if draft_model_path is not None:
             self.processor = AutoInfinilmProcessor.from_pretrained(model_path)
@@ -316,6 +318,7 @@ class TestModel:
                 use_mla=self.use_mla,
                 weight_load_mode=self.weight_load_mode,
                 skip_load=self.skip_load,
+                enable_prefix_caching=self.enable_prefix_caching,
             )
             t1 = time.time()
             print("=================== start generate ====================")
@@ -442,6 +445,7 @@ if __name__ == "__main__":
         weight_load_mode=cfg.weight_load_mode,
         moe_ep_backend=moe_ep_backend,
         moe_ep_size=ep,
+        enable_prefix_caching=False,
     )
 
     # ---------------------------------------------------------------------------- #

--- a/examples/bench_videonsa.py
+++ b/examples/bench_videonsa.py
@@ -10,7 +10,6 @@ from infinilm.llm.sampling_params import SamplingParams
 from infinilm.processors import AutoInfinilmProcessor
 from infinilm.processors.videonsa_processor import decode_video_frames
 
-
 VIDEO_AUTO_MIN_FRAMES = 4
 VIDEO_AUTO_MAX_FRAMES = 8
 VIDEO_AUTO_SAMPLE_FPS = 1.0
@@ -180,6 +179,7 @@ def run_case(model, tokenizer, cfg, video_payload, batch_size, input_len, output
 
 def main():
     cfg = BaseConfig()
+    cfg.enable_prefix_caching = False
     normalize_bench_defaults(cfg)
 
     input_lens = as_int_list(cfg.input_len)
@@ -219,6 +219,7 @@ def main():
         attn_backend=cfg.attn,
         enable_graph=cfg.enable_graph,
         weight_load_mode=cfg.weight_load_mode,
+        enable_prefix_caching=cfg.enable_prefix_caching,
     )
 
     for input_len in input_lens:

--- a/examples/test_infer.py
+++ b/examples/test_infer.py
@@ -34,6 +34,7 @@ def test(
     skip_load=False,
     weight_load_mode="async",
     use_legacy_moe=False,
+    enable_prefix_caching=True,
 ):
     model_path = os.path.expanduser(model_path)
     # ---------------------------------------------------------------------------- #
@@ -64,6 +65,7 @@ def test(
         skip_load=skip_load,
         weight_load_mode=weight_load_mode,
         use_legacy_moe=use_legacy_moe,
+        enable_prefix_caching=enable_prefix_caching,
     )
 
     conversations = [
@@ -154,4 +156,5 @@ if __name__ == "__main__":
         skip_load=cfg.skip_load,
         weight_load_mode=cfg.weight_load_mode,
         use_legacy_moe=cfg.use_legacy_moe,
+        enable_prefix_caching=cfg.enable_prefix_caching,
     )

--- a/python/infinilm/base_config.py
+++ b/python/infinilm/base_config.py
@@ -71,6 +71,7 @@ class BaseConfig:
         self.attn = self.args.attn
         self.enable_graph = self.args.enable_graph
         self.enable_paged_attn = self.args.enable_paged_attn
+        self.enable_prefix_caching = self.args.enable_prefix_caching
         self.use_mla = self.args.use_mla
         self.num_blocks = self.args.num_blocks
         self.block_size = self.args.block_size
@@ -232,6 +233,13 @@ class BaseConfig:
             "--enable-paged-attn",
             action="store_true",
             help="use paged cache",
+        )
+        self.parser.add_argument(
+            "--disable-prefix-caching",
+            dest="enable_prefix_caching",
+            action="store_false",
+            default=True,
+            help="disable KV prefix cache reuse",
         )
         self.parser.add_argument(
             "--num-blocks", type=int, default=512, help="number of KV cache blocks"

--- a/python/infinilm/config/engine_config.py
+++ b/python/infinilm/config/engine_config.py
@@ -23,6 +23,7 @@ class EngineConfig:
         num_blocks: Number of KV cache blocks (only for paged cache).
         block_size: Size of each KV cache block (only for paged cache).
         max_cache_len: Maximum sequence length (only for static cache).
+        enable_prefix_caching: Whether to reuse KV cache across requests.
         temperature: Default sampling temperature.
         top_p: Default top-p sampling parameter.
         top_k: Default top-k sampling parameter.
@@ -58,6 +59,7 @@ class EngineConfig:
     skip_load: bool = False
     use_legacy_moe: bool = False
     kv_transfer_config: Optional[KVTransferConfig] = None
+    enable_prefix_caching: bool = True
 
     def __post_init__(self) -> None:
         if self.num_draft_tokens < 1:

--- a/python/infinilm/infer_engine.py
+++ b/python/infinilm/infer_engine.py
@@ -50,6 +50,24 @@ def _normalize_videonsa_config(config_dict):
     return config_dict
 
 
+def model_uses_mamba_cache(config: dict) -> bool:
+    llm_config = config.get("text_config", config)
+    layer_types = llm_config.get("layer_types") or []
+    return (
+        config.get("model_type") == "mamba"
+        or llm_config.get("model_type") == "mamba"
+        or "linear_attention" in layer_types
+        or all(
+            key in llm_config
+            for key in (
+                "linear_conv_kernel_dim",
+                "linear_num_key_heads",
+                "linear_num_value_heads",
+            )
+        )
+    )
+
+
 def read_hf_config(model_path):
     config_path = os.path.join(model_path, "config.json")
     with open(config_path, "r") as f:
@@ -160,13 +178,7 @@ class InferEngine(_infinilm.InferEngine):
         self.use_cache = False
 
         self.enable_paged_attn = isinstance(cache_config, PagedKVCacheConfig)
-        llm_config = self.hf_config.get("text_config", self.hf_config)
-        layer_types = llm_config.get("layer_types") or []
-        self.has_mamba_cache = "linear_attention" in layer_types or (
-            "linear_conv_kernel_dim" in llm_config
-            and "linear_num_key_heads" in llm_config
-            and "linear_num_value_heads" in llm_config
-        )
+        self.has_mamba_cache = model_uses_mamba_cache(self.hf_config)
 
     @property
     def dtype(self):

--- a/python/infinilm/llm/cache_manager.py
+++ b/python/infinilm/llm/cache_manager.py
@@ -1,43 +1,37 @@
-"""
-KV Cache Manager - Paged Attention block-based cache allocation and management.
-"""
+"""Paged KV cache allocation and source-agnostic prefix lookup."""
 
 from collections import deque
+from collections.abc import Sequence
 from typing import Dict, List, Set
 
-import numpy as np
-import xxhash
+from infinilm.llm.prefix_cache import (
+    EMPTY_BLOCK_HASH,
+    BlockHash,
+)
 
 
 class Block:
-    """KV Cache Block with reference counting and hash-based reuse support."""
+    """Control-plane metadata for one physical KV cache page."""
 
     def __init__(self, block_id: int):
         self.block_id = block_id
         self.ref_count = 0
-        self.hash = -1
-        self.token_ids: List[int] = []
+        self.hash: BlockHash = EMPTY_BLOCK_HASH
 
     def __repr__(self) -> str:
         return f"Block(id={self.block_id}, ref={self.ref_count}, hash={self.hash})"
 
-    def update(self, hash_value: int, token_ids: List[int]) -> None:
-        self.hash = hash_value
-        self.token_ids = token_ids.copy()
-
     def reset(self) -> None:
         self.ref_count = 1
-        self.hash = -1
-        self.token_ids = []
+        self.hash = EMPTY_BLOCK_HASH
 
     def free(self) -> None:
         self.ref_count = 0
-        self.hash = -1
-        self.token_ids = []
+        self.hash = EMPTY_BLOCK_HASH
 
 
 class MambaCacheManager:
-    """Manages request ownership of mamba state cache rows.
+    """Manage request ownership of Mamba state cache rows.
 
     Row 0 is reserved as the permanent zero state. Request-owned rows are
     allocated from [1, num_blocks).
@@ -49,7 +43,7 @@ class MambaCacheManager:
         if num_blocks < 2:
             raise ValueError("mamba cache pool size must be at least 2")
         self.num_blocks = num_blocks
-        self.free_block_ids: deque = deque(range(1, num_blocks))
+        self.free_block_ids: deque[int] = deque(range(1, num_blocks))
         self.used_block_ids: Set[int] = set()
 
     def can_allocate(self) -> bool:
@@ -75,96 +69,55 @@ class MambaCacheManager:
 
 
 class BlockManager:
-    """Manages Paged KV Cache allocation with prefix caching support.
-
-    Features:
-    - Block allocation/deallocation with reference counting
-    - Hash-based prefix caching for token sequence reuse
-    - Slot mapping generation for physical-to-logical position mapping
-    """
-
-    @classmethod
-    def compute_hash(
-        cls,
-        token_ids: List[int],
-        prefix_hash: int = -1,
-        mm_data_identifiers: List[str] = None,
-    ) -> int:
-        """Compute hash for token sequence with optional prefix chaining."""
-        h = xxhash.xxh64()
-        if prefix_hash != -1:
-            h.update(prefix_hash.to_bytes(8, "little"))
-        h.update(np.array(token_ids, dtype=np.int32).tobytes())
-        if mm_data_identifiers is not None:
-            for identifier in mm_data_identifiers:
-                h.update(identifier.encode("utf-8"))
-        return h.intdigest()
+    """Manage physical paged-cache blocks and published prefix hashes."""
 
     def __init__(self, num_blocks: int, block_size: int):
-        assert num_blocks > 0 and block_size > 0, (
-            "num_blocks and block_size must be positive"
-        )
+        if num_blocks <= 0 or block_size <= 0:
+            raise ValueError("num_blocks and block_size must be positive")
         self.num_blocks = num_blocks
         self.block_size = block_size
 
         self.blocks: List[Block] = [Block(i) for i in range(num_blocks)]
-        self.hash_to_block_id: Dict[int, int] = {}
-        self.free_block_ids: deque = deque(range(num_blocks))
+        self.hash_to_block_ids: Dict[BlockHash, Set[int]] = {}
+        self.free_block_ids: deque[int] = deque(range(num_blocks))
         self.used_block_ids: Set[int] = set()
-        self.pending_block_ids: Set[int] = set()
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             f"BlockManager(blocks={self.num_blocks}, block_size={self.block_size}, "
             f"free={len(self.free_block_ids)}, used={len(self.used_block_ids)})"
         )
 
-    # Private low-level operations
-
-    def _allocate_partial_block(self) -> Block:
-        """Pop the first free block and add it to used blocks as a partial block."""
+    def _allocate_block(self) -> Block:
         block_id = self.free_block_ids.popleft()
         block = self.blocks[block_id]
         assert block.ref_count == 0, f"Block {block_id} ref_count not zero"
-
         block.reset()
         self.used_block_ids.add(block_id)
         return block
 
-    def _allocate_full_block(self) -> Block:
-        """Pop the first free block and add it to pending blocks as a full block."""
-        block_id = self.free_block_ids.popleft()
-        block = self.blocks[block_id]
-        assert block.ref_count == 0, f"Block {block_id} ref_count not zero"
+    def _remove_block_hash(self, block: Block) -> None:
+        if block.hash == EMPTY_BLOCK_HASH:
+            return
+        block_ids = self.hash_to_block_ids.get(block.hash)
+        if block_ids is None or block.block_id not in block_ids:
+            raise RuntimeError(
+                f"block {block.block_id} hash metadata is missing from the prefix index"
+            )
+        block_ids.remove(block.block_id)
+        if not block_ids:
+            del self.hash_to_block_ids[block.hash]
+        block.hash = EMPTY_BLOCK_HASH
 
-        block.reset()
-        self.pending_block_ids.add(block_id)
-        return block
-
-    def _deallocate_block(self, block_id: int):
-        """Deallocate a block and return it to free list."""
+    def _deallocate_block(self, block_id: int) -> None:
         block = self.blocks[block_id]
         assert block.ref_count == 0, (
             f"Block {block_id} ref_count not zero, cannot deallocate"
         )
-
-        if block.hash != -1 and self.hash_to_block_id.get(block.hash) == block_id:
-            del self.hash_to_block_id[block.hash]
-
+        self._remove_block_hash(block)
         block.free()
         self.used_block_ids.remove(block_id)
         self.free_block_ids.append(block_id)
-
-    def _commit_pending_blocks(self) -> None:
-        """Commit pending prefill blocks into used_block_ids and register their hashes."""
-        for block_id in self.pending_block_ids:
-            self.used_block_ids.add(block_id)
-            block = self.blocks[block_id]
-            if block.hash != -1:
-                self.hash_to_block_id[block.hash] = block_id
-        self.pending_block_ids.clear()
-
-    # Read-only state queries
 
     def can_allocate(self, num_required_blocks: int) -> bool:
         return len(self.free_block_ids) >= num_required_blocks
@@ -174,430 +127,238 @@ class BlockManager:
 
     def get_total_usable_blocks(self) -> int:
         freeable_used_blocks = sum(
-            1 for bid in self.used_block_ids if self.blocks[bid].ref_count == 0
+            1
+            for block_id in self.used_block_ids
+            if self.blocks[block_id].ref_count == 0
         )
         return len(self.free_block_ids) + freeable_used_blocks
 
-    # Core public operations
-
     def get_computed_blocks(
         self,
-        token_ids: List[int],
-        mm_token_index_mappings: List[dict] = None,
-    ) -> tuple[List[int], int, List[dict]]:
-        """Find locally cached prefix blocks for the given token sequence.
-
-        The last token is never matched, as it must be recomputed to obtain logits.
-
-        Args:
-            token_ids: Input token sequence.
-            mm_token_index_mappings: List of multimodal token index mappings.
-        Returns:
-            A tuple of (cached_block_table, num_local_cached_tokens, blocks_blueprint):
-            - cached_block_table: List of matched block IDs (each with ref_count incremented).
-            - num_local_cached_tokens: Number of cached tokens (always a multiple of block_size).
-            - blocks_blueprint: Per-block cached block id and precomputed prefix hash.
-        """
-        num_tokens = len(token_ids)
-        num_blocks = (num_tokens + self.block_size - 1) // self.block_size
-        num_full_blocks = num_tokens // self.block_size
-        remain_tokens = num_tokens % self.block_size
-        mm_token_index_mappings = mm_token_index_mappings or []
-        num_mm_inputs = len(mm_token_index_mappings)
-
-        # Variables
-        cached_block_table = []
-        prefix_hash = -1
-        cache_miss = False
-        mm_start_counter = 0
-        mm_caching_queue = deque()
-        blocks_blueprint = []  # [{"prefix_hash": int or -1 if not a full block, "block_id": int or -1 if not cached}, ...]
-        max_blocks_to_reuse = num_full_blocks
-
-        for block_idx in range(num_blocks):
-            start_idx = block_idx * self.block_size
-            end_idx = min(start_idx + self.block_size, num_tokens)
-            block_tokens = token_ids[start_idx:end_idx]
-
-            # Process multimodal token index mappings for this block
-            mm_data_identifiers = []
-            while (
-                mm_start_counter < num_mm_inputs
-                and mm_token_index_mappings[mm_start_counter]["start_index"] < end_idx
-                and mm_token_index_mappings[mm_start_counter]["start_index"]
-                >= start_idx
-            ):
-                # for all mm_data whose start_index is within this block's token range, add its identifier to the list
-                mm_data_identifiers.append(
-                    mm_token_index_mappings[mm_start_counter]["identifier"]
-                )
-                mm_caching_queue.append(mm_start_counter)
-                mm_start_counter += 1
-
-            prefix_hash = (
-                self.compute_hash(block_tokens, prefix_hash, mm_data_identifiers)
-                if len(block_tokens) == self.block_size
-                else -1
-            )
-
-            # Try to reuse existing block if no previous cache miss yet
-            cached_block_id = (
-                self.hash_to_block_id.get(prefix_hash, -1) if not cache_miss else -1
-            )
-            if (
-                cached_block_id != -1
-                and self.blocks[cached_block_id].token_ids != block_tokens
-            ):
-                cached_block_id = -1
-            if end_idx == num_tokens and remain_tokens == 0:
-                # Spicial case, when the last block is fully packed, we cannot reuse it because we need to leave at least one uncached token for forward
-                cached_block_id = -1
-
-            # Deal with the first cache miss
-            if not cache_miss and cached_block_id == -1:
-                max_blocks_to_reuse = min(max_blocks_to_reuse, block_idx)
-                cache_miss = True
-
-            if not cache_miss:
-                # pop fully cached mm_data
-                while (
-                    mm_caching_queue
-                    and mm_token_index_mappings[mm_caching_queue[0]]["end_index"]
-                    < end_idx
-                ):
-                    mm_caching_queue.popleft()
-
-            blocks_blueprint.append(
-                {"prefix_hash": prefix_hash, "block_id": cached_block_id}
-            )
-
-        # If there is one incomplete mm_data, tailing blocks need to fall back until all included mm_data are complete
-        if mm_caching_queue:
-            incomplete_mm = mm_token_index_mappings[mm_caching_queue.popleft()]
-            incomplete_mm_start = incomplete_mm[
-                "start_index"
-            ]  # Fall back until this index is no longer included in the block
-            max_blocks_to_reuse = min(
-                max_blocks_to_reuse, incomplete_mm_start // self.block_size
-            )
-
-        num_local_cached_tokens = max_blocks_to_reuse * self.block_size
-
-        for block_id in range(max_blocks_to_reuse):
-            block = self.blocks[blocks_blueprint[block_id]["block_id"]]
+        block_hashes: Sequence[BlockHash],
+        max_cache_hit_tokens: int,
+    ) -> tuple[List[int], int]:
+        """Pin the longest consecutive cached prefix identified by hashes."""
+        max_hit_blocks = min(
+            len(block_hashes), max(0, max_cache_hit_tokens) // self.block_size
+        )
+        cached_block_table: List[int] = []
+        for block_idx in range(max_hit_blocks):
+            block_hash = block_hashes[block_idx]
+            block_ids = self.hash_to_block_ids.get(block_hash)
+            if not block_ids:
+                break
+            block_id = next(iter(block_ids))
+            block = self.blocks[block_id]
+            assert block.hash == block_hash and block_id in self.used_block_ids
             block.ref_count += 1
-            cached_block_table.append(block.block_id)
-
-        return cached_block_table, num_local_cached_tokens, blocks_blueprint
+            cached_block_table.append(block_id)
+        return cached_block_table, len(cached_block_table) * self.block_size
 
     def allocate_slots(
         self,
-        token_ids: List[int],
         num_new_tokens: int,
         num_computed_tokens: int = 0,
-        cached_block_table: List[int] = None,
-        blocks_blueprint: List[dict] = None,
-        delay_cache_blocks: bool = False,
+        cached_block_table: List[int] | None = None,
     ) -> tuple[List[int], List[int]] | None:
-        """Allocate KV cache slots for a request (PD-disaggregation aware).
-
-        Note: Requires that the underlying attention kernel writes KV cache before
-        reading it (write-before-read ordering).
-
-        Args:
-            token_ids: Complete token sequence for the request.
-            num_new_tokens: Number of tokens to compute in this step.
-            num_computed_tokens: Total number of tokens already computed across local and remote workers.
-            cached_block_table: Already-matched local block IDs.
-            blocks_blueprint: Per-block precomputed prefix hashes from get_computed_blocks.
-            delay_cache_blocks: When True (async PD transfer in progress), allocate
-                blocks but defer hash registration until transfer completes.
-
-        Returns:
-            A tuple of (block_table, slot_mapping), or None if blocks are insufficient.
-            - block_table: Full block list.
-            - slot_mapping: Physical slot IDs for the tokens that need to be computed.
-        """
-        if cached_block_table is None:
-            cached_block_table = []
+        """Allocate physical blocks without publishing prefix hashes."""
+        if num_new_tokens < 0 or num_computed_tokens < 0:
+            raise ValueError("token counts must be non-negative")
+        cached_block_table = cached_block_table or []
         block_table = list(cached_block_table)
-        slot_mapping = []
+        cached_tokens = len(block_table) * self.block_size
+        if num_computed_tokens < cached_tokens:
+            raise ValueError(
+                "num_computed_tokens cannot precede the cached block boundary"
+            )
 
         total_tokens = num_computed_tokens + num_new_tokens
-
-        num_blocks_needed = (
-            total_tokens + self.block_size - 1
-        ) // self.block_size - len(cached_block_table)
+        total_blocks = (total_tokens + self.block_size - 1) // self.block_size
+        num_blocks_needed = total_blocks - len(block_table)
 
         if not self.can_allocate(num_blocks_needed):
             if not self.try_free_blocks(num_blocks_needed):
                 return None
 
-        start_block_idx = len(cached_block_table)
-        total_blocks = (total_tokens + self.block_size - 1) // self.block_size
-        prefix_hash = (
-            self.blocks[cached_block_table[-1]].hash if cached_block_table else -1
-        )
+        for _ in range(num_blocks_needed):
+            block_table.append(self._allocate_block().block_id)
 
-        for block_idx in range(start_block_idx, total_blocks):
-            start_tok = block_idx * self.block_size
-            end_tok = min(start_tok + self.block_size, len(token_ids))
-            block_tokens = token_ids[start_tok:end_tok]
-            is_full_block = len(block_tokens) == self.block_size
-
-            if not self.free_block_ids:
-                return None
-
-            if is_full_block:
-                block_hash = -1
-                if blocks_blueprint is not None and block_idx < len(blocks_blueprint):
-                    block_hash = blocks_blueprint[block_idx]["prefix_hash"]
-                if block_hash == -1:
-                    block_hash = self.compute_hash(block_tokens, prefix_hash)
-                prefix_hash = block_hash
-                block = self._allocate_full_block()
-                block.update(block_hash, block_tokens)
-            else:
-                block = self._allocate_partial_block()
-
-            block_table.append(block.block_id)
-
-        for tok_idx in range(num_computed_tokens, total_tokens):
-            blk_idx = tok_idx // self.block_size
-            blk_offset = tok_idx % self.block_size
-            slot_mapping.append(block_table[blk_idx] * self.block_size + blk_offset)
-
-        if delay_cache_blocks:
-            for block_id in list(self.pending_block_ids):
-                self.used_block_ids.add(block_id)
-            self.pending_block_ids.clear()
-        else:
-            self._commit_pending_blocks()
-
+        slot_mapping = []
+        for token_idx in range(num_computed_tokens, total_tokens):
+            block_idx = token_idx // self.block_size
+            block_offset = token_idx % self.block_size
+            slot_mapping.append(block_table[block_idx] * self.block_size + block_offset)
         return block_table, slot_mapping
 
     def append_slots(
-        self,
-        block_table: List[int],
-        start_num_tokens: int,
-        num_slots: int,
-        total_token_ids: List[int] = None,
-        update_hash: bool = True,
+        self, block_table: List[int], start_num_tokens: int, num_slots: int
     ) -> tuple[List[int], List[int]]:
-        """Append multiple decode slots for speculative target verification."""
-        slots = []
-        for offset in range(num_slots):
-            block_table, slot = self.append_slot(
-                block_table,
-                start_num_tokens + offset,
-                total_token_ids,
-                update_hash=update_hash,
+        """Append contiguous provisional slots for speculative verification."""
+        if num_slots < 0:
+            raise ValueError("num_slots must be non-negative")
+        if num_slots == 0:
+            return block_table, []
+        if start_num_tokens <= 0:
+            raise ValueError("start_num_tokens must be greater than 0")
+        expected_blocks = (start_num_tokens + self.block_size - 2) // self.block_size
+        if len(block_table) != expected_blocks:
+            raise ValueError(
+                "start_num_tokens must immediately follow the allocated logical length"
             )
-            slots.append(slot)
+
+        max_num_tokens = start_num_tokens + num_slots - 1
+        required_blocks = (max_num_tokens + self.block_size - 1) // self.block_size
+        additional_blocks = max(required_blocks - len(block_table), 0)
+        if not self.can_allocate(additional_blocks) and not self.try_free_blocks(
+            additional_blocks
+        ):
+            raise RuntimeError("No available cache blocks")
+
+        for _ in range(additional_blocks):
+            block_table.append(self._allocate_block().block_id)
+
+        slots = []
+        for num_tokens in range(start_num_tokens, start_num_tokens + num_slots):
+            token_idx = num_tokens - 1
+            block_idx, block_offset = divmod(token_idx, self.block_size)
+            slots.append(block_table[block_idx] * self.block_size + block_offset)
         return block_table, slots
 
     def truncate_blocks(
         self, block_table: List[int], keep_num_tokens: int
     ) -> List[int]:
-        """Trim block_table to the logical token length after speculative verify.
+        """Release private, unpublished speculative pages past an accepted length.
 
-        KV tensors are not physically cleared; future attention only sees slots reachable
-        from the returned block table and sequence lengths. Any newly allocated blocks
-        past keep_num_tokens are dereferenced, and hash metadata for the partial tail is
-        invalidated so rejected draft tokens are never reused as a prefix hit.
+        The caller must pass a manager-produced block table with unique page IDs.
         """
-        assert keep_num_tokens > 0, "keep_num_tokens must be greater than 0"
-        keep_blocks = (keep_num_tokens + self.block_size - 1) // self.block_size
-        keep_blocks = min(keep_blocks, len(block_table))
+        if keep_num_tokens <= 0:
+            raise ValueError("keep_num_tokens must be greater than 0")
+        capacity = len(block_table) * self.block_size
+        if keep_num_tokens > capacity:
+            raise ValueError(
+                f"keep_num_tokens={keep_num_tokens} exceeds block table capacity={capacity}"
+            )
 
-        removed = block_table[keep_blocks:]
-        for block_id in removed:
+        keep_blocks = (keep_num_tokens + self.block_size - 1) // self.block_size
+        discarded_block_ids = block_table[keep_blocks:]
+
+        # Validate the complete mutation set first so a malformed speculative
+        # table cannot be only partially released.
+        for block_id in discarded_block_ids:
+            if not 0 <= block_id < self.num_blocks:
+                raise RuntimeError(f"invalid provisional block id {block_id}")
+            block = self.blocks[block_id]
+            if block_id not in self.used_block_ids or block.ref_count != 1:
+                raise RuntimeError(
+                    f"provisional block {block_id} must be privately owned"
+                )
+            if block.hash != EMPTY_BLOCK_HASH:
+                raise RuntimeError(
+                    f"provisional block {block_id} must not be published"
+                )
+
+        if keep_num_tokens % self.block_size != 0:
+            retained_block_id = block_table[keep_blocks - 1]
+            if not 0 <= retained_block_id < self.num_blocks:
+                raise RuntimeError(f"invalid retained block id {retained_block_id}")
+            retained_block = self.blocks[retained_block_id]
+            if (
+                retained_block_id not in self.used_block_ids
+                or retained_block.ref_count != 1
+            ):
+                raise RuntimeError(
+                    f"retained partial block {retained_block_id} must be privately owned"
+                )
+            if retained_block.hash != EMPTY_BLOCK_HASH:
+                raise RuntimeError(
+                    f"retained partial block {retained_block_id} must not be published"
+                )
+
+        for block_id in discarded_block_ids:
             block = self.blocks[block_id]
             block.ref_count = 0
             self._deallocate_block(block_id)
 
-        truncated = block_table[:keep_blocks]
-        if truncated and keep_num_tokens % self.block_size != 0:
-            tail_id = truncated[-1]
-            tail = self.blocks[tail_id]
-            if tail.hash != -1 and self.hash_to_block_id.get(tail.hash) == tail_id:
-                del self.hash_to_block_id[tail.hash]
-            tail.hash = -1
-            tail.token_ids = []
+        return block_table[:keep_blocks]
 
-        return truncated
-
-    def commit_blocks_hash(
-        self, block_table: List[int], token_ids: List[int], num_tokens: int
-    ) -> None:
-        """Register hashes for full blocks whose tokens are finalized."""
-        assert num_tokens <= len(token_ids), "num_tokens exceeds token_ids length"
-        num_full_blocks = min(num_tokens // self.block_size, len(block_table))
-        prefix_hash = -1
-        for block_idx in range(num_full_blocks):
+    def publish_computed_blocks(
+        self,
+        block_table: Sequence[int],
+        block_hashes: Sequence[BlockHash],
+        start_block: int,
+        num_computed_tokens: int,
+    ) -> int:
+        """Publish newly computed full blocks and return the indexed boundary."""
+        end_block = min(
+            num_computed_tokens // self.block_size,
+            len(block_table),
+            len(block_hashes),
+        )
+        if not 0 <= start_block <= end_block:
+            raise ValueError(
+                f"invalid publish range: start_block={start_block}, end_block={end_block}"
+            )
+        for block_idx in range(start_block, end_block):
             block_id = block_table[block_idx]
             block = self.blocks[block_id]
-            block_start = block_idx * self.block_size
-            block_end = block_start + self.block_size
-            block_tokens = token_ids[block_start:block_end]
-            current_hash = self.compute_hash(block_tokens, prefix_hash)
+            if block.hash != EMPTY_BLOCK_HASH:
+                raise RuntimeError(
+                    f"published block {block_id} cannot change its prefix hash"
+                )
 
-            if block.hash != -1 and block.hash != current_hash:
-                if self.hash_to_block_id.get(block.hash) == block_id:
-                    del self.hash_to_block_id[block.hash]
-
-            if block.hash != current_hash or block.token_ids != block_tokens:
-                block.update(current_hash, block_tokens)
-            self.hash_to_block_id[current_hash] = block_id
-            prefix_hash = current_hash
+        for block_idx in range(start_block, end_block):
+            block_id = block_table[block_idx]
+            block = self.blocks[block_id]
+            block_hash = block_hashes[block_idx]
+            block.hash = block_hash
+            self.hash_to_block_ids.setdefault(block_hash, set()).add(block_id)
+        return end_block
 
     def append_slot(
-        self,
-        block_table: List[int],
-        num_tokens: int,
-        total_token_ids: List[int] = None,
-        update_hash: bool = True,
+        self, block_table: List[int], num_tokens: int
     ) -> tuple[List[int], int]:
-        """Append slot for decode phase (generate one new token).
+        """Allocate the slot used to compute the latest logical token."""
+        if (num_tokens - 1) % self.block_size == 0:
+            if not self.free_block_ids and not self.try_free_blocks(1):
+                raise RuntimeError("No available cache blocks")
+            block_table.append(self._allocate_block().block_id)
 
-        Args:
-            block_table: Current block_table
-            num_tokens: Current total token count (including newly generated token)
-            total_token_ids: All token sequence (for updating block hash)
-
-        Returns:
-            Tuple of (block_table, slot_id)
-        """
-        assert len(block_table) > 0, "block_table cannot be empty"
-        assert num_tokens > 0, "num_tokens must be greater than 0"
-
-        if num_tokens % self.block_size == 1:
-            if update_hash:
-                # Previous block is full, update its hash for future prefix caching.
-                last_block_id = block_table[-1]
-                last_block = self.blocks[last_block_id]
-
-                # Only update if block's token_ids is empty (avoid duplicate updates)
-                if len(last_block.token_ids) == 0:
-                    block_start_idx = num_tokens - self.block_size - 1
-                    block_end_idx = num_tokens - 1
-                    block_tokens = total_token_ids[block_start_idx:block_end_idx]
-
-                    # Compute prefix_hash using previous block's hash if available
-                    if len(block_table) > 1:
-                        prev_block = self.blocks[block_table[-2]]
-                        prefix_hash = prev_block.hash
-                    else:
-                        prefix_hash = -1
-
-                    current_hash = self.compute_hash(block_tokens, prefix_hash)
-                    last_block.update(current_hash, block_tokens)
-                    self.hash_to_block_id[current_hash] = last_block_id
-
-            # Need new block
-            if not self.free_block_ids:
-                if not self.try_free_blocks(1):
-                    raise RuntimeError("No available cache blocks")
-            new_block = self._allocate_partial_block()
-            block_table.append(new_block.block_id)
-
-        # Calculate slot
         last_block_id = block_table[-1]
         offset = (num_tokens - 1) % self.block_size
-        slot_id = last_block_id * self.block_size + offset
+        return block_table, last_block_id * self.block_size + offset
 
-        return block_table, slot_id
-
-    # Reference management
-
-    def free_blocks(self, block_table: List[int]):
-        """Decrease reference count for all blocks. Blocks with ref_count=0 are not
-        immediately freed to allow reuse."""
+    def free_blocks(self, block_table: Sequence[int]) -> None:
+        """Release request references while retaining computed blocks for reuse."""
         for block_id in reversed(block_table):
             block = self.blocks[block_id]
             assert block.ref_count > 0, "block ref_count must be greater than 0"
             block.ref_count -= 1
 
     def try_free_blocks(self, num_required: int) -> bool:
-        """Try to free blocks with ref_count=0."""
+        """Evict unreferenced blocks until the requested capacity is available."""
         to_free = [
-            bid for bid in self.used_block_ids if self.blocks[bid].ref_count == 0
+            block_id
+            for block_id in self.used_block_ids
+            if self.blocks[block_id].ref_count == 0
         ]
-
         for block_id in to_free:
             self._deallocate_block(block_id)
             if self.can_allocate(num_required):
                 return True
-
         return self.can_allocate(num_required)
-
-    # PD-disaggregation specific
-
-    def update_blocks_hash(self, block_table: List[int], num_local_cached_tokens: int):
-        """Register hashes for blocks beyond the locally cached prefix into the lookup table.
-
-        Called on the decode node after receiving KV data from the prefill node,
-        so that subsequent requests can hit these blocks via prefix caching.
-        Only full blocks (with a valid hash) are registered; partial blocks are skipped.
-
-        Args:
-            block_table: Block IDs for the current request.
-            num_local_cached_tokens: Number of locally cached tokens (must be a multiple of
-                block_size).
-        """
-        assert num_local_cached_tokens % self.block_size == 0, (
-            "num_local_cached_tokens must be multiple of block_size"
-        )
-        for idx in range(num_local_cached_tokens // self.block_size, len(block_table)):
-            block_id = block_table[idx]
-            block = self.blocks[block_id]
-            if block.hash != -1:
-                self.hash_to_block_id[block.hash] = block_id
 
     def update_blocks_slot(
         self, block_table: List[int], num_computed_tokens: int, total_tokens: int
     ) -> List[int]:
-        """Build the slot mapping for tokens that still need to be computed.
+        """Build slots for the recomputed suffix after a partial remote load."""
+        if num_computed_tokens >= total_tokens:
+            return []
 
-        Used on the decode node after a partial KV transfer failure to reconstruct
-        the slot mapping covering [num_computed_tokens, total_tokens).
-
-        Args:
-            block_table: Block IDs for the current request.
-            num_computed_tokens: Number of tokens already computed (may not be
-                a multiple of block_size).
-            total_tokens: Total token count for this request.
-
-        Returns:
-            Slot IDs for the range [num_computed_tokens, total_tokens).
-        """
-        bs = self.block_size
         new_slot_mapping = []
-
-        start_block = num_computed_tokens // bs
-        start_offset = num_computed_tokens % bs
-
-        last_token_idx = total_tokens - 1
-        end_block = last_token_idx // bs
-        end_offset = last_token_idx % bs + 1
-
-        if start_block == end_block:
-            block_id = block_table[start_block]
-            base = block_id * bs
-            new_slot_mapping.extend(range(base + start_offset, base + end_offset))
-            return new_slot_mapping
-
-        block_id = block_table[start_block]
-        base = block_id * bs
-        new_slot_mapping.extend(range(base + start_offset, base + bs))
-
-        for idx in range(start_block + 1, end_block):
-            block_id = block_table[idx]
-            base = block_id * bs
-            new_slot_mapping.extend(range(base, base + bs))
-
-        block_id = block_table[end_block]
-        base = block_id * bs
-        new_slot_mapping.extend(range(base, base + end_offset))
-
+        for token_idx in range(num_computed_tokens, total_tokens):
+            block_idx = token_idx // self.block_size
+            block_offset = token_idx % self.block_size
+            new_slot_mapping.append(
+                block_table[block_idx] * self.block_size + block_offset
+            )
         return new_slot_mapping

--- a/python/infinilm/llm/llm.py
+++ b/python/infinilm/llm/llm.py
@@ -18,6 +18,7 @@ import janus
 
 from infinilm.config.engine_config import EngineConfig
 from infinilm.config.kv_transfer import KVTransferConfig
+from infinilm.infer_engine import model_uses_mamba_cache, read_hf_config
 from infinilm.kv_connector import KVConnectorFactory, KVConnectorRole
 from infinilm.llm.model_runner.model_runner import ModelRunner
 from infinilm.llm.request import (
@@ -39,6 +40,15 @@ class LLMEngine:
 
     def __init__(self, config: EngineConfig):
         self.config = config
+        hf_config = read_hf_config(config.model_path)
+        has_mamba_cache = model_uses_mamba_cache(hf_config)
+        if has_mamba_cache and config.enable_prefix_caching:
+            model_type = hf_config["model_type"]
+            raise RuntimeError(
+                "Prefix caching is not supported for Mamba-cache model "
+                f"{model_type!r} yet. Restart with "
+                "--disable-prefix-caching."
+            )
 
         self.model_runner = ModelRunner(config)
 
@@ -51,7 +61,10 @@ class LLMEngine:
 
         # Initialize KV cache based on cache type
         if config.cache_type == "static":
-            self.scheduler = StaticScheduler(max_cache_len=config.max_cache_len)
+            self.scheduler = StaticScheduler(
+                max_cache_len=config.max_cache_len,
+                enable_prefix_caching=config.enable_prefix_caching,
+            )
             logger.info(
                 f"Using Static KV Cache with max_cache_len={config.max_cache_len}"
             )
@@ -74,12 +87,6 @@ class LLMEngine:
             max_position_embeddings = llm_config.get(
                 "max_position_embeddings", config.max_cache_len
             )
-            layer_types = llm_config.get("layer_types") or []
-            has_mamba_cache = "linear_attention" in layer_types or (
-                "linear_conv_kernel_dim" in llm_config
-                and "linear_num_key_heads" in llm_config
-                and "linear_num_value_heads" in llm_config
-            )
             num_mamba_cache_blocks = max(2, config.num_blocks // 4)
 
             max_num_batched_tokens = int(
@@ -95,6 +102,7 @@ class LLMEngine:
                 connector=connector,
                 has_mamba_cache=has_mamba_cache,
                 num_mamba_cache_blocks=num_mamba_cache_blocks,
+                enable_prefix_caching=config.enable_prefix_caching,
             )
             logger.info(f"Using Paged KV Cache with num_blocks={config.num_blocks}")
             if has_mamba_cache:
@@ -136,16 +144,12 @@ class LLMEngine:
         if scheduler_output is None:
             return False, []
 
-        # Execute model
         runner_output = self.model_runner.execute_model(scheduler_output)
-        sampled_tokens_list = runner_output.sampled_token_ids
+        sampled_token_ids = runner_output.sampled_token_ids
         self.scheduler.update_from_output(runner_output)
-
-        # Update request status
         pending = self._update_requests(
-            scheduler_output.is_prefill,
             scheduler_output.scheduled_requests,
-            sampled_tokens_list,
+            sampled_token_ids,
         )
 
         # Return False (no immediate work) only when no requests were scheduled
@@ -163,21 +167,22 @@ class LLMEngine:
 
     def _update_requests(
         self,
-        is_prefill: bool,
         requests: List[InferenceRequest],
-        sampled_tokens: List[int],
+        sampled_token_ids: list[int | list[int]],
     ) -> List[tuple]:
-        """Update request status after inference step."""
-        if is_prefill:
-            match self.cache_type:
-                case "paged":
-                    pass
-                case "static":
-                    self.scheduler.update_cache()
-                case _:
-                    raise ValueError(f"Unsupported cache_type: {self.cache_type}")
+        """Apply sampled tokens and publish their target-model KV boundary."""
+        if len(requests) != len(sampled_token_ids):
+            raise RuntimeError(
+                "model output count does not match the scheduled request count: "
+                f"requests={len(requests)}, outputs={len(sampled_token_ids)}"
+            )
         pending = []
-        for req, token_ids in zip(requests, sampled_tokens):
+        for req, token_ids in zip(requests, sampled_token_ids):
+            # The model successfully consumed the request's current logical tokens.
+            # Commit this boundary before observing a concurrent client abort.
+            pre_output_computed_tokens = req.get_total_length()
+            self.scheduler.commit_computed_tokens(req, pre_output_computed_tokens)
+
             if req.is_aborted():
                 logger.info(
                     f"Request {req.request_id} aborted by client, skipping update"
@@ -188,13 +193,18 @@ class LLMEngine:
                     req.mark_canceled()
                 continue
 
-            if not isinstance(token_ids, list):
+            if isinstance(token_ids, list):
+                num_computed_output_tokens = max(len(token_ids) - 1, 0)
+            else:
+                num_computed_output_tokens = 0
                 token_ids = [token_ids]
 
+            num_appended_tokens = 0
             for token_id in token_ids:
                 if req.is_finished():
                     break
-                req.generated_token_ids.append(token_id)
+                req.append_generated_token_id(token_id)
+                num_appended_tokens += 1
                 pending_tokens = req.generated_token_ids[req._token_decode_offset :]
                 delta = self.tokenizer.decode(pending_tokens)
                 holds_back = bool(delta) and delta.endswith("\ufffd")
@@ -245,6 +255,13 @@ class LLMEngine:
                         )
                         continue
                     pending.append((req.output_queue.async_q, output))
+
+            post_output_computed_tokens = pre_output_computed_tokens + min(
+                num_appended_tokens,
+                num_computed_output_tokens,
+            )
+            if post_output_computed_tokens > pre_output_computed_tokens:
+                self.scheduler.commit_computed_tokens(req, post_output_computed_tokens)
 
         self.scheduler.complete_requests(requests)
         return pending
@@ -333,6 +350,7 @@ class LLM:
         weight_load_mode: str = "async",
         skip_load: bool = False,
         use_legacy_moe: bool = False,
+        enable_prefix_caching: bool = True,
     ):
         """Initialize LLM.
 
@@ -379,6 +397,7 @@ class LLM:
             weight_load_mode=weight_load_mode,
             skip_load=skip_load,
             use_legacy_moe=use_legacy_moe,
+            enable_prefix_caching=enable_prefix_caching,
         )
         self.engine = LLMEngine(config)
         self.config = config
@@ -422,6 +441,7 @@ class LLM:
             request_id = f"cmpl-{uuid.uuid4().hex}"
             processed_inputs = None
             mm_index_mappings = None
+            has_multimodal_inputs = False
             if apply_chat_template:
                 prompt = self.engine.apply_chat_template(
                     content, add_generation_prompt=True
@@ -429,6 +449,9 @@ class LLM:
 
                 mm_inputs = resolve_multimodal_inputs(content)
 
+                has_multimodal_inputs = any(
+                    mm_inputs[key] for key in ("images", "videos", "audios")
+                )
                 processed_inputs = self.engine.process(
                     prompt,
                     mm_inputs["images"],
@@ -454,6 +477,7 @@ class LLM:
                 prompt_token_ids=prompt_token_ids,
                 processed_inputs=processed_inputs,
                 mm_token_index_mappings=mm_index_mappings,
+                has_multimodal_inputs=has_multimodal_inputs,
                 sampling_params=sampling_params,
                 eos_token_ids=self.engine.eos_token_ids,
             )
@@ -540,6 +564,7 @@ class AsyncLLMEngine:
         use_mla: bool = False,
         weight_load_mode: str = "async",
         use_legacy_moe: bool = False,
+        enable_prefix_caching: bool = True,
     ):
         """Initialize AsyncLLMEngine.
 
@@ -589,6 +614,7 @@ class AsyncLLMEngine:
             use_mla=use_mla,
             weight_load_mode=weight_load_mode,
             use_legacy_moe=use_legacy_moe,
+            enable_prefix_caching=enable_prefix_caching,
         )
         self.engine = LLMEngine(config)
         self.config = config
@@ -759,6 +785,7 @@ class AsyncLLMEngine:
 
         mm_index_mappings = None
         processed_inputs = None
+        has_multimodal_inputs = False
 
         if prompt_token_ids is not None:
             prompt = self.engine.detokenize(prompt_token_ids)
@@ -779,6 +806,9 @@ class AsyncLLMEngine:
 
             mm_inputs = resolve_multimodal_inputs(messages)
 
+            has_multimodal_inputs = any(
+                mm_inputs[key] for key in ("images", "videos", "audios")
+            )
             processed_inputs = self.engine.process(
                 prompt,
                 mm_inputs["images"],
@@ -807,6 +837,7 @@ class AsyncLLMEngine:
             prompt_token_ids=prompt_token_ids,
             processed_inputs=processed_inputs,
             mm_token_index_mappings=mm_index_mappings,
+            has_multimodal_inputs=has_multimodal_inputs,
             sampling_params=sampling_params,
             eos_token_ids=self.engine.eos_token_ids,
             request_data=request_data,

--- a/python/infinilm/llm/model_runner/speculative_runner.py
+++ b/python/infinilm/llm/model_runner/speculative_runner.py
@@ -118,12 +118,10 @@ class SpeculativeRunner:
                 continue
 
             base_len = req.get_total_length()
-            total_token_ids = req.get_all_token_ids() + draft_tokens
             verify_block_table, verify_slots = cache_ops.append_verify_slots(
                 list(req.block_table),
                 base_len + 1,
                 len(draft_tokens),
-                total_token_ids,
             )
             req.block_table = verify_block_table
             req.num_blocks = len(req.block_table)
@@ -175,10 +173,6 @@ class SpeculativeRunner:
                 )
                 req.num_blocks = len(req.block_table)
                 req.slot_mapping = []
-                accepted_token_ids = req.get_all_token_ids() + draft_tokens[:accepted]
-                cache_ops.commit_accepted_tokens(
-                    req.block_table, accepted_token_ids, keep_tokens
-                )
 
                 output_tokens = draft_tokens[:accepted] + [correction]
                 remaining = candidate["remaining"]

--- a/python/infinilm/llm/prefix_cache.py
+++ b/python/infinilm/llm/prefix_cache.py
@@ -1,0 +1,28 @@
+"""Prefix-cache block hashing utilities."""
+
+from collections.abc import Sequence
+
+import numpy as np
+import xxhash
+
+BlockHash = bytes
+EMPTY_BLOCK_HASH = b""
+
+_HASH_SCHEMA = b"InfiniLM-prefix-cache-v1\0"
+_EMPTY_PARENT_MARKER = b"\0"
+
+
+def hash_block_tokens(
+    token_ids: Sequence[int], parent_hash: BlockHash = EMPTY_BLOCK_HASH
+) -> BlockHash:
+    """Hash one full token block, chained to its parent prefix."""
+    if parent_hash and len(parent_hash) != 16:
+        raise ValueError("parent_hash must be a 128-bit digest")
+
+    token_array = np.asarray(token_ids, dtype="<i4")
+    hasher = xxhash.xxh3_128()
+    hasher.update(_HASH_SCHEMA)
+    hasher.update(parent_hash or _EMPTY_PARENT_MARKER)
+    hasher.update(len(token_array).to_bytes(4, "little"))
+    hasher.update(token_array.tobytes())
+    return hasher.digest()

--- a/python/infinilm/llm/request.py
+++ b/python/infinilm/llm/request.py
@@ -5,15 +5,45 @@ Request and Output - Data structures for inference requests and outputs.
 import asyncio
 import logging
 import time
+from collections.abc import Iterator, Sequence
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import List, Optional
 
 import janus
 
+from infinilm.llm.prefix_cache import (
+    EMPTY_BLOCK_HASH,
+    BlockHash,
+    hash_block_tokens,
+)
 from infinilm.llm.sampling_params import SamplingParams
 
 logger = logging.getLogger(__name__)
+
+
+class _SequenceView(Sequence):
+    """Live read-only view over an internally mutable list."""
+
+    def __init__(self, values: list) -> None:
+        self._values = values
+
+    def __getitem__(self, index):
+        return self._values[index]
+
+    def __iter__(self) -> Iterator:
+        return iter(self._values)
+
+    def __len__(self) -> int:
+        return len(self._values)
+
+    def __repr__(self) -> str:
+        return repr(self._values)
+
+    def __eq__(self, other: object) -> bool:
+        return (
+            list(self._values) == list(other) if isinstance(other, Sequence) else False
+        )
 
 
 class RequestStatus(Enum):
@@ -126,6 +156,8 @@ class InferenceRequest:
         arrival_time: Optional[float] = None,
         # For server use
         request_data: Optional[dict] = None,
+        *,
+        has_multimodal_inputs: bool = False,
     ):
         self.arrival_time: float = arrival_time or time.time()
         self.finished_time: Optional[float] = None
@@ -133,12 +165,15 @@ class InferenceRequest:
         # Request metadata
         self.request_id: str = request_id
         self.prompt: Optional[str] = prompt
-        self.prompt_token_ids: List[int] = (
-            prompt_token_ids if prompt_token_ids is not None else []
+        self._prompt_token_ids: tuple[int, ...] = (
+            tuple(prompt_token_ids) if prompt_token_ids is not None else ()
         )
-        self.prompt_length: int = len(self.prompt_token_ids)
+        self.prompt_length: int = len(self._prompt_token_ids)
         self.processed_inputs: Optional[dict] = processed_inputs
         self.mm_token_index_mappings: Optional[List[dict]] = mm_token_index_mappings
+        self.has_multimodal_inputs: bool = has_multimodal_inputs or bool(
+            mm_token_index_mappings
+        )
         self.priority: int = 0
 
         # Sampling & stopping criteria
@@ -148,19 +183,28 @@ class InferenceRequest:
         )
 
         # Generation state
-        self.generated_token_ids: List[int] = []
+        self._generated_token_ids: List[int] = []
+        self._generated_token_ids_view = _SequenceView(self._generated_token_ids)
         self.generated_text: str = ""  # generated_text == tokenizer.decode(generated_token_ids[:_token_decode_offset])
         self.status: RequestStatus = RequestStatus.WAITING
         self.finish_reason: Optional[FinishReason] = None
 
-        # KV cache management
-        self.block_table: List[int] = []
+        # KV cache state
+        self.block_table: List[int] = []  # Logical block to physical page ID
         self.slot_mapping: List[int] = []
         self.num_local_cached_tokens: int = (
-            0  # Number of locally cached (prefix-hit) tokens
+            0  # Number of cached tokens visible to the current model step
         )
         self.num_computed_tokens: int = 0  # Total tokens computed (local + remote)
         self.num_blocks: int = 0
+        # Incremental hashes for complete logical token blocks.
+        self._block_hashes: List[BlockHash] = []
+        self._block_hashes_view = _SequenceView(self._block_hashes)
+        self._hash_block_size: Optional[int] = None
+        self._prefix_caching_enabled: bool = False
+        self._hash_tail_token_ids: List[int] = []
+        # Number of leading full blocks published to the prefix-cache index.
+        self.num_cache_indexed_blocks: int = 0
 
         # Mamba cache management. None means no mamba cache row is currently owned.
         self.mamba_cache_index: Optional[int] = None
@@ -189,20 +233,80 @@ class InferenceRequest:
             self._output_queue = janus.Queue()
         return self._output_queue
 
+    @property
+    def prompt_token_ids(self) -> tuple[int, ...]:
+        return self._prompt_token_ids
+
+    @property
+    def generated_token_ids(self) -> Sequence[int]:
+        return self._generated_token_ids_view
+
+    @property
+    def block_hashes(self) -> Sequence[BlockHash]:
+        return self._block_hashes_view
+
     def get_prompt_length(self) -> int:
         return self.prompt_length
 
-    def get_input_tokens(self) -> List[int]:
-        return self.prompt_token_ids
+    def get_input_tokens(self) -> Sequence[int]:
+        return self._prompt_token_ids
 
     def get_num_generated_tokens(self) -> int:
-        return len(self.generated_token_ids)
+        return len(self._generated_token_ids)
 
     def get_total_length(self) -> int:
-        return self.prompt_length + len(self.generated_token_ids)
+        return self.prompt_length + len(self._generated_token_ids)
 
     def get_all_token_ids(self) -> List[int]:
-        return self.prompt_token_ids + self.generated_token_ids
+        return list(self._prompt_token_ids) + self._generated_token_ids
+
+    def initialize_block_hashes(
+        self, block_size: int, enable_prefix_caching: bool
+    ) -> None:
+        """Initialize incremental block hashing for this request."""
+        if block_size <= 0:
+            raise ValueError("block_size must be positive")
+        if self._hash_block_size is not None:
+            if (
+                self._hash_block_size != block_size
+                or self._prefix_caching_enabled != enable_prefix_caching
+            ):
+                raise RuntimeError("request block hashing is already initialized")
+            return
+
+        self._hash_block_size = block_size
+        self._prefix_caching_enabled = enable_prefix_caching
+        if not enable_prefix_caching:
+            return
+
+        num_full_blocks = self.prompt_length // block_size
+        parent_hash = EMPTY_BLOCK_HASH
+        for block_idx in range(num_full_blocks):
+            start = block_idx * block_size
+            end = start + block_size
+            parent_hash = hash_block_tokens(
+                self.prompt_token_ids[start:end], parent_hash
+            )
+            self._block_hashes.append(parent_hash)
+
+        tail_start = num_full_blocks * block_size
+        self._hash_tail_token_ids = list(self._prompt_token_ids[tail_start:])
+
+    def append_generated_token_id(self, token_id: int) -> None:
+        """Append one output token and extend the hash chain at block boundaries."""
+        self._generated_token_ids.append(token_id)
+        if not self._prefix_caching_enabled:
+            return
+
+        self._hash_tail_token_ids.append(token_id)
+        if len(self._hash_tail_token_ids) == self._hash_block_size:
+            parent_hash = (
+                self._block_hashes[-1] if self._block_hashes else EMPTY_BLOCK_HASH
+            )
+            self._block_hashes.append(
+                hash_block_tokens(self._hash_tail_token_ids, parent_hash)
+            )
+            self._hash_tail_token_ids.clear()
 
     def get_num_blocks_required(self, block_size: int) -> int:
         total_tokens = self.get_total_length()
@@ -285,12 +389,12 @@ class InferenceRequest:
         return RequestOutput(
             request_id=self.request_id,
             prompt=self.prompt,
-            prompt_token_ids=self.prompt_token_ids,
+            prompt_token_ids=list(self._prompt_token_ids),
             outputs=[
                 CompletionOutput(
                     index=0,
                     text=self.generated_text,
-                    token_ids=self.generated_token_ids.copy(),
+                    token_ids=list(self._generated_token_ids),
                     finish_reason=self.finish_reason,
                 )
             ],

--- a/python/infinilm/llm/scheduler.py
+++ b/python/infinilm/llm/scheduler.py
@@ -25,23 +25,15 @@ class SpeculativeCacheOps:
         block_table: List[int],
         start_length: int,
         num_slots: int,
-        token_ids: List[int],
     ):
         return self._cache_manager.append_slots(
             block_table,
             start_length,
             num_slots,
-            token_ids,
-            update_hash=False,
         )
 
     def rollback_to_length(self, block_table: List[int], keep_tokens: int):
         return self._cache_manager.truncate_blocks(block_table, keep_tokens)
-
-    def commit_accepted_tokens(
-        self, block_table: List[int], token_ids: List[int], num_tokens: int
-    ) -> None:
-        self._cache_manager.commit_blocks_hash(block_table, token_ids, num_tokens)
 
 
 class SchedulerOutput:
@@ -78,6 +70,7 @@ class Scheduler:
         connector=None,
         has_mamba_cache: bool = False,
         num_mamba_cache_blocks: int | None = None,
+        enable_prefix_caching: bool = True,
     ):
         self.waiting_queue = janus.Queue()
         self.running_queue = janus.Queue()
@@ -100,9 +93,18 @@ class Scheduler:
         self.block_size = block_size
         self.max_num_batched_tokens = max_num_batched_tokens
         self.connector = connector
+        self.enable_prefix_caching = enable_prefix_caching
 
     def add_request(self, request: InferenceRequest):
         if request is not None:
+            # TODO: Remove the multimodal exclusion once media-aware prefix
+            # hashing and model-side cache-boundary handling are supported.
+            request.initialize_block_hashes(
+                self.block_size,
+                self.enable_prefix_caching
+                and not self.has_mamba_cache
+                and not request.has_multimodal_inputs,
+            )
             request.status = RequestStatus.WAITING
             self.waiting_queue.sync_q.put(request)
 
@@ -146,23 +148,23 @@ class Scheduler:
                 self.complete_requests([req])
                 continue
 
-            req_tokens = req.get_input_tokens()
-
             if req.num_computed_tokens == 0:
                 if self.has_mamba_cache:
                     cached_block_table = []
                     num_local_computed_tokens = 0
-                    blocks_blueprint = []
                     load_kv_async = False
                     num_external_computed_tokens = 0
                 else:
-                    (
-                        cached_block_table,
-                        num_local_computed_tokens,
-                        blocks_blueprint,
-                    ) = self.cache_manager.get_computed_blocks(
-                        req_tokens, req.get_mm_token_index_mappings()
-                    )
+                    if self.enable_prefix_caching:
+                        (
+                            cached_block_table,
+                            num_local_computed_tokens,
+                        ) = self.cache_manager.get_computed_blocks(
+                            req.block_hashes, req.get_prompt_length() - 1
+                        )
+                    else:
+                        cached_block_table = []
+                        num_local_computed_tokens = 0
                     if self.connector is not None:
                         ext_tokens, load_kv_async = (
                             self.connector.get_num_new_matched_tokens(
@@ -174,19 +176,19 @@ class Scheduler:
                         load_kv_async = False
                         num_external_computed_tokens = 0
 
-                num_computed_tokens = (
+                available_cached_tokens = (
                     num_local_computed_tokens + num_external_computed_tokens
                 )
-                if load_kv_async:
-                    num_computed_tokens -= 1
+                num_computed_tokens = min(
+                    available_cached_tokens,
+                    max(req.get_prompt_length() - 1, 0),
+                )
                 num_new_tokens = req.get_prompt_length() - num_computed_tokens
 
                 # Early token budget check: skip can_accept_request and allocate_slots
                 # for requests that would exceed the per-schedule token budget.
                 if not load_kv_async:
-                    num_tokens_this_step = (
-                        req.get_prompt_length() - num_local_computed_tokens
-                    )
+                    num_tokens_this_step = req.get_prompt_length() - num_computed_tokens
                     if self._exceeds_token_budget(
                         current_num_batched_tokens,
                         num_tokens_this_step,
@@ -212,16 +214,13 @@ class Scheduler:
                     deferred_requests.append(req)
                     break
 
-                req_blocks, slot_mapping = self.cache_manager.allocate_slots(
-                    req_tokens,
+                allocation = self.cache_manager.allocate_slots(
                     num_new_tokens,
                     num_computed_tokens=num_computed_tokens,
                     cached_block_table=cached_block_table,
-                    blocks_blueprint=blocks_blueprint,
-                    delay_cache_blocks=load_kv_async,
                 )
 
-                if req_blocks is None:
+                if allocation is None:
                     logger.warning(
                         "Failed to allocate KV cache blocks for request: %s",
                         req.request_id,
@@ -230,6 +229,7 @@ class Scheduler:
                         self.cache_manager.free_blocks(cached_block_table)
                     deferred_requests.append(req)
                     break
+                req_blocks, slot_mapping = allocation
 
                 if self.has_mamba_cache and req.mamba_cache_index is None:
                     req.mamba_cache_index = self.mamba_cache_manager.allocate()
@@ -245,7 +245,10 @@ class Scheduler:
                 req.block_table = req_blocks
                 req.slot_mapping = slot_mapping
                 req.num_blocks = len(req_blocks)
-                req.num_local_cached_tokens = num_local_computed_tokens
+                req.num_local_cached_tokens = (
+                    num_local_computed_tokens if load_kv_async else num_computed_tokens
+                )
+                req.num_cache_indexed_blocks = len(cached_block_table)
                 req.num_computed_tokens = num_computed_tokens
 
                 if self.connector is not None:
@@ -267,9 +270,7 @@ class Scheduler:
                 ):
                     deferred_requests.append(req)
                     break
-                self.cache_manager.update_blocks_hash(
-                    req.block_table, req.num_local_cached_tokens
-                )
+                self.commit_computed_tokens(req, req.num_computed_tokens)
 
             if load_kv_async:
                 req.status = RequestStatus.WAITING_FOR_REMOTE_KVS
@@ -316,17 +317,13 @@ class Scheduler:
                 continue
 
             # Decode phase: allocate slot for newly generated token
-            try:
-                req.block_table, new_slot = self.cache_manager.append_slot(
-                    req.block_table, req.get_total_length(), req.get_all_token_ids()
-                )
-                req.slot_mapping = [new_slot]
-                req.num_blocks = len(req.block_table)
-                req.num_local_cached_tokens = req.get_total_length() - 1
-                scheduled_requests.append(req)
-
-            except RuntimeError as e:
-                raise RuntimeError("No available cache blocks for new token") from e
+            req.block_table, new_slot = self.cache_manager.append_slot(
+                req.block_table, req.get_total_length()
+            )
+            req.slot_mapping = [new_slot]
+            req.num_blocks = len(req.block_table)
+            req.num_local_cached_tokens = req.get_total_length() - 1
+            scheduled_requests.append(req)
 
         # Promote completed remote KV transfers (lower priority than running queue).
         # Cleanup (is_finished, failed re-queue) runs unconditionally; batch append only if slots remain.
@@ -386,11 +383,7 @@ class Scheduler:
         ) // self.block_size
         if request.request_id in self.failed_receiving_kv_req_ids:
             if request.num_computed_tokens:
-                valid_block_count = request.num_computed_tokens // self.block_size
-                self.cache_manager.update_blocks_hash(
-                    request.block_table[:valid_block_count],
-                    request.num_local_cached_tokens,
-                )
+                self.commit_computed_tokens(request, request.num_computed_tokens)
                 request.slot_mapping = self.cache_manager.update_blocks_slot(
                     request.block_table,
                     request.num_computed_tokens,
@@ -404,9 +397,7 @@ class Scheduler:
                 request.num_local_cached_tokens = 0
             self.failed_receiving_kv_req_ids.discard(request.request_id)
         else:
-            self.cache_manager.update_blocks_hash(
-                request.block_table, request.num_local_cached_tokens
-            )
+            self.commit_computed_tokens(request, request.num_computed_tokens)
             request.num_local_cached_tokens = request.num_computed_tokens
         self.finished_receiving_kv_req_ids.discard(request.request_id)
 
@@ -509,6 +500,28 @@ class Scheduler:
         total_required_blocks = (total_length + self.block_size - 1) // self.block_size
         return max(total_required_blocks - len(request.block_table), 0)
 
+    def commit_computed_tokens(
+        self, request: InferenceRequest, num_computed_tokens: int
+    ) -> None:
+        if not self.enable_prefix_caching or self.has_mamba_cache:
+            return
+
+        indexed_blocks = request.num_cache_indexed_blocks
+        target_blocks = min(
+            num_computed_tokens // self.block_size,
+            len(request.block_table),
+            len(request.block_hashes),
+        )
+        if target_blocks == indexed_blocks:
+            return
+
+        request.num_cache_indexed_blocks = self.cache_manager.publish_computed_blocks(
+            request.block_table,
+            request.block_hashes,
+            request.num_cache_indexed_blocks,
+            num_computed_tokens,
+        )
+
     def update_from_output(self, model_output):
         if self.connector is None or model_output.kv_connector_output is None:
             return
@@ -536,27 +549,32 @@ class Scheduler:
             # else: already processed or unknown, discard to avoid stale entries.
         for req_id in finished_sending_req_ids:
             self.cache_manager.free_blocks(self.pending_free_blocks.pop(req_id, []))
+
+        invalid_set = set(invalid_block_ids)
         for req_id in failed_recving_req_ids:
-            # Only track failures for active (non-aborted) requests; aborted
-            # requests are handled via pending_free_blocks in finished_recving.
-            if req_id in self.remote_kv_requests:
-                self.failed_receiving_kv_req_ids.add(req_id)
+            req = self.remote_kv_requests.get(req_id)
+            if req is None:
+                continue
 
-        if invalid_block_ids:
-            invalid_set = set(invalid_block_ids)
+            self.failed_receiving_kv_req_ids.add(req_id)
+            if req.has_multimodal_inputs:
+                # A physical block boundary can split a media span. Recompute
+                # the prompt until multimodal cache-boundary handling is supported.
+                req.num_computed_tokens = 0
+                continue
 
-            for req in self.remote_kv_requests.values():
-                start_block_idx = req.num_local_cached_tokens // self.block_size
-                for i, block_id in enumerate(
-                    req.block_table[start_block_idx:], start=start_block_idx
-                ):
-                    if block_id in invalid_set:
-                        req.num_computed_tokens = i * self.block_size
-                        break
-        elif self.failed_receiving_kv_req_ids:
-            for req_id in self.failed_receiving_kv_req_ids:
-                req = self.remote_kv_requests[req_id]
-                req.num_computed_tokens = req.num_local_cached_tokens
+            trusted_boundary = req.num_local_cached_tokens
+            start_block_idx = req.num_cache_indexed_blocks
+            for block_idx, block_id in enumerate(
+                req.block_table[start_block_idx:], start=start_block_idx
+            ):
+                if block_id in invalid_set:
+                    trusted_boundary = min(
+                        req.num_computed_tokens,
+                        block_idx * self.block_size,
+                    )
+                    break
+            req.num_computed_tokens = trusted_boundary
 
     def get_cache_stats(self) -> dict:
         """Get cache statistics."""
@@ -565,7 +583,6 @@ class Scheduler:
             "block_size": self.cache_manager.block_size,
             "num_free_blocks": self.cache_manager.get_num_free_blocks(),
             "usable_blocks": self.cache_manager.get_total_usable_blocks(),
-            "num_pending_blocks": len(self.cache_manager.pending_block_ids),
             "num_used_blocks": len(self.cache_manager.used_block_ids),
         }
         if self.mamba_cache_manager is not None:

--- a/python/infinilm/llm/static_scheduler.py
+++ b/python/infinilm/llm/static_scheduler.py
@@ -4,14 +4,15 @@ Static Scheduler - Single-batch request scheduling for Static KV Cache.
 
 import logging
 import queue
-import janus
 from typing import List, Optional
 
-from infinilm.llm.cache_manager import BlockManager
+import janus
+
+from infinilm.llm.prefix_cache import BlockHash
 from infinilm.llm.request import (
-    RequestStatus,
-    InferenceRequest,
     FinishReason,
+    InferenceRequest,
+    RequestStatus,
     TokenOutput,
 )
 
@@ -46,15 +47,25 @@ class StaticScheduler:
     - Prefix cache reuse via chained block hashing (block size = _BLOCK_SIZE)
     """
 
-    def __init__(self, max_cache_len: int = 4096):
+    def __init__(
+        self,
+        max_cache_len: int = 4096,
+        enable_prefix_caching: bool = True,
+    ):
         self.waiting_queue = janus.Queue()
         self.running_request: Optional[InferenceRequest] = None
         self.max_cache_len = max_cache_len
-        self.cached_block_hashes: List[int] = []
-        self.pending_block_hashes: List[int] = []
+        self.enable_prefix_caching = enable_prefix_caching
+        self.cached_block_hashes: List[BlockHash] = []
 
     def add_request(self, request: InferenceRequest):
         if request is not None:
+            # TODO: Remove the multimodal exclusion once media-aware prefix
+            # hashing and model-side cache-boundary handling are supported.
+            request.initialize_block_hashes(
+                _BLOCK_SIZE,
+                self.enable_prefix_caching and not request.has_multimodal_inputs,
+            )
             request.status = RequestStatus.WAITING
             self.waiting_queue.sync_q.put(request)
 
@@ -93,23 +104,6 @@ class StaticScheduler:
                         )
                     continue
 
-                total_length = req.get_total_length()
-                if total_length % _BLOCK_SIZE == 1 and total_length > _BLOCK_SIZE:
-                    block_index = total_length // _BLOCK_SIZE - 1
-                    if len(self.cached_block_hashes) <= block_index:
-                        all_tokens = req.get_all_token_ids()
-                        block_tokens = all_tokens[-(_BLOCK_SIZE + 1) : -1]
-                        prev_h = (
-                            self.cached_block_hashes[-1]
-                            if self.cached_block_hashes
-                            else -1
-                        )
-                        new_h = BlockManager.compute_hash(block_tokens, prev_h)
-                        self.cached_block_hashes.append(new_h)
-                        logger.debug(
-                            f"Decode: appended block hash at index {block_index}"
-                        )
-
                 return StaticSchedulerOutput(scheduled_requests=[req], is_prefill=False)
 
             # Case 2: Get new request from waiting queue (prefill phase)
@@ -147,66 +141,27 @@ class StaticScheduler:
                     )
                 continue
 
-            tokens = req.prompt_token_ids
-            num_full_blocks = prompt_len // _BLOCK_SIZE
             matched = 0
 
-            self.pending_block_hashes.clear()
-
-            for i in range(num_full_blocks):
-                prev_h = self.cached_block_hashes[i - 1] if i > 0 else -1
-                h = BlockManager.compute_hash(
-                    tokens[i * _BLOCK_SIZE : (i + 1) * _BLOCK_SIZE], prev_h
-                )
-                if (
-                    i < len(self.cached_block_hashes)
-                    and h == self.cached_block_hashes[i]
-                ):
-                    matched = i + 1
-                else:
-                    del self.cached_block_hashes[i:]
-                    cur_h = h
-                    self.pending_block_hashes.append(cur_h)
-                    for j in range(i + 1, num_full_blocks):
-                        cur_h = BlockManager.compute_hash(
-                            tokens[j * _BLOCK_SIZE : (j + 1) * _BLOCK_SIZE],
-                            cur_h,
-                        )
-                        self.pending_block_hashes.append(cur_h)
-                    break
+            if self.enable_prefix_caching:
+                for block_idx in range(len(req.block_hashes)):
+                    if (
+                        block_idx >= len(self.cached_block_hashes)
+                        or req.block_hashes[block_idx]
+                        != self.cached_block_hashes[block_idx]
+                    ):
+                        break
+                    matched += 1
+                self.cached_block_hashes = self.cached_block_hashes[:matched]
             else:
-                del self.cached_block_hashes[matched:]
+                self.cached_block_hashes.clear()
 
-            prefix_hit_len = matched * _BLOCK_SIZE
-
-            # Prevent 100% prefix cache hits to avoid an empty prefill input.
-            # When prefix_hit_len equals the total token length, the remaining tokens
-            # for prefill would be zero (input_ids becomes empty), leading to crashes
-            # or incorrect state transitions in the downstream processor.
-            #
-            # This fix is directly inspired by SGLang's approach in their core scheduler
-            # logic (specifically the `adjust_max_prefix_ids` method). SGLang explicitly
-            # trims the prefix matching length to ensure at least one token is left:
-            #
-            #   # To work around some bugs in logprob computation, we need to
-            #   # ensure each request has at least one token. Later, we can relax
-            #   # this requirement and use `input_len`.
-            #   max_prefix_len = input_len - 1
-            #
-            # By forcing the last token to be "missed" from the cache hit, we guarantee
-            # that every request has at least one token to go through the prefill forward
-            # pass. This elegantly avoids the complexity of hijacking the request into
-            # the decode phase and handles edge cases in logprob computation gracefully.
-            #
-            # Mathematically and architecturally, this 2-line adjustment is exactly
-            # equivalent to SGLang's robust production strategy.
-            #
-            if prefix_hit_len >= len(tokens):
-                prefix_hit_len = len(tokens) - 1
+            # Leave the last prompt token for a non-empty model input.
+            prefix_hit_len = min(matched * _BLOCK_SIZE, max(prompt_len - 1, 0))
 
             logger.info(
-                f"Prefill cache match: {matched}/{num_full_blocks} blocks "
-                f"({prefix_hit_len} tokens reused, {len(self.pending_block_hashes)} pending)"
+                f"Prefill cache match: {matched}/{len(req.block_hashes)} blocks "
+                f"({prefix_hit_len} tokens reused)"
             )
 
             req.status = RequestStatus.RUNNING
@@ -215,12 +170,25 @@ class StaticScheduler:
                 scheduled_requests=[req], is_prefill=True, prefix_hit_len=prefix_hit_len
             )
 
-    def update_cache(self):
-        """Commit hashes computed during prefill into the confirmed cache hash list."""
-        self.cached_block_hashes.extend(self.pending_block_hashes)
-        self.pending_block_hashes.clear()
-        logger.debug(
-            f"update_cache: cached_block_hashes now has {len(self.cached_block_hashes)} blocks"
+    def commit_computed_tokens(
+        self, request: InferenceRequest, num_computed_tokens: int
+    ) -> None:
+        """Publish the current request's computed static-cache prefix."""
+        if not self.enable_prefix_caching:
+            self.cached_block_hashes.clear()
+            return
+        num_computed_blocks = min(
+            num_computed_tokens // _BLOCK_SIZE,
+            len(request.block_hashes),
+        )
+        if len(self.cached_block_hashes) > num_computed_blocks:
+            del self.cached_block_hashes[num_computed_blocks:]
+        start_block = len(self.cached_block_hashes)
+        if start_block == num_computed_blocks:
+            return
+
+        self.cached_block_hashes.extend(
+            request.block_hashes[start_block:num_computed_blocks]
         )
 
     def update_from_output(self, model_output):

--- a/python/infinilm/server/inference_server.py
+++ b/python/infinilm/server/inference_server.py
@@ -118,6 +118,7 @@ class InferenceServer:
         weight_load_mode: str = "async",
         ignore_eos: bool = False,
         kv_transfer_config: Optional[KVTransferConfig] = None,
+        enable_prefix_caching: bool = True,
     ):
         """Initialize inference server.
 
@@ -173,6 +174,7 @@ class InferenceServer:
         self.weight_load_mode = weight_load_mode
         self.ignore_eos = ignore_eos
         self.kv_transfer_config = kv_transfer_config
+        self.enable_prefix_caching = enable_prefix_caching
 
         self.engine: AsyncLLMEngine = None
 
@@ -210,6 +212,7 @@ class InferenceServer:
                 use_mla=self.use_mla,
                 weight_load_mode=self.weight_load_mode,
                 kv_transfer_config=self.kv_transfer_config,
+                enable_prefix_caching=self.enable_prefix_caching,
             )
             self.engine.start()
             logger.info(f"Engine initialized with model at {self.model_path}")
@@ -632,6 +635,7 @@ def main():
         weight_load_mode=cfg.weight_load_mode,
         ignore_eos=cfg.ignore_eos,
         kv_transfer_config=kv_transfer_config,
+        enable_prefix_caching=cfg.enable_prefix_caching,
     )
     server.start()
 

--- a/test/models/ernie4_5_moe_vl/test_correctness.py
+++ b/test/models/ernie4_5_moe_vl/test_correctness.py
@@ -75,6 +75,7 @@ def run_infinilm(
         top_k=1,  # greedy
         top_p=1.0,
         attn_backend=attn_backend,
+        enable_prefix_caching=False,
     )
 
     sp = SamplingParams(


### PR DESCRIPTION


<!--
Thanks for contributing to InfiniLM! Please read `CONTRIBUTING.md` before
opening a pull request and fill out every section below. Delete any section
that is genuinely not applicable (and note why), but do not delete the
"Checklist" section — it must be filled in for every PR.

The PR title MUST follow Conventional Commits, e.g.
  feat: support Llama 3 models
  fix: correct linear attention calculations
See: https://www.conventionalcommits.org/
-->

## Summary

<!--
A concise description of **what** this PR changes. Prefer bullet points over
prose. Reference files with backtick-fenced paths (e.g. `csrc/models/llama/*`).
-->

- Move prefix block hashing to request initialization and reuse the precomputed hashes during scheduling.
- Publish cache blocks only after their KV states are computed or externally available.
- Add a prefix caching switch and reject prefix caching for unsupported multimodal models.

## Motivation

<!--
Explain **why** this change is needed. Link to any related issue, bug, or
discussion. If this is a performance change, include before/after numbers
(hardware, shape, dtype, and the measurement methodology).
-->

The previous implementation performed hashing inside the KV cache manager and could expose blocks before their KV states were ready, adding scheduling overhead and complicating speculative decoding and PD disaggregation paths. This change aligns cache lookup and publication with request execution boundaries while keeping multimodal prefix caching disabled until model-side support is available.

Closes #515 

## Type of Change

<!-- Tick one or more. -->

- [x] `feat` — new feature / new model
- [ ] `fix` — bug fix
- [ ] `perf` — performance improvement (no behavioral change)
- [ ] `refactor` — code restructuring without behavior change
- [ ] `test` — adding or fixing tests only
- [ ] `docs` — documentation only
- [ ] `build` / `ci` — build system or CI configuration
- [ ] `chore` — tooling, formatting, or other non-code changes
- [ ] Breaking change

## Test Results of Involved Models on Supported Platforms (Please attach screenshots)

<!--
For now, provide the screenshots for involved tests performed on platforms supposed to support the changes.

Tests that might be involved:
Single request test: examples/test_infer.py
Offline performance: examples/bench.py
Sanity test: test/bench/test_benchmark.py
Service: python/infinilm/server/inference_server.py + scripts/test_perf.py

Model adaptations may involve all four tests, unless specifying partial support for vastly new structures and confirmed with admin.

Python-level changes may involve less tests depending on which files/features are modified. 

Framework-level and Python-level changes may affect different models. Test a few models that might be affected.
-->

## Benchmark / Performance Impact

<!--
Required for `perf` PRs; optional otherwise. Describe the benchmark harness,
shapes, dtypes, hardware, and include baseline vs. new numbers. If the PR is
not performance-sensitive, write "N/A".
-->

## Notes for Reviewers

<!--
Anything reviewers should focus on: subtle invariants, known trade-offs,
follow-up work intentionally left out of scope, etc.
-->

## CI / ChatOps

<!--
CI does not run automatically on pull requests. Trigger it manually from the
Actions tab (workflow: **CI**, branch: this PR's head branch), or ask a
maintainer to comment `/retest` or `/test` on this PR.
-->

---

## Checklist

> Every contributor **must** verify every item below before requesting
> review. Tick each box only after the check has actually been performed —
> do not tick speculatively. If an item truly does not apply, replace the
> checkbox with `N/A` and briefly explain why in an inline comment.

### Title, Branch, and Commits

- [ ] PR **title** follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(nvidia): …`, `fix(cuda/gemm): …`).
- [ ] Branch name follows `<type>/xxx-yyyy-zzzz` where `<type>` matches the PR title's Conventional Commits type and words are joined with hyphens (see `CONTRIBUTING.md` §Branches).
- [ ] Each **commit** message follows Conventional Commits.
- [ ] Small PR is a **single squashable commit**; or, for a large PR, every commit is meaningful, well-formed, and independently reviewable (see `CONTRIBUTING.md` §Pull Requests).
- [ ] No stray merge commits from `main` — the branch is rebased cleanly on top of the current `main`.
- [ ] No `fixup!` / `squash!` / `wip` commits remain.
- [ ] Existing PR/branch/commit that followed the legacy issue format.

### Scope and Design

- [ ] Changes are **minimal** — nothing unrelated to the stated motivation was added (`CONTRIBUTING.md` §Code/General).
- [ ] No dead code, commented-out blocks, debug prints, `printf`/`std::cout`/`print(...)` left behind, or `TODO` without an owner and issue link.
- [ ] No unrelated formatting churn that would obscure the diff.
- [ ] Public API changes (if any) are intentional, documented, and reflected in affected callers/tests.

### General Code Hygiene (applies to all languages)

- [ ] The code is self-explanatory; comments were added **only** where the *why* is non-obvious (`CONTRIBUTING.md` §Code/General).
- [ ] Every modified or added file **ends with a single trailing newline** (`CONTRIBUTING.md` §Code/General).
- [ ] No trailing whitespace, tab/space mixing, or stray BOMs.
- [ ] Identifiers in comments and error messages are wrapped in backticks (e.g. ``the `seqlens_k` tensor``) (`CONTRIBUTING.md` §Code/General).
- [ ] All comments and error messages are in **English** (`CONTRIBUTING.md` §Code/General).
- [ ] Comments and error messages are complete sentences — capitalized first letter, terminal punctuation — **unless** the language/framework convention says otherwise (`CONTRIBUTING.md` §Code/General; §Python).

### C++ Specific (if C++ files changed)

- [ ] Code follows the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) strictly.
- [ ] Error and warning message wording follows the [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html#error-and-warning-messages) (`CONTRIBUTING.md` §C++).
- [ ] Constructor **initializer list order matches member declaration order** (`CONTRIBUTING.md` §C++).
- [ ] No raw `new`/`delete`; RAII / smart pointers / existing allocators are used.
- [ ] Changed files are formatted by `scripts/format.py`.
- [ ] No changes/reference to `csrc/models/llama_legacy/`.

### Python Specific (if Python files changed)

- [ ] Code is [PEP 8](https://peps.python.org/pep-0008/) compliant.
- [ ] Comments are complete English sentences, starting with a capital letter and ending with punctuation; Markdown backticks are used for code references (`CONTRIBUTING.md` §Python).
- [ ] Docstrings (if any) follow [PEP 257](https://peps.python.org/pep-0257/) (`CONTRIBUTING.md` §Python).
- [ ] Changed files are formatted by `scripts/format.py`.
- [ ] No changes/reference to `python/infinilm/auto_config.py`.

### Testing

- [ ] For any platform that could not be tested, an explicit reason is given in the table and a reviewer with access has been tagged.
- [ ] Passed single request test (`examples/test_infer.py`), or specify the reason for skipping.
- [ ] Passed offline performance test (`examples/bench.py`), or specify the reason for skipping.
- [ ] Passed sanity test (`test/bench/test_benchmark.py`), or specify the reason for skipping.
- [ ] Passed service test (`python/infinilm/server/inference_server.py` + `scripts/test_perf.py`), or specify the reason for skipping.

### Build, CI, and Tooling

- [ ] The project builds cleanly from a fresh directory on at least one affected platform.
- [ ] CI has been triggered manually (Actions → **CI** on this branch), or `/retest` was requested.

### Documentation

- [ ] `README.md`, `CONTRIBUTING.md`, or inline docs updated when behavior, build flags, or developer workflow changed.
- [ ] Any user-visible breaking change is called out explicitly under "Motivation" **and** in the commit/PR title with a `!` or `BREAKING CHANGE:` footer.

### Security and Safety

- [ ] No secrets, access tokens, internal URLs, customer data, or personal hardware identifiers have been committed.
- [ ] Third-party code is license-compatible and attributed.
- [ ] No unsafe pointer arithmetic, uninitialized reads, or missing bounds checks were introduced.
