### PR TITLE
feat: cross node PP + intra-node TP

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,20 @@
     python examples/test_infer.py --device nvidia --model=/models/9G7B_MHA/ --backend=cpp --tp=4 --batch-size=16
     ```
 
+    - PP=2 示例：
+
+      在两个终端中分别启动 stage 0 和 stage 1。两个进程的模型、并行和缓存参数必须保持一致。
+
+      ```bash
+      # Terminal 1: stage 0 / coordinator (--node-rank=0)
+      CUDA_VISIBLE_DEVICES=0 python examples/test_infer.py --device=nvidia --model=<path/to/model> --tp=1 --pp=2 --node-rank=0 --master-addr=127.0.0.1 --master-port=29500 --enable-paged-attn --attn=flash-attn --num-blocks=128
+
+      # Terminal 2: stage 1 / worker
+      CUDA_VISIBLE_DEVICES=1 python examples/test_infer.py --device=nvidia --model=<path/to/model> --tp=1 --pp=2 --node-rank=1 --master-addr=127.0.0.1 --master-port=29500 --enable-paged-attn --attn=flash-attn --num-blocks=128
+      ```
+
+      跨节点运行时，每个节点的命令中的 `--master-addr` 和 `--master-port` 设置为 stage 0 节点的 IP 地址和通信端口。
+
 
   - 推理服务测试
     - 启动推理服务
@@ -75,6 +89,18 @@
     - 使用paged attention, flash attention后端，cuda graph等功能：
       ```bash
       CUDA_VISIBLE_DEVICES=0,1,2,3 python python/infinilm/server/inference_server.py --device nvidia --model=/models/9G7B_MHA/ --enable-paged-attn --attn=flash-attn --enable-graph
+      ```
+
+    - PP=2 推理服务示例：
+
+      只有 stage 0 启动 HTTP 服务。两个进程使用相同的 PP rendezvous 地址和模型配置。
+
+      ```bash
+      # Terminal 1: stage 0 / coordinator and HTTP server
+      python python/infinilm/server/inference_server.py --device=nvidia --model=<path/to/model> --tp=1 --pp=2 --node-rank=0 --master-addr=<HOST.IP> --master-port=29500 --enable-paged-attn --attn=flash-attn --num-blocks=128 --max-batch-size=32 --port=8000
+
+      # Terminal 2: stage 1 / worker
+      python python/infinilm/server/inference_server.py --device=nvidia --model=<path/to/model> --tp=1 --pp=2 --node-rank=1 --master-addr=<HOST.IP> --master-port=29500 --enable-paged-attn --attn=flash-attn --num-blocks=128 --max-batch-size=32 --port=8000
       ```
     
     - 测试推理服务性能：

--- a/csrc/engine/distributed/communication_group.cpp
+++ b/csrc/engine/distributed/communication_group.cpp
@@ -1,11 +1,24 @@
 #include "communication_group.hpp"
 #include "../../utils.hpp"
+#include "tcp_rendezvous.hpp"
+
+#include <exception>
+#include <stdexcept>
+#include <thread>
 
 namespace infinilm::engine::distributed {
 
 CommunicationGroup::CommunicationGroup(const DistConfig &dist_config, infinicore::Device::Type device_type)
     : dist_config_(dist_config), device_type_(device_type),
-      communicators_(std::vector<infinicclComm_t>(dist_config.tp_device_ids.size(), nullptr)) {
+      communicators_(std::vector<infinicclComm_t>(dist_config.tp_device_ids.size(), nullptr)),
+      world_communicators_(std::vector<infinicclComm_t>(dist_config.tp_device_ids.size(), nullptr)) {
+
+    if (dist_config_.pp_size < 1) {
+        throw std::runtime_error("DistConfig.pp_size must be at least 1");
+    }
+    if (dist_config_.pp_stage < 0 || dist_config_.pp_stage >= dist_config_.pp_size) {
+        throw std::runtime_error("DistConfig.pp_stage must be in [0, pp_size)");
+    }
 
     size_t world_size = dist_config_.tp_device_ids.size();
     size_t device_count = infinicore::context::getDeviceCount(device_type);
@@ -22,6 +35,63 @@ CommunicationGroup::CommunicationGroup(const DistConfig &dist_config, infinicore
             communicators_.data(),
             dist_config.tp_device_ids.size(),
             dist_config.tp_device_ids.data()));
+        spdlog::info(
+            "Intra-node TP communicator established: node_rank={}, local_ranks={}",
+            dist_config_.pp_stage,
+            world_size);
+    }
+    if (dist_config_.pp_size > 1) {
+        // Bootstrap one InfiniCCL unique ID across nodes over a short-lived TCP
+        // rendezvous. The resulting world communicator is independent of TCP
+        // and is shared by PP activation transfers and final-token delivery.
+        infinicclUniqueId_t unique_id;
+        if (dist_config_.pp_stage == 0) {
+            RUN_INFINI(infinicclGetUniqueId(&unique_id));
+        }
+        broadcast_rendezvous_payload(
+            TcpRendezvousConfig{
+                dist_config_.master_addr,
+                dist_config_.master_port,
+                dist_config_.pp_size,
+                dist_config_.pp_stage,
+            },
+            &unique_id,
+            sizeof(unique_id));
+
+        const int tp_size = static_cast<int>(dist_config_.tp_device_ids.size());
+        const int pp_world_size = dist_config_.pp_size * tp_size;
+        std::vector<std::thread> init_threads;
+        std::vector<std::exception_ptr> exceptions(tp_size);
+        init_threads.reserve(tp_size);
+        for (int local_rank = 0; local_rank < tp_size; ++local_rank) {
+            init_threads.emplace_back([&, local_rank] {
+                try {
+                    infinicore::context::setDevice(infinicore::Device(device_type_, dist_config_.tp_device_ids[local_rank]));
+                    const int global_rank = dist_config_.pp_stage * tp_size + local_rank;
+                    RUN_INFINI(infinicclCommInitRank(&world_communicators_[local_rank],
+                                                     pp_world_size,
+                                                     unique_id,
+                                                     global_rank));
+                } catch (...) {
+                    exceptions[local_rank] = std::current_exception();
+                }
+            });
+        }
+        for (auto &thread : init_threads) {
+            thread.join();
+        }
+        for (auto &exception : exceptions) {
+            if (exception) {
+                std::rethrow_exception(exception);
+            }
+        }
+        spdlog::info(
+            "Global InfiniCCL communicator established: role={}, node_rank={}, nodes={}, local_tp_ranks={}, world_size={}",
+            dist_config_.pp_stage == 0 ? "coordinator" : "participant",
+            dist_config_.pp_stage,
+            dist_config_.pp_size,
+            tp_size,
+            pp_world_size);
     }
 }
 
@@ -35,6 +105,11 @@ RankInfo CommunicationGroup::get_rank_info(int rank) const {
     info.tp_rank = rank;
     info.device = infinicore::Device(device_type_, dist_config_.tp_device_ids[rank]);
     info.comm = communicators_[rank];
+    info.pp_size = dist_config_.pp_size;
+    info.pp_stage = dist_config_.pp_stage;
+    info.world_size = dist_config_.pp_size * info.tp_size;
+    info.world_rank = dist_config_.pp_stage * info.tp_size + info.tp_rank;
+    info.world_comm = world_communicators_[rank];
     return info;
 }
 
@@ -45,6 +120,11 @@ int CommunicationGroup::get_world_size() const {
 CommunicationGroup::~CommunicationGroup() {
     if (communicators_.size() > 1) {
         for (auto &comm : communicators_) {
+            infinicclCommDestroy(comm);
+        }
+    }
+    for (auto &comm : world_communicators_) {
+        if (comm != nullptr) {
             infinicclCommDestroy(comm);
         }
     }

--- a/csrc/engine/distributed/communication_group.hpp
+++ b/csrc/engine/distributed/communication_group.hpp
@@ -14,19 +14,43 @@ namespace infinilm::engine::distributed {
 struct RankInfo {
     // Device Type and ID assigned to this rank
     infinicore::Device device;
-    // Tensor parallelism size
+    // Local tensor parallelism size
     int tp_size;
-    // Tensor parallelism rank number of this rank
+    // Local tensor parallelism rank number of this rank
     int tp_rank;
-    // Communicator handle
+    // Local communicator for current node
     infinicclComm_t comm;
+    // Inter-node pipeline parallelism size
+    int pp_size;
+    // Inter-node pipeline parallelism stage number of this node
+    int pp_stage;
+    // The total number of ranks in the communication world
+    int world_size;
+    // The global rank id of this rank
+    int world_rank;
+    // Inter-node communicator
+    infinicclComm_t world_comm;
 
     RankInfo(infinicore::Device _device = infinicore::context::getDevice())
-        : tp_size(1), tp_rank(0), device(_device), comm(nullptr){};
+        : device(_device),
+          tp_size(1),
+          tp_rank(0),
+          comm(nullptr),
+          pp_size(1),
+          pp_stage(0),
+          world_size(1),
+          world_rank(0),
+          world_comm(nullptr){};
 
     std::string to_string() const {
         std::stringstream ss;
-        ss << "RankInfo: device=" << device.toString() << ", tp_size=" << tp_size << ", tp_rank=" << tp_rank;
+        ss << "RankInfo: device=" << device.toString()
+           << ", tp_size=" << tp_size
+           << ", tp_rank=" << tp_rank
+           << ", pp_size=" << pp_size
+           << ", pp_stage=" << pp_stage
+           << ", world_size=" << world_size
+           << ", world_rank=" << world_rank;
         return ss.str();
     }
 };
@@ -48,6 +72,7 @@ protected:
     DistConfig dist_config_;
     infinicore::Device::Type device_type_;
     std::vector<infinicclComm_t> communicators_;
+    std::vector<infinicclComm_t> world_communicators_;
 };
 
 } // namespace infinilm::engine::distributed

--- a/csrc/engine/distributed/dist_config.cpp
+++ b/csrc/engine/distributed/dist_config.cpp
@@ -22,7 +22,7 @@ DistConfig::operator std::string() const {
             repr += ", ";
         }
     }
-    repr += "], moe_ep_backend=" + moe_ep_backend + ", moe_ep_size=" + std::to_string(moe_ep_size) + ")";
+    repr += "], moe_ep_backend=" + moe_ep_backend + ", moe_ep_size=" + std::to_string(moe_ep_size) + ", pp_size=" + std::to_string(pp_size) + ", pp_stage=" + std::to_string(pp_stage) + ", master_addr=" + master_addr + ", master_port=" + std::to_string(master_port) + ")";
     return repr;
 }
 

--- a/csrc/engine/distributed/dist_config.hpp
+++ b/csrc/engine/distributed/dist_config.hpp
@@ -7,10 +7,18 @@
 namespace infinilm::engine::distributed {
 
 struct DistConfig {
-    // Device IDs for each rank in tensor parallelism
+    // Device IDs for each local rank in tensor parallelism
     std::vector<int> tp_device_ids;
     std::string moe_ep_backend{"disabled"};
     size_t moe_ep_size{1};
+
+    // Inter-node pipeline parallelism size
+    int pp_size{1};
+    // Inter-node pipeline parallelism stage number of current node
+    int pp_stage{0};
+    // Address used to bootstrap distributed communication.
+    std::string master_addr{"127.0.0.1"};
+    int master_port{29500};
 
     DistConfig();
     explicit DistConfig(int tp_size);

--- a/csrc/engine/distributed/tcp_rendezvous.cpp
+++ b/csrc/engine/distributed/tcp_rendezvous.cpp
@@ -1,0 +1,197 @@
+#include "tcp_rendezvous.hpp"
+
+#include <arpa/inet.h>
+#include <cerrno>
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <netdb.h>
+#include <spdlog/spdlog.h>
+#include <stdexcept>
+#include <string>
+#include <sys/socket.h>
+#include <thread>
+#include <unistd.h>
+#include <vector>
+
+namespace infinilm::engine::distributed {
+namespace {
+
+class SocketFd {
+public:
+    explicit SocketFd(int fd = -1) : fd_(fd) {}
+    ~SocketFd() {
+        if (fd_ >= 0) {
+            close(fd_);
+        }
+    }
+
+    SocketFd(const SocketFd &) = delete;
+    SocketFd &operator=(const SocketFd &) = delete;
+    SocketFd(SocketFd &&other) noexcept : fd_(other.fd_) { other.fd_ = -1; }
+    SocketFd &operator=(SocketFd &&other) noexcept {
+        if (this != &other) {
+            reset(other.fd_);
+            other.fd_ = -1;
+        }
+        return *this;
+    }
+
+    int get() const { return fd_; }
+    void reset(int fd = -1) {
+        if (fd_ >= 0) {
+            close(fd_);
+        }
+        fd_ = fd;
+    }
+
+private:
+    int fd_;
+};
+
+void throw_errno(const char *operation) {
+    throw std::runtime_error(std::string(operation) + ": " + std::strerror(errno));
+}
+
+void send_all(int fd, const void *data, size_t size) {
+    const char *ptr = static_cast<const char *>(data);
+    while (size > 0) {
+        const ssize_t sent = send(fd, ptr, size, 0);
+        if (sent <= 0) {
+            throw_errno("TCP rendezvous send");
+        }
+        ptr += sent;
+        size -= static_cast<size_t>(sent);
+    }
+}
+
+void recv_all(int fd, void *data, size_t size) {
+    char *ptr = static_cast<char *>(data);
+    while (size > 0) {
+        const ssize_t received = recv(fd, ptr, size, 0);
+        if (received <= 0) {
+            throw_errno("TCP rendezvous recv");
+        }
+        ptr += received;
+        size -= static_cast<size_t>(received);
+    }
+}
+
+SocketFd connect_to_coordinator(const TcpRendezvousConfig &config) {
+    addrinfo hints{};
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+
+    addrinfo *addresses_raw = nullptr;
+    const std::string port = std::to_string(config.coordinator_port);
+    const int status = getaddrinfo(config.coordinator_addr.c_str(),
+                                   port.c_str(),
+                                   &hints,
+                                   &addresses_raw);
+    if (status != 0) {
+        throw std::runtime_error("TCP rendezvous getaddrinfo: " + std::string(gai_strerror(status)));
+    }
+    std::unique_ptr<addrinfo, decltype(&freeaddrinfo)> addresses(addresses_raw,
+                                                                 freeaddrinfo);
+
+    for (int attempt = 0; attempt < 300; ++attempt) {
+        for (addrinfo *address = addresses.get(); address != nullptr; address = address->ai_next) {
+            SocketFd fd(socket(address->ai_family, address->ai_socktype, address->ai_protocol));
+            if (fd.get() < 0) {
+                continue;
+            }
+            if (connect(fd.get(), address->ai_addr, address->ai_addrlen) == 0) {
+                return fd;
+            }
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+    throw std::runtime_error("failed to connect to TCP rendezvous coordinator");
+}
+
+} // namespace
+
+void broadcast_rendezvous_payload(const TcpRendezvousConfig &config,
+                                  void *payload,
+                                  size_t payload_size) {
+    if (config.participant_count < 1) {
+        throw std::runtime_error("TCP rendezvous participant_count must be at least 1");
+    }
+    if (config.participant_rank < 0 || config.participant_rank >= config.participant_count) {
+        throw std::runtime_error("TCP rendezvous participant_rank is out of range");
+    }
+    if (payload == nullptr && payload_size != 0) {
+        throw std::runtime_error("TCP rendezvous payload must not be null");
+    }
+    if (config.participant_count == 1) {
+        return;
+    }
+
+    if (config.participant_rank != 0) {
+        auto fd = connect_to_coordinator(config);
+        const uint32_t network_rank = htonl(static_cast<uint32_t>(config.participant_rank));
+        send_all(fd.get(), &network_rank, sizeof(network_rank));
+        recv_all(fd.get(), payload, payload_size);
+        spdlog::info(
+            "Distributed bootstrap connection established: role=participant, rank={}, coordinator={}:{}",
+            config.participant_rank,
+            config.coordinator_addr,
+            config.coordinator_port);
+        return;
+    }
+
+    SocketFd listen_fd(socket(AF_INET, SOCK_STREAM, 0));
+    if (listen_fd.get() < 0) {
+        throw_errno("TCP rendezvous socket");
+    }
+    int reuse_address = 1;
+    setsockopt(listen_fd.get(),
+               SOL_SOCKET,
+               SO_REUSEADDR,
+               &reuse_address,
+               sizeof(reuse_address));
+
+    sockaddr_in address{};
+    address.sin_family = AF_INET;
+    address.sin_addr.s_addr = htonl(INADDR_ANY);
+    address.sin_port = htons(static_cast<uint16_t>(config.coordinator_port));
+    if (bind(listen_fd.get(), reinterpret_cast<sockaddr *>(&address), sizeof(address)) != 0) {
+        throw_errno("TCP rendezvous bind");
+    }
+    if (listen(listen_fd.get(), config.participant_count - 1) != 0) {
+        throw_errno("TCP rendezvous listen");
+    }
+
+    spdlog::info(
+        "Distributed bootstrap rendezvous listening: role=coordinator, endpoint=0.0.0.0:{}, participants={}",
+        config.coordinator_port,
+        config.participant_count);
+
+    std::vector<bool> registered(config.participant_count, false);
+    registered[0] = true;
+    for (int connection_idx = 1; connection_idx < config.participant_count; ++connection_idx) {
+        SocketFd client_fd(accept(listen_fd.get(), nullptr, nullptr));
+        if (client_fd.get() < 0) {
+            throw_errno("TCP rendezvous accept");
+        }
+        uint32_t network_rank = 0;
+        recv_all(client_fd.get(), &network_rank, sizeof(network_rank));
+        const int participant_rank = static_cast<int>(ntohl(network_rank));
+        if (participant_rank <= 0 || participant_rank >= config.participant_count || registered[participant_rank]) {
+            throw std::runtime_error("TCP rendezvous received an invalid or duplicate participant rank");
+        }
+        registered[participant_rank] = true;
+        send_all(client_fd.get(), payload, payload_size);
+        spdlog::info(
+            "Distributed bootstrap connection established: role=coordinator, participant_rank={}, connected={}/{}",
+            participant_rank,
+            connection_idx,
+            config.participant_count - 1);
+    }
+    spdlog::info(
+        "Distributed bootstrap rendezvous complete: role=coordinator, participants={}",
+        config.participant_count);
+}
+
+} // namespace infinilm::engine::distributed

--- a/csrc/engine/distributed/tcp_rendezvous.hpp
+++ b/csrc/engine/distributed/tcp_rendezvous.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <cstddef>
+#include <string>
+
+namespace infinilm::engine::distributed {
+
+/**
+ * Configuration for a one-shot TCP rendezvous among distributed processes.
+ * Participant 0 is the coordinator. All other participants connect to it at
+ * coordinator_addr:coordinator_port.
+ */
+struct TcpRendezvousConfig {
+    std::string coordinator_addr;
+    int coordinator_port;
+    int participant_count;
+    int participant_rank;
+};
+
+/**
+ * Broadcast an opaque, fixed-size payload from participant 0.
+ *
+ * The call blocks until the coordinator has served every participant, or until
+ * a participant has received the payload. Nonzero participants first register
+ * their rank, allowing the coordinator to reject duplicates and invalid ranks.
+ * The API does not interpret the payload and can bootstrap any distributed
+ * feature, such as PP or EP. Every participant must pass the same payload_size.
+ * This is a one-shot rendezvous; callers establish their long-lived transport
+ * after this function returns.
+ */
+void broadcast_rendezvous_payload(const TcpRendezvousConfig &config,
+                                  void *payload,
+                                  size_t payload_size);
+
+} // namespace infinilm::engine::distributed

--- a/csrc/engine/rank_worker.cpp
+++ b/csrc/engine/rank_worker.cpp
@@ -1,6 +1,7 @@
 #include "rank_worker.hpp"
 #include "../models/model_factory.hpp"
 #include "infinicore/ops.hpp"
+#include "infinicore/ops/distributed/send_recv.hpp"
 #include <spdlog/spdlog.h>
 #include <stdexcept>
 
@@ -291,7 +292,7 @@ void RankWorker::thread_loop() {
                 model_config_,
                 rank_info_.device,
                 pending_cache_config_ != nullptr ? pending_cache_config_.get() : nullptr);
-            if (enable_graph_compiling_) {
+            if (enable_graph_compiling_ && rank_info_.pp_size == 1) {
                 compiler_ = std::make_unique<GeneralCompiler>(model_, barrier_);
             }
 
@@ -419,7 +420,7 @@ void RankWorker::thread_loop() {
                         infinicore::Tensor hidden_states;
                         // All-position speculative/MTP runs need eager mode because
                         // hidden states are not part of compiled graph outputs.
-                        if (!local_args.sample_all_positions && compiler_ != nullptr) {
+                        if (!local_args.sample_all_positions && compiler_ != nullptr && rank_info_.pp_size == 1) {
                             auto [graph, output] = compiler_->get_compiled(local_args.to_model_input(infinicore::Device::cpu()));
                             if (graph != nullptr && output != nullptr) {
                                 graph->run();
@@ -432,6 +433,35 @@ void RankWorker::thread_loop() {
                             auto model_output = model_->forward(model_args);
                             logits = model_output.logits;
                             hidden_states = model_output.hidden_states;
+                        }
+
+                        if (rank_info_.pp_size > 1 && rank_info_.pp_stage + 1 != rank_info_.pp_size) {
+                            infinicore::Tensor output_ids;
+                            if (rank_info_.pp_stage == 0 && rank_info_.tp_rank == 0) {
+                                // The last PP stage samples tokens. Return them
+                                // directly to stage-0/rank-0, which owns the
+                                // scheduler and user-facing request lifecycle.
+                                const size_t n_req = local_args.input_offsets.value()->size(0) - 1;
+                                const auto *input_offsets = reinterpret_cast<const int32_t *>(local_args.input_offsets.value()->data());
+                                const size_t n_out = local_args.sample_all_positions
+                                                       ? static_cast<size_t>(input_offsets[n_req])
+                                                       : n_req;
+                                output_ids = infinicore::op::distributed::recv(
+                                    {n_out},
+                                    infinicore::DataType::I64,
+                                    rank_info_.device,
+                                    (rank_info_.pp_size - 1) * rank_info_.tp_size,
+                                    rank_info_.world_comm);
+                                output_ids = output_ids->to(infinicore::Device::cpu());
+                                infinicore::context::syncStream();
+                            }
+                            output_ = Output{
+                                output_ids,
+                                logits,
+                                hidden_states};
+                            job_done_ = true;
+                            cv_.notify_all();
+                            continue;
                         }
 
                         // Random sampling (rank 0 only)
@@ -462,6 +492,13 @@ void RankWorker::thread_loop() {
                                 float random_val = std::uniform_real_distribution<float>(0, 1)(rng_);
                                 infinicore::op::random_sample_(
                                     out, score, random_val, top_p, top_k, temperature);
+                            }
+
+                            if (rank_info_.pp_size > 1) {
+                                infinicore::op::distributed::send(
+                                    output_ids,
+                                    0,
+                                    rank_info_.world_comm);
                             }
 
                             output_ids = output_ids->to(infinicore::Device::cpu());

--- a/csrc/layers/causal_lm_templates/text_causal_lm.hpp
+++ b/csrc/layers/causal_lm_templates/text_causal_lm.hpp
@@ -1,8 +1,10 @@
 #pragma once
 
+#include "../../global_state/global_state.hpp"
 #include "../../models/infinilm_model.hpp"
 #include "../linear/linear.hpp"
 #include "infinicore/device.hpp"
+#include <stdexcept>
 
 namespace infinilm::layers::causal_lm_templates {
 
@@ -34,9 +36,14 @@ public:
         size_t hidden_size = model_config->get<size_t>("hidden_size");
         size_t vocab_size = model_config->get<size_t>("vocab_size");
         const auto &dtype{model_config->get_dtype()};
+        const auto &rank_info = infinilm::global_state::get_tensor_model_parallel_rank_info();
+        pp_size_ = static_cast<size_t>(rank_info.pp_size);
+        pp_stage_ = static_cast<size_t>(rank_info.pp_stage);
 
         model_ = this->register_module<Model>("model", model_config, device);
-        lm_head_ = this->register_module<infinilm::layers::linear::ReplicatedLinear>("lm_head", hidden_size, vocab_size, false, dtype, device);
+        if (is_last_pp_stage()) {
+            lm_head_ = this->register_module<infinilm::layers::linear::ReplicatedLinear>("lm_head", hidden_size, vocab_size, false, dtype, device);
+        }
     }
 
     /**
@@ -44,11 +51,17 @@ public:
      */
     Output forward(const Input &input) const override {
         auto hidden_states = model_->forward(input);
+        if (!is_last_pp_stage()) {
+            return {infinicore::Tensor(), hidden_states};
+        }
         auto logits = lm_head_->forward(hidden_states);
-        return {logits};
+        return {logits, hidden_states};
     }
 
     infinicore::Tensor logits_from_hidden(const infinicore::Tensor &hidden_states) const {
+        if (!lm_head_) {
+            throw std::runtime_error("TextCausalLM::logits_from_hidden called on a non-last pipeline stage");
+        }
         return lm_head_->forward(const_cast<infinicore::Tensor &>(hidden_states));
     }
 
@@ -57,6 +70,12 @@ public:
 protected:
     INFINICORE_NN_MODULE(Model, model);
     INFINICORE_NN_MODULE(infinilm::layers::linear::ReplicatedLinear, lm_head);
+
+private:
+    bool is_last_pp_stage() const { return pp_stage_ + 1 == pp_size_; }
+
+    size_t pp_size_{1};
+    size_t pp_stage_{0};
 };
 
 } // namespace infinilm::layers::causal_lm_templates

--- a/csrc/layers/causal_lm_templates/text_model.hpp
+++ b/csrc/layers/causal_lm_templates/text_model.hpp
@@ -1,11 +1,16 @@
 #pragma once
 
 #include "../../config/model_config.hpp"
+#include "../../global_state/global_state.hpp"
 #include "../../models/infinilm_model.hpp"
 #include "infinicore/nn/embedding.hpp"
 #include "infinicore/nn/rmsnorm.hpp"
+#include "infinicore/ops.hpp"
+#include "infinicore/ops/distributed/allgather.hpp"
+#include "infinicore/ops/distributed/send_recv.hpp"
 #include "infinicore/tensor.hpp"
 #include <memory>
+#include <stdexcept>
 
 namespace infinilm::layers::causal_lm_templates {
 
@@ -25,28 +30,40 @@ public:
     TextModel(std::shared_ptr<infinilm::config::ModelConfig> model_config,
               const infinicore::Device &device) {
         const auto &dtype{model_config->get_dtype()};
+        dtype_ = dtype;
         size_t vocab_size = model_config->get<size_t>("vocab_size");
-        size_t hidden_size = model_config->get<size_t>("hidden_size");
+        hidden_size_ = model_config->get<size_t>("hidden_size");
         size_t num_hidden_layers = model_config->get<size_t>("num_hidden_layers");
         double rms_norm_eps = model_config->get<double>("rms_norm_eps");
+        const auto &rank_info = infinilm::global_state::get_tensor_model_parallel_rank_info();
 
-        embed_tokens_ = this->register_module<infinicore::nn::Embedding>("embed_tokens", vocab_size, hidden_size, std::nullopt, dtype, device);
+        pp_size_ = static_cast<size_t>(rank_info.pp_size);
+        pp_stage_ = static_cast<size_t>(rank_info.pp_stage);
+        tp_size_ = static_cast<size_t>(rank_info.tp_size);
+        tp_rank_ = static_cast<size_t>(rank_info.tp_rank);
+        // Contiguous layer ranges are assigned proportionally so uneven layer
+        // counts differ by at most one layer between adjacent PP stages.
+        local_layer_begin_ = num_hidden_layers * pp_stage_ / pp_size_;
+        local_layer_end_ = num_hidden_layers * (pp_stage_ + 1) / pp_size_;
 
-        layers_.reserve(num_hidden_layers);
-        for (size_t i = 0; i < num_hidden_layers; ++i) {
+        if (is_first_pp_stage()) {
+            embed_tokens_ = this->register_module<infinicore::nn::Embedding>("embed_tokens", vocab_size, hidden_size_, std::nullopt, dtype, device);
+        }
+
+        layers_.reserve(local_layer_end_ - local_layer_begin_);
+        for (size_t i = local_layer_begin_; i < local_layer_end_; ++i) {
             layers_.push_back(this->register_module<DecoderLayer>("layers." + std::to_string(i), model_config, i, device));
         }
 
-        norm_ = this->register_module<infinicore::nn::RMSNorm>("norm", hidden_size, rms_norm_eps, dtype, device);
+        if (is_last_pp_stage()) {
+            norm_ = this->register_module<infinicore::nn::RMSNorm>("norm", hidden_size_, rms_norm_eps, dtype, device);
+        }
     }
 
     infinicore::Tensor forward(const infinilm::InfinilmModel::Input &input) const {
-        auto input_ids = input.input_ids.value();
         auto positions = input.position_ids.value();
-        // 1. Embed tokens: input_ids -> [batch, seq_len, hidden_size]
-        auto hidden_states = embed_tokens_->forward(input_ids);
+        auto hidden_states = initial_hidden_states(input);
 
-        // 2. Process through all decoder layers
         size_t num_layers = layers_.size();
         infinicore::Tensor residual;
         for (size_t i = 0; i < num_layers; ++i) {
@@ -56,17 +73,26 @@ public:
                 residual);
         }
 
+        if (!is_last_pp_stage()) {
+            hidden_states = materialize_hidden_states(hidden_states, residual);
+            send_pipeline_hidden(hidden_states);
+            return hidden_states;
+        }
+
         norm_->forward_inplace(hidden_states, residual);
         return hidden_states;
     }
 
     infinicore::Tensor forward_naive(const infinilm::InfinilmModel::Input &input) const {
-        auto input_ids = input.input_ids.value();
         auto positions = input.position_ids.value();
-        auto hidden_states = embed_tokens_->forward(input_ids);
+        auto hidden_states = initial_hidden_states(input);
         size_t num_layers = layers_.size();
         for (size_t i = 0; i < num_layers; ++i) {
             hidden_states = layers_.at(i)->forward(positions, hidden_states);
+        }
+        if (!is_last_pp_stage()) {
+            send_pipeline_hidden(hidden_states);
+            return hidden_states;
         }
         hidden_states = norm_->forward(hidden_states);
         return hidden_states;
@@ -75,7 +101,7 @@ public:
     infinicore::Tensor forward_embeds(const infinicore::Tensor &inputs_embeds,
                                       const infinicore::Tensor &position_ids) const {
 
-        auto hidden_states = inputs_embeds;
+        auto hidden_states = is_first_pp_stage() ? inputs_embeds : recv_pipeline_hidden(inputs_embeds->shape()[0], inputs_embeds->shape()[1], inputs_embeds->dtype(), inputs_embeds->device());
 
         //  Process through all decoder layers
         size_t num_layers = layers_.size();
@@ -87,11 +113,20 @@ public:
                 residual);
         }
 
+        if (!is_last_pp_stage()) {
+            hidden_states = materialize_hidden_states(hidden_states, residual);
+            send_pipeline_hidden(hidden_states);
+            return hidden_states;
+        }
+
         norm_->forward_inplace(hidden_states, residual);
         return hidden_states;
     }
 
     infinicore::Tensor embed_tokens(const infinicore::Tensor &input_ids) const {
+        if (!embed_tokens_) {
+            throw std::runtime_error("TextModel::embed_tokens called on a non-first pipeline stage");
+        }
         return embed_tokens_->forward(input_ids);
     }
 
@@ -99,6 +134,86 @@ protected:
     INFINICORE_NN_MODULE(infinicore::nn::Embedding, embed_tokens);
     INFINICORE_NN_MODULE_VEC(DecoderLayer, layers);
     INFINICORE_NN_MODULE(infinicore::nn::RMSNorm, norm);
+
+private:
+    bool is_first_pp_stage() const { return pp_stage_ == 0; }
+    bool is_last_pp_stage() const { return pp_stage_ + 1 == pp_size_; }
+
+    infinicore::Tensor initial_hidden_states(const infinilm::InfinilmModel::Input &input) const {
+        auto input_ids = input.input_ids.value();
+        if (is_first_pp_stage()) {
+            return embed_tokens_->forward(input_ids);
+        }
+        auto shape = input_ids->shape();
+        return recv_pipeline_hidden(shape[0], shape[1], input_ids->dtype(), input_ids->device());
+    }
+
+    infinicore::Tensor recv_pipeline_hidden(size_t batch_size,
+                                            size_t seq_len,
+                                            const infinicore::DataType &dtype_hint,
+                                            const infinicore::Device &device) const {
+        (void)dtype_hint;
+        const auto &rank_info = infinilm::global_state::get_tensor_model_parallel_rank_info();
+        if (hidden_size_ % tp_size_ != 0) {
+            throw std::runtime_error("TextModel PP recv requires hidden_size divisible by tp_size");
+        }
+        const size_t shard_hidden = hidden_size_ / tp_size_;
+        // Every TP rank receives the matching hidden-size shard from the same
+        // TP rank on the previous node. The local all-gather reconstructs the
+        // complete hidden state required by the replicated decoder input.
+        auto local_shard = infinicore::op::distributed::recv(
+            {batch_size * seq_len, shard_hidden},
+            dtype_,
+            device,
+            static_cast<int>((pp_stage_ - 1) * tp_size_ + tp_rank_),
+            rank_info.world_comm);
+        if (tp_size_ == 1) {
+            return local_shard->view({batch_size, seq_len, hidden_size_});
+        }
+        auto gathered = infinicore::op::distributed::allgather(local_shard, tp_size_, rank_info.comm);
+        return gathered->view({tp_size_, batch_size, seq_len, shard_hidden})
+            ->permute({1, 2, 0, 3})
+            ->contiguous()
+            ->view({batch_size, seq_len, hidden_size_});
+    }
+
+    void send_pipeline_hidden(const infinicore::Tensor &hidden_states) const {
+        const auto &rank_info = infinilm::global_state::get_tensor_model_parallel_rank_info();
+        auto shape = hidden_states->shape();
+        if (shape.size() != 3 || shape[2] != hidden_size_) {
+            throw std::runtime_error("TextModel PP send expects hidden states with shape [batch, seq, hidden_size]");
+        }
+        if (hidden_size_ % tp_size_ != 0) {
+            throw std::runtime_error("TextModel PP send requires hidden_size divisible by tp_size");
+        }
+        const size_t shard_hidden = hidden_size_ / tp_size_;
+        // Split hidden_size across local TP ranks. Matching ranks transfer their
+        // shards independently, avoiding one full activation transfer per rank.
+        auto local_shard = hidden_states->narrow({{2, tp_rank_ * shard_hidden, shard_hidden}})
+                               ->contiguous()
+                               ->view({shape[0] * shape[1], shard_hidden});
+        infinicore::op::distributed::send(
+            local_shard,
+            static_cast<int>((pp_stage_ + 1) * tp_size_ + tp_rank_),
+            rank_info.world_comm);
+    }
+
+    infinicore::Tensor materialize_hidden_states(infinicore::Tensor &hidden_states,
+                                                 infinicore::Tensor &residual) const {
+        if (!residual) {
+            return hidden_states;
+        }
+        return infinicore::op::add(residual, hidden_states);
+    }
+
+    infinicore::DataType dtype_{infinicore::DataType::F32};
+    size_t hidden_size_{0};
+    size_t pp_size_{1};
+    size_t pp_stage_{0};
+    size_t tp_size_{1};
+    size_t tp_rank_{0};
+    size_t local_layer_begin_{0};
+    size_t local_layer_end_{0};
 };
 
 } // namespace infinilm::layers::causal_lm_templates

--- a/csrc/models/infinilm_model.cpp
+++ b/csrc/models/infinilm_model.cpp
@@ -34,6 +34,11 @@ std::vector<infinicore::Tensor> InfinilmModel::default_allocate_kv_cache_tensors
     size_t max_position_embeddings = text_config->get<size_t>("max_position_embeddings");
     const auto &dtype = model_config_->get_kv_cache_dtype();
     const size_t num_hidden_layers = text_config->get<size_t>("num_hidden_layers");
+    const auto &rank_info = infinilm::global_state::get_tensor_model_parallel_rank_info();
+    const size_t pp_size = static_cast<size_t>(rank_info.pp_size);
+    const size_t pp_stage = static_cast<size_t>(rank_info.pp_stage);
+    const size_t local_layer_begin = num_hidden_layers * pp_stage / pp_size;
+    const size_t local_layer_end = num_hidden_layers * (pp_stage + 1) / pp_size;
 
     std::vector<infinicore::Tensor> kv_cache_vec;
     switch (attention_backend) {
@@ -42,9 +47,9 @@ std::vector<infinicore::Tensor> InfinilmModel::default_allocate_kv_cache_tensors
         if (nullptr == static_kv_cache_config) {
             throw std::runtime_error("infinilm::InfinilmModel::default_allocate_kv_cache_tensors: invalid static kv cache config type");
         }
-        kv_cache_vec.reserve(num_hidden_layers);
+        kv_cache_vec.resize(num_hidden_layers);
 
-        for (size_t layer_idx = 0; layer_idx < num_hidden_layers; ++layer_idx) {
+        for (size_t layer_idx = local_layer_begin; layer_idx < local_layer_end; ++layer_idx) {
             auto kv_cache = cache::StaticKVCache::create_layer_kv_cache(
                 head_dim,
                 head_dim,
@@ -53,7 +58,7 @@ std::vector<infinicore::Tensor> InfinilmModel::default_allocate_kv_cache_tensors
                 max_position_embeddings,
                 dtype,
                 *static_kv_cache_config);
-            kv_cache_vec.push_back(kv_cache);
+            kv_cache_vec[layer_idx] = kv_cache;
         }
         break;
     }
@@ -66,9 +71,9 @@ std::vector<infinicore::Tensor> InfinilmModel::default_allocate_kv_cache_tensors
             throw std::runtime_error(
                 "infinilm::InfinilmModel::default_allocate_kv_cache_tensors: invalid paged kv cache config type");
         }
-        kv_cache_vec.reserve(num_hidden_layers);
+        kv_cache_vec.resize(num_hidden_layers);
 
-        for (size_t layer_idx = 0; layer_idx < num_hidden_layers; ++layer_idx) {
+        for (size_t layer_idx = local_layer_begin; layer_idx < local_layer_end; ++layer_idx) {
             auto kv_cache = cache::PagedKVCache::create_layer_kv_cache(
                 head_dim,
                 head_dim,
@@ -76,7 +81,7 @@ std::vector<infinicore::Tensor> InfinilmModel::default_allocate_kv_cache_tensors
                 num_key_value_heads,
                 dtype,
                 *paged_kv_cache_config);
-            kv_cache_vec.push_back(kv_cache);
+            kv_cache_vec[layer_idx] = kv_cache;
         }
         infinicore::context::syncStream();
         break;

--- a/csrc/pybind11/engine/engine.hpp
+++ b/csrc/pybind11/engine/engine.hpp
@@ -21,6 +21,14 @@ inline void bind_dist_config(py::module &m) {
                        "MoE expert-parallel backend")
         .def_readwrite("moe_ep_size", &DistConfig::moe_ep_size,
                        "MoE expert-parallel size")
+        .def_readwrite("pp_size", &DistConfig::pp_size,
+                       "Pipeline parallel size")
+        .def_readwrite("pp_stage", &DistConfig::pp_stage,
+                       "Pipeline parallel stage index for this engine")
+        .def_readwrite("master_addr", &DistConfig::master_addr,
+                       "Address used to bootstrap distributed communication")
+        .def_readwrite("master_port", &DistConfig::master_port,
+                       "TCP port used to bootstrap distributed communication")
         .def("__repr__", [](const DistConfig &cfg) {
             return std::string(cfg);
         })
@@ -83,9 +91,9 @@ inline void bind_infer_engine(py::module &m) {
                      use_mla,
                      weight_load_mode);
              }),
-             py::arg("config_str") = "",
-             py::arg("distributed_config") = distributed::DistConfig(),
-             py::arg("device_type") = infinicore::context::getDevice().getType(),
+             py::arg("config_str"),
+             py::arg("distributed_config"),
+             py::arg("device_type"),
              py::arg("cache_config") = py::none(),
              py::arg("enable_graph_compiling") = false,
              py::arg("attention_backend") = "default",

--- a/examples/test_infer.py
+++ b/examples/test_infer.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import time
 
@@ -17,6 +18,10 @@ def test(
     max_new_tokens=100,
     device="cpu",
     tp=1,
+    pp=1,
+    pp_stage=0,
+    master_addr="127.0.0.1",
+    master_port=29500,
     moe_ep_backend="disabled",
     ep=1,
     enable_paged_attn=False,
@@ -48,6 +53,10 @@ def test(
         num_draft_tokens=num_draft_tokens,
         device=device,
         tensor_parallel_size=tp,
+        pipeline_parallel_size=pp,
+        pipeline_parallel_stage=pp_stage,
+        master_addr=master_addr,
+        master_port=master_port,
         moe_ep_backend=moe_ep_backend,
         moe_ep_size=ep,
         cache_type="paged" if enable_paged_attn else "static",
@@ -87,9 +96,12 @@ def test(
     t1 = time.time()
     print("=================== start generate ====================")
 
-    outputs = model.chat(
-        messages=conversations,
-    )
+    try:
+        outputs = model.chat(
+            messages=conversations,
+        )
+    finally:
+        model.close()
     t2 = time.time()
 
     for i, output in enumerate(outputs):
@@ -107,6 +119,15 @@ def test(
 
 if __name__ == "__main__":
     cfg = BaseConfig()
+    logging.basicConfig(
+        level=getattr(logging, cfg.log_level.upper(), logging.INFO),
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+    if cfg.pp > 1 and cfg.node_rank > 0:
+        from infinilm.server.pipeline_worker import run_worker
+
+        run_worker(cfg)
+        raise SystemExit(0)
 
     device_str = cfg.get_device_str(cfg.device)
 
@@ -137,6 +158,10 @@ if __name__ == "__main__":
         max_new_tokens=max_new_tokens,
         device=device_str,
         tp=tp,
+        pp=cfg.pp,
+        pp_stage=cfg.node_rank,
+        master_addr=cfg.master_addr,
+        master_port=cfg.master_port,
         moe_ep_backend=moe_ep_backend,
         ep=ep,
         enable_paged_attn=enable_paged_attn,

--- a/python/infinilm/base_config.py
+++ b/python/infinilm/base_config.py
@@ -63,6 +63,10 @@ class BaseConfig:
         self.num_draft_tokens = self.args.num_draft_tokens
         self.device = self.args.device
         self.tp = self.args.tp
+        self.pp = self.args.pp
+        self.node_rank = self.args.node_rank
+        self.master_addr = self.args.master_addr
+        self.master_port = self.args.master_port
         self.dp = self.args.dp
         self.ep = self.args.ep
         self.moe_ep_backend = self.args.moe_ep_backend
@@ -199,6 +203,29 @@ class BaseConfig:
             ),
         )
         self.parser.add_argument("--tp", "--tensor-parallel-size", type=int, default=1)
+        self.parser.add_argument(
+            "--pp", "--pipeline-parallel-size", type=int, default=1
+        )
+        self.parser.add_argument(
+            "--node-rank",
+            "--pp-stage",
+            "--pipeline-parallel-stage",
+            dest="node_rank",
+            type=int,
+            default=0,
+        )
+        self.parser.add_argument(
+            "--master-addr",
+            dest="master_addr",
+            type=str,
+            default="127.0.0.1",
+        )
+        self.parser.add_argument(
+            "--master-port",
+            dest="master_port",
+            type=int,
+            default=29500,
+        )
         self.parser.add_argument("--dp", "--data-parallel-size", type=int, default=1)
         self.parser.add_argument(
             "--ep", "--expert-parallel-size", type=int, default=None

--- a/python/infinilm/config/engine_config.py
+++ b/python/infinilm/config/engine_config.py
@@ -15,6 +15,10 @@ class EngineConfig:
         device: Device type string ('cpu', 'cuda', 'mlu', etc.).
         dtype: Data type string ('float16', 'bfloat16', 'float32').
         tensor_parallel_size: Number of devices for tensor parallelism.
+        pipeline_parallel_size: Number of pipeline stages.
+        pipeline_parallel_stage: Pipeline stage index for this engine.
+        master_addr: Address used to bootstrap distributed communication.
+        master_port: TCP port used to bootstrap distributed communication.
         moe_ep_backend: MoE expert-parallel backend.
         moe_ep_size: MoE expert-parallel size.
         cache_type: Cache type ('paged' or 'static').
@@ -40,6 +44,10 @@ class EngineConfig:
     device: str = "cuda"
     dtype: str = "float16"
     tensor_parallel_size: int = 1
+    pipeline_parallel_size: int = 1
+    pipeline_parallel_stage: int = 0
+    master_addr: str = "127.0.0.1"
+    master_port: int = 29500
     moe_ep_backend: str = "disabled"
     moe_ep_size: int = 1
     cache_type: str = "paged"  # "paged" or "static"
@@ -62,6 +70,14 @@ class EngineConfig:
     def __post_init__(self) -> None:
         if self.num_draft_tokens < 1:
             raise ValueError("num_draft_tokens must be >= 1")
+        if self.pipeline_parallel_size < 1:
+            raise ValueError("pipeline_parallel_size must be >= 1")
+        if not 0 <= self.pipeline_parallel_stage < self.pipeline_parallel_size:
+            raise ValueError(
+                "pipeline_parallel_stage must be in [0, pipeline_parallel_size)"
+            )
+        if not 1 <= self.master_port <= 65535:
+            raise ValueError("master_port must be in [1, 65535]")
 
         if self.weight_load_mode not in {"async", "sync"}:
             raise ValueError("weight_load_mode must be either 'async' or 'sync'")

--- a/python/infinilm/distributed/dist_config.py
+++ b/python/infinilm/distributed/dist_config.py
@@ -9,6 +9,10 @@ class DistConfig:
         tp_device_ids=None,
         moe_ep_backend="disabled",
         moe_ep_size=1,
+        pp_size=1,
+        pp_stage=0,
+        master_addr="127.0.0.1",
+        master_port=29500,
     ):
         from infinilm.lib import _infinilm
 
@@ -23,6 +27,10 @@ class DistConfig:
             self._underlying = _infinilm.DistConfig()
         self.moe_ep_backend = moe_ep_backend
         self.moe_ep_size = moe_ep_size
+        self.pp_size = pp_size
+        self.pp_stage = pp_stage
+        self.master_addr = master_addr
+        self.master_port = master_port
 
     @property
     def tp_device_ids(self):
@@ -47,6 +55,38 @@ class DistConfig:
     @moe_ep_size.setter
     def moe_ep_size(self, value):
         self._underlying.moe_ep_size = int(value)
+
+    @property
+    def pp_size(self):
+        return self._underlying.pp_size
+
+    @pp_size.setter
+    def pp_size(self, value):
+        self._underlying.pp_size = int(value)
+
+    @property
+    def pp_stage(self):
+        return self._underlying.pp_stage
+
+    @pp_stage.setter
+    def pp_stage(self, value):
+        self._underlying.pp_stage = int(value)
+
+    @property
+    def master_addr(self):
+        return self._underlying.master_addr
+
+    @master_addr.setter
+    def master_addr(self, value):
+        self._underlying.master_addr = str(value)
+
+    @property
+    def master_port(self):
+        return self._underlying.master_port
+
+    @master_port.setter
+    def master_port(self, value):
+        self._underlying.master_port = int(value)
 
     def __repr__(self):
         return repr(self._underlying)

--- a/python/infinilm/distributed/pipeline_transport.py
+++ b/python/infinilm/distributed/pipeline_transport.py
@@ -1,0 +1,272 @@
+"""Persistent host-to-worker control transport for pipeline parallelism.
+
+PP startup has two network layers which intentionally reuse ``master_port`` in
+sequence. During ``InferEngine`` construction, the C++ TCP rendezvous briefly
+binds the port and distributes the InfiniCCL unique ID. Once every process has
+joined the global communicator, that socket closes. After model loading, stage
+0 binds the same port as the persistent control server implemented here.
+
+For each scheduler step, stage 0 sends identical model metadata to all worker
+stages before entering its own forward. Tensor activations do not travel over
+this socket: matching TP ranks send them through the global InfiniCCL
+communicator, and each receiving node all-gathers its hidden-size shards.
+"""
+
+import ctypes
+import logging
+import pickle
+import socket
+import struct
+import time
+import traceback
+from typing import Any
+
+import infinicore
+import numpy as np
+from infinicore.utils import infinicore_to_numpy_dtype
+
+_FRAME_HEADER = struct.Struct("!Q")
+_TENSOR_MARKER = "__infinicore_tensor__"
+_TUPLE_MARKER = "__tuple__"
+
+logger = logging.getLogger(__name__)
+
+
+def _recv_exact(sock: socket.socket, size: int) -> bytes:
+    chunks = bytearray()
+    while len(chunks) < size:
+        chunk = sock.recv(size - len(chunks))
+        if not chunk:
+            raise ConnectionError("pipeline control connection closed")
+        chunks.extend(chunk)
+    return bytes(chunks)
+
+
+def _send_payload(sock: socket.socket, payload: bytes) -> None:
+    sock.sendall(_FRAME_HEADER.pack(len(payload)))
+    sock.sendall(payload)
+
+
+def _recv_payload(sock: socket.socket) -> bytes:
+    (size,) = _FRAME_HEADER.unpack(_recv_exact(sock, _FRAME_HEADER.size))
+    return _recv_exact(sock, size)
+
+
+def _send_message(sock: socket.socket, message: Any) -> None:
+    _send_payload(sock, pickle.dumps(message, protocol=pickle.HIGHEST_PROTOCOL))
+
+
+def _recv_message(sock: socket.socket) -> Any:
+    return pickle.loads(_recv_payload(sock))
+
+
+def _tensor_to_numpy(tensor: infinicore.Tensor) -> np.ndarray:
+    if tensor.device.type != "cpu":
+        tensor = tensor.to(infinicore.device("cpu", 0))
+        infinicore.sync_device()
+    if not tensor.is_contiguous():
+        tensor = tensor.contiguous()
+
+    shape = tuple(tensor.shape)
+    dtype = np.dtype(infinicore_to_numpy_dtype(tensor.dtype))
+    if tensor.numel() == 0:
+        return np.empty(shape, dtype=dtype)
+
+    num_bytes = tensor.numel() * dtype.itemsize
+    buffer_type = ctypes.c_ubyte * num_bytes
+    buffer = buffer_type.from_address(tensor.data_ptr())
+    return (
+        np.frombuffer(buffer, dtype=dtype, count=tensor.numel()).reshape(shape).copy()
+    )
+
+
+def _encode(value: Any) -> Any:
+    if isinstance(value, infinicore.Tensor):
+        return {_TENSOR_MARKER: _tensor_to_numpy(value)}
+    if isinstance(value, dict):
+        return {key: _encode(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_encode(item) for item in value]
+    if isinstance(value, tuple):
+        return {_TUPLE_MARKER: [_encode(item) for item in value]}
+    return value
+
+
+def _decode(value: Any) -> Any:
+    if isinstance(value, dict) and _TENSOR_MARKER in value:
+        return infinicore.from_numpy(value[_TENSOR_MARKER])
+    if isinstance(value, dict) and _TUPLE_MARKER in value:
+        return tuple(_decode(item) for item in value[_TUPLE_MARKER])
+    if isinstance(value, dict):
+        return {key: _decode(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_decode(item) for item in value]
+    return value
+
+
+def _parse_endpoint(endpoint: str) -> tuple[str, int]:
+    host, separator, port = endpoint.rpartition(":")
+    if not separator or not host or not port:
+        raise ValueError(
+            f"invalid pipeline worker endpoint {endpoint!r}; expected HOST:PORT"
+        )
+    return host, int(port)
+
+
+def _connect_with_retry(endpoint: str, timeout: float = 300.0) -> socket.socket:
+    host, port = _parse_endpoint(endpoint)
+    deadline = time.monotonic() + timeout
+    last_error: OSError | None = None
+    while time.monotonic() < deadline:
+        try:
+            sock = socket.create_connection((host, port), timeout=5.0)
+            sock.settimeout(None)
+            sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+            return sock
+        except OSError as error:
+            last_error = error
+            time.sleep(0.1)
+    raise ConnectionError(
+        f"failed to connect to pipeline host {endpoint}"
+    ) from last_error
+
+
+class PipelineControlServer:
+    """Stage-0 control plane for persistent PP worker processes."""
+
+    def __init__(self, pp_size: int, master_port: int):
+        connections_by_stage: dict[int, socket.socket] = {}
+        self._connections: list[socket.socket] = []
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as server:
+                server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                server.bind(("0.0.0.0", master_port))
+                server.listen(pp_size - 1)
+                logger.info(
+                    "Pipeline control server listening: role=coordinator, "
+                    "stage=0, endpoint=0.0.0.0:%s, workers=%s",
+                    master_port,
+                    pp_size - 1,
+                )
+
+                while len(connections_by_stage) < pp_size - 1:
+                    connection, peer = server.accept()
+                    connection.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+                    ready = _recv_message(connection)
+                    stage = ready.get("pp_stage")
+                    if (
+                        ready.get("status") != "ready"
+                        or not isinstance(stage, int)
+                        or not 1 <= stage < pp_size
+                        or stage in connections_by_stage
+                    ):
+                        connection.close()
+                        raise RuntimeError(
+                            f"invalid pipeline worker registration: {ready!r}"
+                        )
+                    connections_by_stage[stage] = connection
+                    _send_message(
+                        connection,
+                        {"status": "registered", "pp_stage": stage},
+                    )
+                    logger.info(
+                        "Pipeline control connection established: "
+                        "role=coordinator, stage=0, peer_stage=%s, peer=%s:%s",
+                        stage,
+                        peer[0],
+                        peer[1],
+                    )
+
+            self._connections = [
+                connections_by_stage[stage] for stage in range(1, pp_size)
+            ]
+            logger.info(
+                "Pipeline control plane ready: role=coordinator, stage=0, stages=%s",
+                pp_size,
+            )
+        except BaseException:
+            for connection in connections_by_stage.values():
+                connection.close()
+            raise
+
+    def dispatch_forward(self, model_input: dict[str, Any]) -> None:
+        payload = pickle.dumps(
+            {"command": "forward", "model_input": _encode(model_input)},
+            protocol=pickle.HIGHEST_PROTOCOL,
+        )
+        for connection in self._connections:
+            _send_payload(connection, payload)
+
+    def wait_forward(self) -> None:
+        for connection in self._connections:
+            response = _recv_message(connection)
+            if not response.get("ok", False):
+                raise RuntimeError(
+                    "pipeline worker forward failed:\n"
+                    + response.get("error", "unknown error")
+                )
+
+    def close(self) -> None:
+        for connection in self._connections:
+            try:
+                _send_message(connection, {"command": "shutdown"})
+                _recv_message(connection)
+            except (ConnectionError, OSError):
+                pass
+            finally:
+                connection.close()
+        self._connections.clear()
+
+
+class PipelineWorkerClient:
+    """Persistent control client run by a nonzero PP stage."""
+
+    def __init__(self, model_runner, master_addr: str, master_port: int, pp_stage: int):
+        self._model_runner = model_runner
+        self._pp_stage = pp_stage
+        endpoint = f"{master_addr}:{master_port}"
+        logger.info(
+            "Connecting pipeline control plane: role=worker, stage=%s, coordinator=%s",
+            self._pp_stage,
+            endpoint,
+        )
+        self._connection = _connect_with_retry(endpoint)
+        _send_message(self._connection, {"status": "ready", "pp_stage": self._pp_stage})
+        response = _recv_message(self._connection)
+        if response != {"status": "registered", "pp_stage": self._pp_stage}:
+            self._connection.close()
+            raise RuntimeError(
+                f"invalid pipeline coordinator registration response: {response!r}"
+            )
+        logger.info(
+            "Pipeline control connection established: "
+            "role=worker, stage=%s, coordinator=%s",
+            self._pp_stage,
+            endpoint,
+        )
+
+    def serve_forever(self) -> None:
+        with self._connection as connection:
+            while True:
+                message = _recv_message(connection)
+                command = message.get("command")
+                if command == "shutdown":
+                    _send_message(connection, {"ok": True})
+                    return
+                if command != "forward":
+                    _send_message(
+                        connection,
+                        {"ok": False, "error": f"unknown command: {command}"},
+                    )
+                    continue
+                try:
+                    model_input = _decode(message["model_input"])
+                    self._model_runner.model_engine.forward(**model_input)
+                    _send_message(connection, {"ok": True})
+                except BaseException:
+                    error = traceback.format_exc()
+                    try:
+                        _send_message(connection, {"ok": False, "error": error})
+                    except (ConnectionError, OSError):
+                        pass
+                    return

--- a/python/infinilm/distributed/pipeline_transport.py
+++ b/python/infinilm/distributed/pipeline_transport.py
@@ -206,6 +206,17 @@ class PipelineControlServer:
                     + response.get("error", "unknown error")
                 )
 
+    def abort(self) -> None:
+        """Close the control plane immediately after an unrecoverable failure."""
+        for connection in self._connections:
+            try:
+                connection.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass
+            finally:
+                connection.close()
+        self._connections.clear()
+
     def close(self) -> None:
         for connection in self._connections:
             try:

--- a/python/infinilm/infer_engine.py
+++ b/python/infinilm/infer_engine.py
@@ -130,6 +130,7 @@ class InferEngine(_infinilm.InferEngine):
             device = infinicore.device()
         if distributed_config is None:
             distributed_config = DistConfig(1)
+        self.distributed_config = distributed_config
         if (
             moe_ep_backend != "disabled"
             or moe_ep_size != 1

--- a/python/infinilm/llm/llm.py
+++ b/python/infinilm/llm/llm.py
@@ -40,6 +40,12 @@ class LLMEngine:
     def __init__(self, config: EngineConfig):
         self.config = config
 
+        if config.pipeline_parallel_size > 1 and config.pipeline_parallel_stage != 0:
+            raise ValueError(
+                "LLMEngine can only run pipeline stage 0; launch non-host nodes "
+                "with inference_server.py --node-rank=N"
+            )
+
         self.model_runner = ModelRunner(config)
 
         self.device = self.model_runner.device
@@ -121,6 +127,9 @@ class LLMEngine:
     def add_request(self, request: InferenceRequest):
         """Add a request to the scheduler."""
         self.scheduler.add_request(request)
+
+    def close(self):
+        self.model_runner.close()
 
     def step(self) -> tuple[bool, list[tuple]]:
         """Run one inference step.
@@ -316,6 +325,10 @@ class LLM:
         device: str = "cuda",
         dtype: str = "float16",
         tensor_parallel_size: int = 1,
+        pipeline_parallel_size: int = 1,
+        pipeline_parallel_stage: int = 0,
+        master_addr: str = "127.0.0.1",
+        master_port: int = 29500,
         moe_ep_backend: str = "disabled",
         moe_ep_size: int = 1,
         cache_type: str = "paged",
@@ -362,6 +375,10 @@ class LLM:
             device=device,
             dtype=dtype,
             tensor_parallel_size=tensor_parallel_size,
+            pipeline_parallel_size=pipeline_parallel_size,
+            pipeline_parallel_stage=pipeline_parallel_stage,
+            master_addr=master_addr,
+            master_port=master_port,
             moe_ep_backend=moe_ep_backend,
             moe_ep_size=moe_ep_size,
             cache_type=cache_type,
@@ -382,6 +399,9 @@ class LLM:
         )
         self.engine = LLMEngine(config)
         self.config = config
+
+    def close(self):
+        self.engine.close()
 
     def generate(
         self,
@@ -523,6 +543,10 @@ class AsyncLLMEngine:
         device: str = "cuda",
         dtype: str = "float16",
         tensor_parallel_size: int = 1,
+        pipeline_parallel_size: int = 1,
+        pipeline_parallel_stage: int = 0,
+        master_addr: str = "127.0.0.1",
+        master_port: int = 29500,
         moe_ep_backend: str = "disabled",
         moe_ep_size: int = 1,
         cache_type: str = "paged",
@@ -572,6 +596,10 @@ class AsyncLLMEngine:
             device=device,
             dtype=dtype,
             tensor_parallel_size=tensor_parallel_size,
+            pipeline_parallel_size=pipeline_parallel_size,
+            pipeline_parallel_stage=pipeline_parallel_stage,
+            master_addr=master_addr,
+            master_port=master_port,
             moe_ep_backend=moe_ep_backend,
             moe_ep_size=moe_ep_size,
             cache_type=cache_type,
@@ -626,6 +654,7 @@ class AsyncLLMEngine:
         self._running = False
         if self._step_thread:
             self._step_thread.join(timeout=5)
+        self.engine.close()
         logger.info("AsyncLLMEngine stopped")
 
     def add_aborted_req(

--- a/python/infinilm/llm/model_runner/model_runner.py
+++ b/python/infinilm/llm/model_runner/model_runner.py
@@ -7,6 +7,7 @@ import infinicore
 from infinilm.cache.cache import PagedKVCacheConfig, StaticKVCacheConfig
 from infinilm.config.engine_config import EngineConfig
 from infinilm.distributed import DistConfig
+from infinilm.distributed.pipeline_transport import PipelineControlServer
 from infinilm.infer_engine import InferEngine
 from infinilm.kv_connector import (
     KVConnectorFactory,
@@ -42,8 +43,9 @@ class ModelRunnerOutput:
 
 
 class ModelRunner:
-    def __init__(self, config: EngineConfig):
+    def __init__(self, config: EngineConfig, initialize_processor: bool = True):
         self.config = config
+        self._closed = False
         self.kv_transfer_config = config.kv_transfer_config
         logger.info(f"kv_transfer_config: {self.kv_transfer_config}")
 
@@ -65,7 +67,9 @@ class ModelRunner:
         else:
             raise ValueError(f"Unsupported cache_type: {config.cache_type}")
 
-        # Initialize model engine
+        # InferEngine creates the per-node TP communicator first. For PP it then
+        # uses the short-lived C++ TCP rendezvous to bootstrap one global
+        # InfiniCCL communicator spanning every (PP stage, TP rank) pair.
         self.model_engine = InferEngine(
             model_path=config.model_path,
             device=self.device,
@@ -73,6 +77,10 @@ class ModelRunner:
                 config.tensor_parallel_size,
                 moe_ep_backend=config.moe_ep_backend,
                 moe_ep_size=config.moe_ep_size,
+                pp_size=config.pipeline_parallel_size,
+                pp_stage=config.pipeline_parallel_stage,
+                master_addr=config.master_addr,
+                master_port=config.master_port,
             ),
             cache_config=cache_config,
             enable_graph_compiling=config.enable_graph,
@@ -101,8 +109,21 @@ class ModelRunner:
                 config, self.model_engine, self.device
             )
 
-        # Initialize processor
-        self.processor = AutoInfinilmProcessor.from_pretrained(config.model_path)
+        self.processor = (
+            AutoInfinilmProcessor.from_pretrained(config.model_path)
+            if initialize_processor
+            else None
+        )
+
+        self.pipeline_control = None
+        if config.pipeline_parallel_size > 1 and config.pipeline_parallel_stage == 0:
+            # The bootstrap listener has closed by this point. Stage 0 now
+            # reuses master_port for the persistent Python control plane; tensor
+            # activations continue to use the global InfiniCCL communicator.
+            self.pipeline_control = PipelineControlServer(
+                config.pipeline_parallel_size,
+                config.master_port,
+            )
 
         # Initialize KV connector
         self.kv_connector = None
@@ -197,8 +218,22 @@ class ModelRunner:
         if self.speculative_runner is not None:
             return self._model_forward_with_speculative(scheduler_output, model_input)
 
-        # Run inference
-        sampled_tokens = self.model_engine.forward(**model_input)
+        # Wake every stage before stage 0 enters forward. Each worker receives
+        # the same metadata and then blocks in its model on the activation from
+        # the preceding stage. Stage 0 waits for all acknowledgements afterward.
+        if self.pipeline_control is not None:
+            self.pipeline_control.dispatch_forward(model_input)
+        try:
+            sampled_tokens = self.model_engine.forward(**model_input)
+        except BaseException:
+            if self.pipeline_control is not None:
+                try:
+                    self.pipeline_control.wait_forward()
+                except BaseException:
+                    logger.exception("pipeline worker also failed during forward")
+            raise
+        if self.pipeline_control is not None:
+            self.pipeline_control.wait_forward()
         sampled_tokens_list = sampled_tokens.to_numpy().tolist()
 
         return sampled_tokens_list
@@ -234,5 +269,10 @@ class ModelRunner:
 
     def close(self) -> None:
         """Release resources held by the KV connector."""
+        if self._closed:
+            return
+        if self.pipeline_control is not None:
+            self.pipeline_control.close()
         if self.kv_connector is not None:
             self.kv_connector.shutdown()
+        self._closed = True

--- a/python/infinilm/llm/model_runner/model_runner.py
+++ b/python/infinilm/llm/model_runner/model_runner.py
@@ -227,10 +227,10 @@ class ModelRunner:
             sampled_tokens = self.model_engine.forward(**model_input)
         except BaseException:
             if self.pipeline_control is not None:
-                try:
-                    self.pipeline_control.wait_forward()
-                except BaseException:
-                    logger.exception("pipeline worker also failed during forward")
+                # A downstream stage may already be blocked waiting for an
+                # activation that this stage failed to produce. Waiting for its
+                # acknowledgement here would deadlock the coordinator.
+                self.pipeline_control.abort()
             raise
         if self.pipeline_control is not None:
             self.pipeline_control.wait_forward()

--- a/python/infinilm/modeling_utils.py
+++ b/python/infinilm/modeling_utils.py
@@ -203,6 +203,9 @@ def load_model_state_dict_by_file(
     torch_device = "cpu"
     torch_dtype = infinicore.utils.to_torch_dtype(dtype)
     model_keys = model.state_dict_keyname()
+    model_key_set = set(model_keys)
+    dist_config = getattr(model, "distributed_config", None)
+    is_pipeline_parallel = dist_config is not None and dist_config.pp_size > 1
     scale_emb = _get_scale_emb(model_path)
 
     already_loaded_keys = []
@@ -241,8 +244,6 @@ def load_model_state_dict_by_file(
             if remapper is not None:
                 model_param = remapper(model_param, config=model.hf_config)
 
-            already_loaded_keys.extend(model_param.keys())
-
             # --------------------------------------------------------- #
             #         Scale embed_tokens on torch side before converting
             # --------------------------------------------------------- #
@@ -252,6 +253,15 @@ def load_model_state_dict_by_file(
                     model_param["model.embed_tokens.weight"] = (
                         embed_tokens_torch_unscaled * float(scale_emb)
                     )
+
+            if is_pipeline_parallel:
+                model_param = {
+                    key: tensor
+                    for key, tensor in model_param.items()
+                    if key in model_key_set
+                }
+
+            already_loaded_keys.extend(model_param.keys())
 
             # --------------------------------------------------------- #
             #         model_param_infini references torch.Tensor
@@ -293,6 +303,13 @@ def load_model_state_dict_by_file(
                 model_params["model.embed_tokens.weight"] = (
                     embed_tokens_torch_unscaled * float(scale_emb)
                 )
+
+        if is_pipeline_parallel:
+            model_params = {
+                key: tensor
+                for key, tensor in model_params.items()
+                if key in model_key_set
+            }
 
         model_param_infini = {}
         for key in model_params.keys():
@@ -343,6 +360,9 @@ def load_model_state_dict_by_tensor(
 
     torch_dtype = infinicore.utils.to_torch_dtype(dtype)
     model_keys = model.state_dict_keyname()
+    model_key_set = set(model_keys)
+    dist_config = getattr(model, "distributed_config", None)
+    is_pipeline_parallel = dist_config is not None and dist_config.pp_size > 1
     scale_emb = _get_scale_emb(model_path)
     already_loaded_keys = []
     embed_tokens_torch_unscaled = None
@@ -361,6 +381,9 @@ def load_model_state_dict_by_tensor(
                         if scale_emb != 1.0:
                             tensor = tensor * float(scale_emb)
 
+                    if is_pipeline_parallel and name not in model_key_set:
+                        continue
+
                     weight_infini = infinicore.from_torch(tensor)
                     model.load_param(name, weight_infini)
                     already_loaded_keys.append(name)
@@ -376,6 +399,8 @@ def load_model_state_dict_by_tensor(
                 embed_tokens_torch_unscaled = tensor
                 if scale_emb != 1.0:
                     tensor = tensor * float(scale_emb)
+            if is_pipeline_parallel and key not in model_key_set:
+                continue
             weight_infini = infinicore.from_torch(tensor)
             model.load_param(key, weight_infini)
             already_loaded_keys.append(key)

--- a/python/infinilm/server/inference_server.py
+++ b/python/infinilm/server/inference_server.py
@@ -98,6 +98,10 @@ class InferenceServer:
         device: str = "cuda",
         dtype: str = "float16",
         tensor_parallel_size: int = 1,
+        pipeline_parallel_size: int = 1,
+        pipeline_parallel_stage: int = 0,
+        master_addr: str = "127.0.0.1",
+        master_port: int = 29500,
         moe_ep_backend: str = "disabled",
         moe_ep_size: int = 1,
         use_legacy_moe: bool = False,
@@ -153,6 +157,10 @@ class InferenceServer:
         self.device = device
         self.dtype = dtype
         self.tensor_parallel_size = tensor_parallel_size
+        self.pipeline_parallel_size = pipeline_parallel_size
+        self.pipeline_parallel_stage = pipeline_parallel_stage
+        self.master_addr = master_addr
+        self.master_port = master_port
         self.moe_ep_backend = moe_ep_backend
         self.moe_ep_size = moe_ep_size
         self.use_legacy_moe = use_legacy_moe
@@ -193,6 +201,10 @@ class InferenceServer:
                 device=self.device,
                 dtype=self.dtype,
                 tensor_parallel_size=self.tensor_parallel_size,
+                pipeline_parallel_size=self.pipeline_parallel_size,
+                pipeline_parallel_stage=self.pipeline_parallel_stage,
+                master_addr=self.master_addr,
+                master_port=self.master_port,
                 moe_ep_backend=self.moe_ep_backend,
                 moe_ep_size=self.moe_ep_size,
                 use_legacy_moe=self.use_legacy_moe,
@@ -587,6 +599,12 @@ def parse_kv_transfer_config(kv_transfer_config_str: str) -> KVTransferConfig:
 def main():
     cfg = BaseConfig()
     setup_logging(cfg.log_level)
+    if cfg.pp > 1 and cfg.node_rank > 0:
+        from infinilm.server.pipeline_worker import run_worker
+
+        run_worker(cfg)
+        return
+
     device = cfg.get_device_str(cfg.device)
 
     kv_transfer_config = None
@@ -612,6 +630,10 @@ def main():
         device=device,
         dtype=cfg.dtype,
         tensor_parallel_size=cfg.tp,
+        pipeline_parallel_size=cfg.pp,
+        pipeline_parallel_stage=cfg.node_rank,
+        master_addr=cfg.master_addr,
+        master_port=cfg.master_port,
         moe_ep_backend=moe_ep_backend,
         moe_ep_size=ep,
         use_legacy_moe=cfg.use_legacy_moe,

--- a/python/infinilm/server/pipeline_worker.py
+++ b/python/infinilm/server/pipeline_worker.py
@@ -1,0 +1,72 @@
+import logging
+
+from infinilm.base_config import BaseConfig
+from infinilm.config.engine_config import EngineConfig
+from infinilm.distributed.pipeline_transport import PipelineWorkerClient
+from infinilm.llm.model_runner.model_runner import ModelRunner
+
+logger = logging.getLogger(__name__)
+
+
+def run_worker(cfg: BaseConfig) -> None:
+    if cfg.pp <= 1 or cfg.node_rank == 0:
+        raise ValueError(
+            "pipeline worker mode requires --pp > 1 and --node-rank in [1, pp)"
+        )
+
+    config = EngineConfig(
+        model_path=cfg.model,
+        device=cfg.get_device_str(cfg.device),
+        dtype=cfg.dtype,
+        tensor_parallel_size=cfg.tp,
+        pipeline_parallel_size=cfg.pp,
+        pipeline_parallel_stage=cfg.node_rank,
+        master_addr=cfg.master_addr,
+        master_port=cfg.master_port,
+        cache_type="paged" if cfg.enable_paged_attn else "static",
+        max_batch_size=cfg.max_batch_size,
+        max_tokens=cfg.max_new_tokens,
+        num_blocks=cfg.num_blocks,
+        block_size=cfg.block_size,
+        max_cache_len=cfg.max_cache_len,
+        temperature=cfg.temperature,
+        top_p=cfg.top_p,
+        top_k=cfg.top_k,
+        enable_graph=cfg.enable_graph,
+        attn_backend=cfg.attn,
+        use_mla=cfg.use_mla,
+        weight_load_mode=cfg.weight_load_mode,
+        skip_load=cfg.skip_load,
+        skip_legacy_moe=cfg.skip_legacy_moe,
+    )
+
+    runner = ModelRunner(config, initialize_processor=False)
+    worker = PipelineWorkerClient(
+        runner,
+        master_addr=cfg.master_addr,
+        master_port=cfg.master_port,
+        pp_stage=cfg.node_rank,
+    )
+    logger.info(
+        "Pipeline worker event loop started: role=worker, stage=%s, coordinator=%s:%s",
+        cfg.node_rank,
+        cfg.master_addr,
+        cfg.master_port,
+    )
+    try:
+        worker.serve_forever()
+    finally:
+        runner.close()
+
+
+def main() -> None:
+    cfg = BaseConfig()
+    logging.basicConfig(
+        level=getattr(logging, cfg.log_level.upper(), logging.INFO),
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+    run_worker(cfg)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/infinilm/server/pipeline_worker.py
+++ b/python/infinilm/server/pipeline_worker.py
@@ -37,7 +37,7 @@ def run_worker(cfg: BaseConfig) -> None:
         use_mla=cfg.use_mla,
         weight_load_mode=cfg.weight_load_mode,
         skip_load=cfg.skip_load,
-        skip_legacy_moe=cfg.skip_legacy_moe,
+        use_legacy_moe=cfg.use_legacy_moe,
     )
 
     runner = ModelRunner(config, initialize_processor=False)


### PR DESCRIPTION
<!--
Thanks for contributing to InfiniLM! Please read `CONTRIBUTING.md` before
opening a pull request and fill out every section below. Delete any section
that is genuinely not applicable (and note why), but do not delete the
"Checklist" section — it must be filled in for every PR.

The PR title MUST follow Conventional Commits, e.g.
  feat: support Llama 3 models
  fix: correct linear attention calculations
See: https://www.conventionalcommits.org/
-->

## Summary

<!--
A concise description of **what** this PR changes. Prefer bullet points over
prose. Reference files with backtick-fenced paths (e.g. `csrc/models/llama/*`).
-->

- Support inter-node PP + intra-node TP config

## Motivation

<!--
Explain **why** this change is needed. Link to any related issue, bug, or
discussion. If this is a performance change, include before/after numbers
(hardware, shape, dtype, and the measurement methodology).
-->

Closes #

## Type of Change

<!-- Tick one or more. -->

- [x] `feat` — new feature / new model
- [ ] `fix` — bug fix
- [ ] `perf` — performance improvement (no behavioral change)
- [ ] `refactor` — code restructuring without behavior change
- [ ] `test` — adding or fixing tests only
- [ ] `docs` — documentation only
- [ ] `build` / `ci` — build system or CI configuration
- [ ] `chore` — tooling, formatting, or other non-code changes
- [ ] Breaking change

## Test Results of Involved Models on Supported Platforms (Please attach screenshots)

<!--
For now, provide the screenshots for involved tests performed on platforms supposed to support the changes.

Tests that might be involved:
Single request test: examples/test_infer.py
Offline performance: examples/bench.py
Sanity test: test/bench/test_benchmark.py
Service: python/infinilm/server/inference_server.py + scripts/test_perf.py

Model adaptations may involve all four tests, unless specifying partial support for vastly new structures and confirmed with admin.

Python-level changes may involve less tests depending on which files/features are modified. 

Framework-level and Python-level changes may affect different models. Test a few models that might be affected.
-->

## Benchmark / Performance Impact

<!--
Required for `perf` PRs; optional otherwise. Describe the benchmark harness,
shapes, dtypes, hardware, and include baseline vs. new numbers. If the PR is
not performance-sensitive, write "N/A".
-->

## Notes for Reviewers

<!--
Anything reviewers should focus on: subtle invariants, known trade-offs,
follow-up work intentionally left out of scope, etc.
-->

## CI / ChatOps

<!--
CI does not run automatically on pull requests. Trigger it manually from the
Actions tab (workflow: **CI**, branch: this PR's head branch), or ask a
maintainer to comment `/retest` or `/test` on this PR.
-->

---

## Checklist

> Every contributor **must** verify every item below before requesting
> review. Tick each box only after the check has actually been performed —
> do not tick speculatively. If an item truly does not apply, replace the
> checkbox with `N/A` and briefly explain why in an inline comment.

### Title, Branch, and Commits

- [ ] PR **title** follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(nvidia): …`, `fix(cuda/gemm): …`).
- [ ] Branch name follows `<type>/xxx-yyyy-zzzz` where `<type>` matches the PR title's Conventional Commits type and words are joined with hyphens (see `CONTRIBUTING.md` §Branches).
- [ ] Each **commit** message follows Conventional Commits.
- [ ] Small PR is a **single squashable commit**; or, for a large PR, every commit is meaningful, well-formed, and independently reviewable (see `CONTRIBUTING.md` §Pull Requests).
- [ ] No stray merge commits from `main` — the branch is rebased cleanly on top of the current `main`.
- [ ] No `fixup!` / `squash!` / `wip` commits remain.
- [ ] Existing PR/branch/commit that followed the legacy issue format.

### Scope and Design

- [ ] Changes are **minimal** — nothing unrelated to the stated motivation was added (`CONTRIBUTING.md` §Code/General).
- [ ] No dead code, commented-out blocks, debug prints, `printf`/`std::cout`/`print(...)` left behind, or `TODO` without an owner and issue link.
- [ ] No unrelated formatting churn that would obscure the diff.
- [ ] Public API changes (if any) are intentional, documented, and reflected in affected callers/tests.

### General Code Hygiene (applies to all languages)

- [ ] The code is self-explanatory; comments were added **only** where the *why* is non-obvious (`CONTRIBUTING.md` §Code/General).
- [ ] Every modified or added file **ends with a single trailing newline** (`CONTRIBUTING.md` §Code/General).
- [ ] No trailing whitespace, tab/space mixing, or stray BOMs.
- [ ] Identifiers in comments and error messages are wrapped in backticks (e.g. ``the `seqlens_k` tensor``) (`CONTRIBUTING.md` §Code/General).
- [ ] All comments and error messages are in **English** (`CONTRIBUTING.md` §Code/General).
- [ ] Comments and error messages are complete sentences — capitalized first letter, terminal punctuation — **unless** the language/framework convention says otherwise (`CONTRIBUTING.md` §Code/General; §Python).

### C++ Specific (if C++ files changed)

- [ ] Code follows the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) strictly.
- [ ] Error and warning message wording follows the [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html#error-and-warning-messages) (`CONTRIBUTING.md` §C++).
- [ ] Constructor **initializer list order matches member declaration order** (`CONTRIBUTING.md` §C++).
- [ ] No raw `new`/`delete`; RAII / smart pointers / existing allocators are used.
- [ ] Changed files are formatted by `scripts/format.py`.
- [ ] No changes/reference to `csrc/models/llama_legacy/`.

### Python Specific (if Python files changed)

- [ ] Code is [PEP 8](https://peps.python.org/pep-0008/) compliant.
- [ ] Comments are complete English sentences, starting with a capital letter and ending with punctuation; Markdown backticks are used for code references (`CONTRIBUTING.md` §Python).
- [ ] Docstrings (if any) follow [PEP 257](https://peps.python.org/pep-0257/) (`CONTRIBUTING.md` §Python).
- [ ] Changed files are formatted by `scripts/format.py`.
- [ ] No changes/reference to `python/infinilm/auto_config.py`.

### Testing

- [ ] For any platform that could not be tested, an explicit reason is given in the table and a reviewer with access has been tagged.
- [ ] Passed single request test (`examples/test_infer.py`), or specify the reason for skipping.
- [ ] Passed offline performance test (`examples/bench.py`), or specify the reason for skipping.
- [ ] Passed sanity test (`test/bench/test_benchmark.py`), or specify the reason for skipping.
- [ ] Passed service test (`python/infinilm/server/inference_server.py` + `scripts/test_perf.py`), or specify the reason for skipping.

### Build, CI, and Tooling

- [ ] The project builds cleanly from a fresh directory on at least one affected platform.
- [ ] CI has been triggered manually (Actions → **CI** on this branch), or `/retest` was requested.

### Documentation

- [ ] `README.md`, `CONTRIBUTING.md`, or inline docs updated when behavior, build flags, or developer workflow changed.
- [ ] Any user-visible breaking change is called out explicitly under "Motivation" **and** in the commit/PR title with a `!` or `BREAKING CHANGE:` footer.

### Security and Safety

- [ ] No secrets, access tokens, internal URLs, customer data, or personal hardware identifiers have been committed.
- [ ] Third-party code is license-compatible and attributed.
- [ ] No unsafe pointer arithmetic, uninitialized reads, or missing bounds checks were introduced.
