### PR TITLE
fix(multimodal): support base64 image_url inputs

### DIFF
--- a/python/infinilm/multimodal/multimodal.py
+++ b/python/infinilm/multimodal/multimodal.py
@@ -1,5 +1,28 @@
+import base64
+import binascii
+import hashlib
+from io import BytesIO
 from typing import List, Union
+
 from PIL import Image
+
+
+def _load_image(image_url):
+    if isinstance(image_url, str) and image_url.startswith("data:image/"):
+        try:
+            _, encoded = image_url.split(",", 1)
+        except ValueError as exc:
+            raise ValueError("Invalid data image URL.") from exc
+
+        try:
+            image_data = base64.b64decode(encoded, validate=True)
+        except binascii.Error as exc:
+            raise ValueError("Invalid base64 image data.") from exc
+
+        image_id = f"data:image:{hashlib.sha256(image_data).hexdigest()}"
+        return Image.open(BytesIO(image_data)).convert("RGB"), image_id
+
+    return Image.open(image_url).convert("RGB"), image_url
 
 
 def has_multimodal_inputs(messages: Union[List[dict], dict]) -> bool:
@@ -40,9 +63,9 @@ def resolve_multimodal_inputs(messages: Union[List[dict], dict]):
             if item.get("type") == "text":
                 pass
             elif item.get("type") == "image_url":
-                # TODO support other image url formats
-                images.append(Image.open(item["image_url"]["url"]))
-                image_urls.append(item["image_url"]["url"])
+                image, image_id = _load_image(item["image_url"]["url"])
+                images.append(image)
+                image_urls.append(image_id)
             elif item.get("type") == "video_url":
                 video = item["video_url"]["url"]
                 videos.append(video)


### PR DESCRIPTION
## Summary

This PR adds support for OpenAI-compatible base64 image URLs in multimodal chat requests.

MiniCPM-V requests can already pass images through `image_url`, but the loader only handled local file paths. This change accepts `data:image/...;base64,...` URLs, decodes them into RGB PIL images, and keeps local path behavior unchanged.

## Example

```bash
curl http://127.0.0.1:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "MiniCPM-V-2_6",
    "messages": [
      {
        "role": "user",
        "content": [
          {
            "type": "image_url",
            "image_url": {
              "url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII="
            }
          },
          {
            "type": "text",
            "text": "Describe this image."
          }
        ]
      }
    ],
    "max_tokens": 64,
    "temperature": 0.0
  }'
```

## Tests

- `git diff --check origin/main...HEAD`
- `python3 -m py_compile python/infinilm/multimodal/multimodal.py`
- `uvx ruff check python/infinilm/multimodal/multimodal.py`
- `uvx ruff format --check python/infinilm/multimodal/multimodal.py`
- `PATH=/tmp:$PATH python3 scripts/format.py --ref origin/main --check --c clang-format`
- Manual A100 smoke test: sent a `data:image/jpeg;base64,...` multimodal chat request to `/v1/chat/completions` and received `200 OK`.
