### PR TITLE
fix(minicpmv): support wide image patch grids

### DIFF
--- a/csrc/models/minicpmv/resampler.cpp
+++ b/csrc/models/minicpmv/resampler.cpp
@@ -50,6 +50,17 @@ void write_pos_embed(void *dst, infinicore::DataType dtype, const float *src, si
     }
     throw std::runtime_error("Unsupported dtype in write_pos_embed");
 }
+
+infinicore::Tensor build_2d_sincos_pos_embed_cpu(size_t h,
+                                                 size_t w,
+                                                 size_t embed_dim,
+                                                 infinicore::DataType dtype) {
+    std::vector<float> buf(h * w * embed_dim);
+    compute_2d_sincos_pos_embed(buf.data(), embed_dim, h, w);
+    auto embedding_cpu = infinicore::Tensor::zeros({h, w, embed_dim}, dtype, infinicore::Device::cpu());
+    write_pos_embed(embedding_cpu->data(), embedding_cpu->dtype(), buf.data(), buf.size());
+    return embedding_cpu;
+}
 } // namespace
 
 ResamplerAttention::ResamplerAttention(size_t embed_dim,
@@ -147,11 +158,8 @@ Resampler::Resampler(size_t num_queries,
     // Initialize full 2d embeddings with max size, calculate on cpu and copy to gpu
     size_t num_patches = image_size_ / patch_size_;
     INFINICORE_NN_BUFFER_INIT(embedding_table, ({num_patches, num_patches, embed_dim_}, dtype, device_));
-    std::vector<float> buf(num_patches * num_patches * embed_dim_);
-    compute_2d_sincos_pos_embed(buf.data(), embed_dim_, num_patches, num_patches);
-    auto embedding_table_cpu = infinicore::Tensor::zeros({num_patches, num_patches, embed_dim_}, dtype, infinicore::Device::cpu());
-    write_pos_embed(embedding_table_cpu->data(), embedding_table_cpu->dtype(), buf.data(), num_patches * num_patches * embed_dim_);
-    embedding_table_->copy_from(embedding_table_cpu);
+    auto embedding_table_init = build_2d_sincos_pos_embed_cpu(num_patches, num_patches, embed_dim_, dtype);
+    embedding_table_->copy_from(embedding_table_init);
 }
 
 infinicore::Tensor Resampler::forward(const infinicore::Tensor &x,
@@ -176,7 +184,15 @@ infinicore::Tensor Resampler::forward(const infinicore::Tensor &x,
         auto tgt_h = static_cast<size_t>(tgt_sizes_ptr[b * 2]);
         auto tgt_w = static_cast<size_t>(tgt_sizes_ptr[b * 2 + 1]);
 
-        auto src_embeddings = embedding_table_->narrow({{0, 0, tgt_h}, {1, 0, tgt_w}});
+        infinicore::Tensor src_embeddings;
+        const size_t table_h = embedding_table_->size(0);
+        const size_t table_w = embedding_table_->size(1);
+        if (tgt_h <= table_h && tgt_w <= table_w) {
+            src_embeddings = embedding_table_->narrow({{0, 0, tgt_h}, {1, 0, tgt_w}});
+        } else {
+            auto dynamic_cpu = build_2d_sincos_pos_embed_cpu(tgt_h, tgt_w, embed_dim_, kv->dtype());
+            src_embeddings = dynamic_cpu->to(kv->device());
+        }
         auto tgt_embeddings = pos_embeddings->narrow({{0, b, 1}, {1, 0, tgt_h * tgt_w}})->view({tgt_h, tgt_w, embed_dim_});
         tgt_embeddings->copy_from(src_embeddings);
     }


### PR DESCRIPTION
## Summary

Fix MiniCPM-V resampler positional embedding lookup for very wide or tall image patch grids.

The previous code sliced the static `[70, 70, hidden]` positional embedding table directly with `tgt_h` and `tgt_w`. For wide images, the processor can produce target grids such as `[[4, 227]]`, which makes the slice exceed dimension 1 and raises an invalid slice error.
```
[2026-08-06 09:18:05.496] [error] [:] Invalid slice [dim=1, start=0, len=227] on Tensor: shape[ 70 70 3584 ] strides[ 250880 3584 1 ] dtype=bfloat16 device=CPU:0.
[2026-08-06 09:18:05.496] [error] [:] [RankWorker{RankInfo: device=NVIDIA:0, tp_size=1, tp_rank=0, pp_size=1, pp_stage=0, world_size=1, world_rank=0 | init_done: true | should_exit: true | has_job: false | job_done: true }] exception during forward: Invalid slice on tensor.

2026-08-06 09:18:05 - infinilm.llm.llm - ERROR - Error in step loop: RankWorker stopped during run
Traceback (most recent call last):
  File "/workspace-pr/InfiniLM/python/infinilm/llm/llm.py", line 746, in _step_loop
    did_work, pending = self.engine.step()
                        ^^^^^^^^^^^^^^^^^^
  File "/workspace-pr/InfiniLM/python/infinilm/llm/llm.py", line 156, in step
    runner_output = self.model_runner.execute_model(scheduler_output)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace-pr/InfiniLM/python/infinilm/llm/model_runner/model_runner.py", line 190, in execute_model
    sampled_tokens_list = self._model_forward(scheduler_output)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace-pr/InfiniLM/python/infinilm/llm/model_runner/model_runner.py", line 227, in _model_forward
    sampled_tokens = self.model_engine.forward(**model_input)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace-pr/InfiniLM/python/infinilm/infer_engine.py", line 382, in forward
    .forward(
     ^^^^^^^^
RuntimeError: RankWorker stopped during run
```

## Scope

This PR only contains the MiniCPM-V wide-image resampler correctness fix.

It intentionally does not include the prefill packing/cache optimization.

## Tests

- `git diff --check origin/main...HEAD`
- `python3 scripts/format.py --check --c clang-format`
- Reproduced the baseline MiniCPM-V-2_6 failure with a wide image patch grid:

```text
tgt_sizes = [[4, 227]]
Invalid slice [dim=1, start=0, len=227] on Tensor: shape[ 70 70 3584 ]
```

- Verified the fix by using the cached `[70, 70]` positional embedding table for normal target grids and dynamically generating resampler sin/cos positional embeddings when `tgt_h` or `tgt_w` exceeds the cached table size.
