### PR TITLE
perf(minicpmv): cache prefill multimodal packing

### DIFF
--- a/csrc/models/minicpmv/minicpmv_model.cpp
+++ b/csrc/models/minicpmv/minicpmv_model.cpp
@@ -50,14 +50,24 @@ void MiniCPMVModel::replace_embeddings(infinicore::Tensor inputs_embeds,
     auto out_slice = inputs_embeds->squeeze(0);
     auto bound_slice = bounds_cpu->squeeze(0);
     auto vision_len = vision_hidden->size(0);
+    auto out_len = static_cast<int64_t>(out_slice->size(0));
     for (size_t patch = 0; patch < vision_len; ++patch) {
         auto patch_embed = vision_hidden->narrow({{0, patch, 1}})->squeeze(0);
         auto bound = bound_slice->narrow({{0, patch, 1}});
         auto bound_ptr = reinterpret_cast<const int64_t *>(bound->data());
-        auto start = bound_ptr[0];
-        auto end = bound_ptr[1];
+        int64_t start = bound_ptr[0];
+        int64_t end = bound_ptr[1];
 
-        out_slice->narrow({{0, size_t(start), size_t(end - start)}})->copy_from(patch_embed);
+        int64_t dst_start = std::max<int64_t>(start, 0);
+        int64_t dst_end = std::min<int64_t>(end, out_len);
+        if (dst_end <= dst_start) {
+            continue;
+        }
+
+        size_t src_start = static_cast<size_t>(dst_start - start);
+        size_t copy_len = static_cast<size_t>(dst_end - dst_start);
+        auto patch_slice = patch_embed->narrow({{0, src_start, copy_len}});
+        out_slice->narrow({{0, static_cast<size_t>(dst_start), copy_len}})->copy_from(patch_slice);
     }
 }
 

--- a/python/infinilm/processors/minicpmv_processor.py
+++ b/python/infinilm/processors/minicpmv_processor.py
@@ -96,6 +96,107 @@ class MiniCPMVProcessor(InfinilmProcessor):
             **kwargs,
         )
 
+    def _get_mm_prefill_cache(self, processed_inputs: dict):
+        import torch
+
+        mm_prefill_cache = processed_inputs.get("_mm_prefill_cache")
+        if mm_prefill_cache is not None:
+            return mm_prefill_cache
+
+        flat_pixel_values = []
+        for pixel_value_group in processed_inputs["pixel_values"]:
+            flat_pixel_values.extend(
+                tensor.flatten(end_dim=1)
+                .permute(1, 0)
+                .to(self.pixel_values_dtype)
+                .contiguous()
+                for tensor in pixel_value_group
+            )
+
+        if flat_pixel_values:
+            pixel_values_tensor = torch.nn.utils.rnn.pad_sequence(
+                flat_pixel_values, batch_first=True, padding_value=0.0
+            )
+            batch_size, max_patch_len, _ = pixel_values_tensor.shape
+            pixel_values_tensor = (
+                pixel_values_tensor.permute(0, 2, 1)
+                .reshape(batch_size, 3, -1, max_patch_len)
+                .contiguous()
+            )
+        else:
+            pixel_values_tensor = torch.empty(
+                (0, 3, 0, 0), dtype=self.pixel_values_dtype
+            )
+
+        tgt_sizes_list = [
+            tgt_size.to(torch.int64)
+            for tgt_size in processed_inputs["tgt_sizes"]
+            if isinstance(tgt_size, torch.Tensor)
+        ]
+        if tgt_sizes_list:
+            tgt_sizes_tensor = torch.vstack(tgt_sizes_list).contiguous()
+        else:
+            tgt_sizes_tensor = torch.empty((0, 2), dtype=torch.int64)
+
+        mm_prefill_cache = {
+            "num_patches": len(flat_pixel_values),
+            "pixel_values_tensor": pixel_values_tensor,
+            "tgt_sizes_tensor": tgt_sizes_tensor,
+            "image_bound": [
+                bound.to(torch.int64) for bound in processed_inputs["image_bound"]
+            ],
+            "suffix_cache": {},
+            "shifted_bound_cache": {},
+        }
+        processed_inputs["_mm_prefill_cache"] = mm_prefill_cache
+        return mm_prefill_cache
+
+    def _get_mm_prefill_suffix(self, mm_prefill_cache: dict, num_cached_patch: int):
+        suffix_cache = mm_prefill_cache["suffix_cache"]
+        suffix = suffix_cache.get(num_cached_patch)
+        if suffix is not None:
+            return suffix
+
+        pixel_values_tensor = mm_prefill_cache["pixel_values_tensor"][num_cached_patch:]
+        if not pixel_values_tensor.is_contiguous():
+            pixel_values_tensor = pixel_values_tensor.contiguous()
+
+        tgt_sizes_tensor = mm_prefill_cache["tgt_sizes_tensor"][num_cached_patch:]
+        if not tgt_sizes_tensor.is_contiguous():
+            tgt_sizes_tensor = tgt_sizes_tensor.contiguous()
+
+        suffix = (pixel_values_tensor, tgt_sizes_tensor)
+        suffix_cache[num_cached_patch] = suffix
+        return suffix
+
+    def _get_shifted_image_bound(
+        self, mm_prefill_cache: dict, num_cached_patch: int, num_cached: int
+    ):
+        import torch
+
+        cache_key = (num_cached_patch, int(num_cached))
+        shifted_bound = mm_prefill_cache["shifted_bound_cache"].get(cache_key)
+        if shifted_bound is not None:
+            return shifted_bound
+
+        shifted_bounds = []
+        for bound in mm_prefill_cache["image_bound"]:
+            bound = bound[num_cached_patch:, :]
+            if len(bound) > 0:
+                bound = bound - int(num_cached)
+            shifted_bounds.append(bound)
+
+        batch_size = len(shifted_bounds)
+        max_ranges = max((len(bound) for bound in shifted_bounds), default=0)
+        shifted_bound = torch.zeros((batch_size, max_ranges, 2), dtype=torch.int64)
+
+        for i, bound in enumerate(shifted_bounds):
+            if len(bound) > 0:
+                shifted_bound[i, : len(bound), :] = bound
+
+        mm_prefill_cache["shifted_bound_cache"][cache_key] = shifted_bound
+        return shifted_bound
+
     @override
     def build_model_inputs(
         self,
@@ -151,68 +252,27 @@ class MiniCPMVProcessor(InfinilmProcessor):
                     req.processed_inputs is not None
                     and "pixel_values" in req.processed_inputs
                 ):
-                    import torch
-
+                    mm_prefill_cache = self._get_mm_prefill_cache(req.processed_inputs)
                     num_cached_patch = (
-                        (req.processed_inputs["image_bound"][0][:, 1] <= num_cached)
+                        (mm_prefill_cache["image_bound"][0][:, 1] <= num_cached)
                         .sum()
                         .item()
                     )
 
-                    # if all patches are already cached, skip processing multimodal inputs and return text-only inputs for this request
-                    if num_cached_patch < len(req.processed_inputs["pixel_values"]):
-                        # 1. pixel_values
-                        all_pixel_values = []
-                        pixel_values = req.processed_inputs["pixel_values"]
-                        tgt_sizes = req.processed_inputs["tgt_sizes"]
-                        image_bound = req.processed_inputs["image_bound"]
-                        for pv in pixel_values:
-                            all_pixel_values.extend(
-                                [
-                                    t.flatten(end_dim=1)
-                                    .permute(1, 0)
-                                    .to(self.pixel_values_dtype)
-                                    for i, t in enumerate(pv)
-                                    if i >= num_cached_patch
-                                ]
+                    # If all patches are already cached, skip multimodal inputs and
+                    # reuse the text-only path for this prefill chunk.
+                    if num_cached_patch < mm_prefill_cache["num_patches"]:
+                        pixel_values_tensor, tgt_sizes_tensor = (
+                            self._get_mm_prefill_suffix(
+                                mm_prefill_cache, num_cached_patch
                             )
-
-                        pixel_values_tensor = torch.nn.utils.rnn.pad_sequence(
-                            all_pixel_values, batch_first=True, padding_value=0.0
-                        )
-                        B, L, _ = pixel_values_tensor.shape
-                        pixel_values_tensor = (
-                            pixel_values_tensor.permute(0, 2, 1)
-                            .reshape(B, 3, -1, L)
-                            .contiguous()
                         )
                         pixel_values_infini = infinicore.from_torch(pixel_values_tensor)
-
-                        # 2. tgt_sizes
-                        all_tgt_sizes = [
-                            tgt_size
-                            for i, tgt_size in enumerate(tgt_sizes)
-                            if isinstance(tgt_size, torch.Tensor)
-                            and i >= num_cached_patch
-                        ]
-
-                        tgt_sizes_tensor = torch.vstack(all_tgt_sizes).to(torch.int64)
-
                         tgt_sizes_infini = infinicore.from_torch(tgt_sizes_tensor)
 
-                        # 3. image_bound
-                        batch_size = len(image_bound)
-                        max_ranges = max(len(b) for b in image_bound)
-
-                        bound = torch.zeros(
-                            (batch_size, max_ranges, 2), dtype=torch.int64
+                        bound = self._get_shifted_image_bound(
+                            mm_prefill_cache, num_cached_patch, num_cached
                         )
-
-                        for i, bnd in enumerate(image_bound):
-                            bnd = bnd[num_cached_patch:, :]
-                            if len(bnd) > 0:
-                                bound[i, : len(bnd), :] = bnd
-
                         image_bound_infini = infinicore.from_torch(bound)
 
                         def append_mm_data(mm_data__: dict, key__: str, value__):

--- a/scripts/bench_minicpmv_prefill_cache.py
+++ b/scripts/bench_minicpmv_prefill_cache.py
@@ -1,0 +1,127 @@
+import argparse
+import datetime
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run_and_log(command, log_file, cwd, check=False):
+    printable_command = " ".join(command)
+    write_line(log_file, f"$ {printable_command}")
+    try:
+        process = subprocess.Popen(
+            command,
+            cwd=cwd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+    except FileNotFoundError:
+        write_line(log_file, f"Command not found: {command[0]}")
+        if check:
+            raise
+        return 127
+
+    assert process.stdout is not None
+    for line in process.stdout:
+        sys.stdout.write(line)
+        log_file.write(line)
+    return_code = process.wait()
+    if check and return_code != 0:
+        raise subprocess.CalledProcessError(return_code, command)
+    return return_code
+
+
+def write_line(log_file, message=""):
+    print(message)
+    log_file.write(f"{message}\n")
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run the MiniCPM-V multimodal benchmark and save a timestamped log. "
+            "Start an InfiniLM OpenAI-compatible server before running this script."
+        )
+    )
+    parser.add_argument(
+        "--api-url",
+        default="127.0.0.1:8000",
+        help="Server address without scheme.",
+    )
+    parser.add_argument(
+        "--model",
+        default="",
+        help="Model name sent to the OpenAI API.",
+    )
+    parser.add_argument(
+        "--image-dir",
+        required=True,
+        help="Directory containing .jpg or .jpeg images.",
+    )
+    parser.add_argument(
+        "--mm-port",
+        default=None,
+        help="Optional local image HTTP server port for scripts/test_perf.py.",
+    )
+    parser.add_argument(
+        "--log-dir",
+        default="logs/minicpmv-prefill-cache",
+        help="Output directory for benchmark logs.",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Print per-request details from scripts/test_perf.py.",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    repo_root = Path(__file__).resolve().parents[1]
+    image_dir = Path(args.image_dir).expanduser().resolve()
+    if not image_dir.is_dir():
+        raise ValueError(f"Not a valid image directory: {image_dir}")
+
+    log_dir = repo_root / args.log_dir
+    log_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+    log_path = log_dir / f"minicpmv-prefill-cache-{timestamp}.log"
+
+    command = [
+        sys.executable,
+        "scripts/test_perf.py",
+        "--api-url",
+        args.api_url,
+        "--model",
+        args.model,
+        "--image-dir",
+        str(image_dir),
+    ]
+    if args.mm_port is not None:
+        command.extend(["--mm-port", args.mm_port])
+    if args.verbose:
+        command.append("--verbose")
+
+    with log_path.open("w", encoding="utf-8") as log_file:
+        write_line(log_file, "=== MiniCPM-V prefill packing cache benchmark ===")
+        write_line(log_file, f"Timestamp: {datetime.datetime.now().isoformat()}")
+        write_line(log_file, f"Repository: {repo_root}")
+        run_and_log(["git", "rev-parse", "HEAD"], log_file, repo_root)
+        run_and_log(["git", "status", "--short"], log_file, repo_root)
+        run_and_log([sys.executable, "--version"], log_file, repo_root)
+        run_and_log(["nvidia-smi"], log_file, repo_root)
+        write_line(log_file, f"API URL: {args.api_url}")
+        write_line(log_file, f"Model: {args.model}")
+        write_line(log_file, f"Image dir: {image_dir}")
+        write_line(log_file, f"MM port: {args.mm_port}")
+        write_line(log_file)
+        return_code = run_and_log(command, log_file, repo_root)
+
+    print(f"Log saved to {log_path}")
+    return return_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Cache MiniCPM-V multimodal prefill packing and reuse the packed suffix when a prefill step starts after already-computed prompt tokens.

This avoids rebuilding the full packed image tensor, target-size tensor, and image-bound tensor for every cached-prefill step. It also makes the image embedding replacement path robust when the current prefill chunk only partially overlaps an image-token span.

## Scope

This PR only contains the MiniCPM-V prefill packing/cache optimization and the corresponding partial-bound copy guard.

It does not include the wide-image resampler positional-embedding fix from the separate PR.

## Why The Bound Guard Is Needed

When a cached-prefill step starts in the middle of an image-token span, the image bound must be interpreted relative to the local token chunk, not the original prompt.

Concrete example:

```text
original image token bound: [100, 164]
num_cached: 120
current compute length: 44
```

Without shifting/clipping, the model-side replacement path can try to copy with:

```text
start=100, len=64, output chunk length=44
```

That is outside the local chunk and can fail with an invalid tensor slice.

With this PR, the bound is shifted to the current prefill chunk:

```text
shifted image bound: [-20, 44]
copy destination: [0, 44)
copy source offset: 20
copy length: 44
```

The model then copies only the visible overlap of the image embedding into the current chunk.

## Reproduction Note

Current InfiniLM disables normal prefix-cache matching for multimodal requests in the scheduler:

```python
request.initialize_block_hashes(
    self.block_size,
    self.enable_prefix_caching
    and not self.has_mamba_cache
    and not request.has_multimodal_inputs,
)
```

Because of that guard, this issue is not expected to reproduce through the default HTTP server path with ordinary multimodal prefix caching enabled. To reproduce the boundary condition, force or construct a cached MiniCPM-V prefill request where:

```text
num_local_cached_tokens > image_bound.start
num_local_cached_tokens < image_bound.end
```

For example:

```text
num_local_cached_tokens = 120
image_bound = [[100, 164]]
prompt length = 164
tokens computed in this step = 44
```

Before this PR, the model input keeps the absolute bound `[[100, 164]]`, which is invalid for a 44-token local chunk. After this PR, the processor shifts it to `[[-20, 44]]`, and the model-side copy clips it to the valid overlap.

## Validation

Verified the focused cached-prefill boundary:

```text
before: image_bound [[100, 164]], compute_len 44, invalid local copy start 100 len 64
after:  image_bound [[-20, 44]], clipped copy dst [0, 44), src offset 20
```

Also ran formatting and whitespace checks:

```text
python3 scripts/format.py --check --c clang-format
git diff --check origin/main..HEAD
```
